### PR TITLE
Adding support for ModuleInfo

### DIFF
--- a/include/framework/ModuleAdapter.hpp
+++ b/include/framework/ModuleAdapter.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef MODULE_ADAPTER_HPP
 #define MODULE_ADAPTER_HPP
 
@@ -74,6 +74,11 @@ private:
 };
 
 class ModuleBase {
+public:
+    ModuleBase(const ModuleInfo& info) : info(info){};
+
+    const ModuleInfo& info;
+
 protected:
     void invoke_init(ImplementationBase& impl) {
         impl.init();

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef UTILS_CONFIG_HPP
 #define UTILS_CONFIG_HPP
 
@@ -105,8 +105,15 @@ public:
     json get_module_json_config(const std::string& module_id);
 
     ///
+    /// \brief assemble basic information about the module (id, name,
+    /// authors, license)
+    ///
+    /// \returns a ModuleInfo object
+    ModuleInfo get_module_info(const std::string& module_id);
+
+    ///
     /// \returns a json object that contains the manifests
-    json get_manifests();
+    const json& get_manifests();
 
     ///
     /// \returns a json object that contains the available interfaces

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef UTILS_TYPES_HPP
+#define UTILS_TYPES_HPP
+
 #include <map>
 #include <string>
 #include <vector>
@@ -23,6 +26,12 @@ using ValueCallback = std::function<void(Value)>;
 using ConfigEntry = boost::variant<std::string, double, int, bool>;
 using ConfigMap = std::map<std::string, ConfigEntry>;
 using ModuleConfigs = std::map<std::string, ConfigMap>;
+struct ModuleInfo {
+    std::string name;
+    std::vector<std::string> authors;
+    std::string license;
+    std::string id;
+};
 using Array = json::array_t;
 using Object = json::object_t;
 // TODO (aw): can we pass the handler arguments by const ref?
@@ -31,3 +40,5 @@ using StringHandler = std::function<void(std::string)>;
 using Token = std::shared_ptr<Handler>;
 
 #define EVCALLBACK(function) [](auto&& PH1) { function(std::forward<decltype(PH1)>(PH1)); }
+
+#endif // UTILS_TYPES_HPP


### PR DESCRIPTION
- added new ModuleInfo type for holding information about a module
- added get_module_info function to retreive the data from the main
  config
- forwarding this information to the module init function
- changed get_manifests(): it now returns a const ref to the json dict

Signed-off-by: aw <aw@pionix.de>