### PR TITLE
Change example license in manifest schema and tests to Apache 2

### DIFF
--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -184,12 +184,12 @@
             ],
             "properties": {
                 "base_license": {
-                    "description": "URI pointing to the base license of this module (e.g. https://opensource.org/licenses/MIT)",
+                    "description": "URI pointing to the base license of this module (e.g. https://opensource.org/licenses/Apache-2.0)",
                     "type": "string",
                     "format": "uri"
                 },
                 "license": {
-                    "description": "URI pointing to the license of this module (e.g. https://opensource.org/licenses/MIT)",
+                    "description": "URI pointing to the license of this module (e.g. https://opensource.org/licenses/Apache-2.0)",
                     "type": "string",
                     "format": "uri"
                 },

--- a/tests/test_modules/TESTValidManifestMissingInterface/manifest.json
+++ b/tests/test_modules/TESTValidManifestMissingInterface/manifest.json
@@ -7,7 +7,7 @@
 		}
 	},
 	"metadata": {
-		"license": "https://opensource.org/licenses/MIT",
+		"license": "https://opensource.org/licenses/Apache-2.0",
 		"authors": ["Kai-Uwe Hermann"]
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>