### PR TITLE
Update error handling and logging

### DIFF
--- a/everestjs/js_exec_ctx.cpp
+++ b/everestjs/js_exec_ctx.cpp
@@ -22,16 +22,24 @@ void JsExecCtx::tramp(Napi::Env env, Napi::Function callback, std::nullptr_t* co
 
 Napi::Value JsExecCtx::on_fulfill(const Napi::CallbackInfo& info) {
     JsExecCtx* this_ = reinterpret_cast<JsExecCtx*>(info.Data());
-    if (this_->res_func != nullptr)
-        this_->res_func(info[0], false);
+    if (this_->res_func != nullptr) {
+        this_->res_func(info, false);
+    }
     this_->promise.set_value();
     return info.Env().Undefined();
 }
 
 Napi::Value JsExecCtx::on_reject(const Napi::CallbackInfo& info) {
     JsExecCtx* this_ = reinterpret_cast<JsExecCtx*>(info.Data());
-    if (this_->res_func != nullptr)
-        this_->res_func(info[0], true);
+    if (this_->res_func != nullptr) {
+        this_->res_func(info, true);
+    } else {
+        // there is no catch handler registered, so we throw
+        throw Napi::Error::New(
+            info.Env(),
+            "JsExecCtx call into javascript code got rejected and could not be handled (rejection handler not defined");
+    }
+
     this_->promise.set_value();
     return info.Env().Undefined();
 }

--- a/everestjs/js_exec_ctx.hpp
+++ b/everestjs/js_exec_ctx.hpp
@@ -21,7 +21,7 @@ private:
 public:
     using TsfnType = Napi::TypedThreadSafeFunction<std::nullptr_t, JsExecCtx, JsExecCtx::tramp>;
     using ArgFuncType = std::function<std::vector<napi_value>(Napi::Env&)>;
-    using ResFuncType = std::function<void(const Napi::Value&, bool)>;
+    using ResFuncType = std::function<void(const Napi::CallbackInfo&, bool)>;
 
     // FIXME (aw): proper module_instance handling if nullptr
     JsExecCtx(const Napi::Env& env, const Napi::Function& func, const std::string& res_name = "RequestDispatcher") :

--- a/everestjs/utils.hpp
+++ b/everestjs/utils.hpp
@@ -13,51 +13,41 @@ namespace EverestJs {
     do {                                                                                                               \
         try {                                                                                                          \
             throw;                                                                                                     \
-        } catch (Napi::Error & e) {                                                                                    \
+        } catch (Napi::Error& e) {                                                                                     \
             try {                                                                                                      \
                 BOOST_THROW_EXCEPTION(boost::enable_error_info(e)                                                      \
                                       << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                    \
-            } catch (std::exception & e) {                                                                             \
+            } catch (boost::exception& ex) {                                                                           \
+                char const * const * f = boost::get_error_info<boost::throw_file>(ex);                                 \
+                int const * l = boost::get_error_info<boost::throw_line>(ex);                                          \
+                char const * const * fn = boost::get_error_info<boost::throw_function>(ex);                            \
                 EVLOG(critical) << "Catched top level Napi::Error, forwarding to javascript..." << std::endl           \
-                                << boost::diagnostic_information(e, true) << std::endl                                 \
+                                << (f ? *f : "") << ":" << (l ? std::to_string(*l) : "") << " in Function "            \
+                                << (fn ? *fn : "") << std::endl                                                        \
+                                << boost::diagnostic_information(e, true)                                              \
+                                << boost::diagnostic_information(ex, false) << std::endl                               \
                                 << "==============================" << std::endl                                       \
                                 << std::endl;                                                                          \
             }                                                                                                          \
-            throw;                                                                                                     \
-        } catch (std::runtime_error & e) {                                                                             \
+            throw;    /* this will forward the exception back to javascript and enable js backtraces */                \
+        } catch (std::exception& e) {                                                                                  \
             try {                                                                                                      \
                 BOOST_THROW_EXCEPTION(boost::enable_error_info(e)                                                      \
                                       << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                    \
-            } catch (std::exception & e) {                                                                             \
-                EVLOG(critical) << "Catched top level runtime exception, forwarding to javascript..." << std::endl     \
-                                << boost::diagnostic_information(e, true) << std::endl                                 \
-                                << "==============================" << std::endl                                       \
-                                << std::endl;                                                                          \
-                metamacro_if_eq(0, metamacro_argcount(__VA_ARGS__))(throw;)(EVTHROW(Napi::Error::New(                  \
-                    metamacro_at(0, __VA_ARGS__), Napi::String::New(metamacro_at(0, __VA_ARGS__), e.what())));)        \
-            }                                                                                                          \
-        } catch (std::logic_error & e) {                                                                               \
-            try {                                                                                                      \
-                BOOST_THROW_EXCEPTION(boost::enable_error_info(e)                                                      \
-                                      << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                    \
-            } catch (std::exception & e) {                                                                             \
-                EVLOG(critical) << "Catched top level logic exception, forwarding to javascript..." << std::endl       \
-                                << boost::diagnostic_information(e, true) << std::endl                                 \
-                                << "==============================" << std::endl                                       \
-                                << std::endl;                                                                          \
-                metamacro_if_eq(0, metamacro_argcount(__VA_ARGS__))(throw;)(EVTHROW(Napi::Error::New(                  \
-                    metamacro_at(0, __VA_ARGS__), Napi::String::New(metamacro_at(0, __VA_ARGS__), e.what())));)        \
-            }                                                                                                          \
-        } catch (std::exception & e) {                                                                                 \
-            try {                                                                                                      \
-                BOOST_THROW_EXCEPTION(boost::enable_error_info(e)                                                      \
-                                      << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                    \
-            } catch (std::exception & e) {                                                                             \
+            } catch (boost::exception & ex) {                                                                          \
+                char const * const * f = boost::get_error_info<boost::throw_file>(ex);                                 \
+                int const * l = boost::get_error_info<boost::throw_line>(ex);                                          \
+                char const * const * fn = boost::get_error_info<boost::throw_function>(ex);                            \
                 EVLOG(critical) << "Catched top level exception, forwarding to javascript..." << std::endl             \
-                                << boost::diagnostic_information(e, true) << std::endl                                 \
+                                << (f ? *f : "") << ":" << (l ? std::to_string(*l) : "") << " in Function "            \
+                                << (fn ? *fn : "") << std::endl                                                        \
+                                << boost::diagnostic_information(e, true)                                              \
+                                << boost::diagnostic_information(ex, false) << std::endl                               \
                                 << "==============================" << std::endl                                       \
                                 << std::endl;                                                                          \
-                throw;                                                                                                 \
+                /* this will forward the exception to javascript and enable js backtraces */                           \
+                metamacro_if_eq(0, metamacro_argcount(__VA_ARGS__))(throw;)(EVTHROW(Napi::Error::New(                  \
+                    metamacro_at(0, __VA_ARGS__), Napi::String::New(metamacro_at(0, __VA_ARGS__), e.what())));)        \
             }                                                                                                          \
         }                                                                                                              \
     } while (0)

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -100,8 +100,7 @@ void Everest::check_code() {
             for (const auto& cmd : cmds_not_registered) {
                 oss << " '" << cmd << "'";
             }
-            EVLOG(error) << oss.str();
-            EVTHROW(EverestApiError(oss.str()));
+            EVLOG_AND_THROW(EverestApiError(oss.str()));
         }
     }
 }
@@ -145,7 +144,7 @@ json Everest::call_cmd(const std::string& requirement_id, const std::string& cmd
                 oss << key << ",";
             }
             oss << "): Argument count does not match manifest!";
-            EVTHROW(EverestApiError(oss.str()));
+            EVLOG_AND_THROW(EverestApiError(oss.str()));
         }
 
         std::set<std::string> unknown_arguments;
@@ -174,7 +173,7 @@ json Everest::call_cmd(const std::string& requirement_id, const std::string& cmd
                 oss << key << ",";
             }
             oss << "!";
-            EVTHROW(EverestApiError(oss.str()));
+            EVLOG_AND_THROW(EverestApiError(oss.str()));
         }
     }
 
@@ -194,7 +193,7 @@ json Everest::call_cmd(const std::string& requirement_id, const std::string& cmd
                 }
                 oss << "): Argument '" << arg_name << "' with value '" << json_args[arg_name]
                     << "' could not be validated with schema: " << e.what();
-                EVTHROW(EverestApiError(oss.str()));
+                EVLOG_AND_THROW(EverestApiError(oss.str()));
             }
         }
     }
@@ -334,7 +333,7 @@ void Everest::publish_var(const std::string& impl_id, const std::string& var_nam
             oss << "Publish var of " << this->config.printable_identifier(this->module_id, impl_id)
                 << " with variable name '" << var_name << "' with value '" << std::setw(4) << json_value
                 << "' could not be validated with schema: " << e.what();
-            EVTHROW(EverestApiError(oss.str()));
+            EVLOG_AND_THROW(EverestApiError(oss.str()));
         }
     }
 
@@ -433,7 +432,7 @@ void Everest::provide_external_mqtt_handler(const std::string& topic, const Stri
     BOOST_LOG_FUNCTION();
 
     if (this->registered_external_mqtt_handlers.count(topic) != 0) {
-        EVTHROW(EVEXCEPTION(EverestApiError, this->config.printable_identifier(this->module_id),
+        EVLOG_AND_THROW(EVEXCEPTION(EverestApiError, this->config.printable_identifier(this->module_id),
                             "->external_mqtt_handler<", topic,
                             ">: External MQTT Handler for this topic already registered",
                             " (you can not register an external MQTT handler twice)!"));
@@ -513,7 +512,7 @@ void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name,
     json cmd_definition = get_cmd_definition(this->module_id, impl_id, cmd_name, false);
 
     if (this->registered_cmds.count(impl_id) != 0 && this->registered_cmds[impl_id].count(cmd_name) != 0) {
-        EVTHROW(EVEXCEPTION(EverestApiError, this->config.printable_identifier(this->module_id, impl_id), "->",
+        EVLOG_AND_THROW(EVEXCEPTION(EverestApiError, this->config.printable_identifier(this->module_id, impl_id), "->",
                             cmd_name, "(...): Handler for this cmd already registered",
                             " (you can not register a cmd handler twice)!"));
     }
@@ -635,7 +634,7 @@ void Everest::provide_cmd(const cmd& cmd) {
             oss << key << ",";
         }
         oss << "): Argument count of cmd handler does not match manifest!";
-        EVTHROW(EverestApiError(oss.str()));
+        EVLOG_AND_THROW(EverestApiError(oss.str()));
     }
 
     std::set<std::string> unknown_arguments;
@@ -662,7 +661,7 @@ void Everest::provide_cmd(const cmd& cmd) {
             oss << key << ",";
         }
         oss << "!";
-        EVTHROW(EverestApiError(oss.str()));
+        EVLOG_AND_THROW(EverestApiError(oss.str()));
     }
 
     std::string arg_name = check_args(arg_types, cmd_definition["arguments"]);
@@ -679,7 +678,7 @@ void Everest::provide_cmd(const cmd& cmd) {
         }
         oss << "' for '" << arg_name << "' does not match manifest type '"
             << cmd_definition["arguments"][arg_name]["type"] << "'!";
-        EVTHROW(EverestApiError(oss.str()));
+        EVLOG_AND_THROW(EverestApiError(oss.str()));
     }
 
     // validate return value annotations
@@ -695,7 +694,7 @@ void Everest::provide_cmd(const cmd& cmd) {
         }
         oss << "' does not match manifest type '" << cmd_definition["result"] << "'!";
         // FIXME (aw): this gives more output EVLOG(error) << oss.str(); than the EVTHROW, why?
-        EVTHROW(EverestApiError(oss.str()));
+        EVLOG_AND_THROW(EverestApiError(oss.str()));
     }
 
     return this->provide_cmd(impl_id, cmd_name, [handler](json data) {


### PR DESCRIPTION
- instead of silencing completely, everestjs throws now errors on
  unhandled rejections, which in turn will lead again to an unhandled
  rejection within the callbackWrapper and could thus yield a stack trace
  (this seems to depend on nodejs version and its runtime configuration,
  because an unhandled rejection doesn't seem to be the same like an
  error)
- append boost log information to napi error exceptions
- use EVLOG_AND_THROW
- added some try and catch blocks, where necessary

Signed-off-by: Thilo Molitor <thilo@eightysoft.de>
Signed-off-by: aw <aw@pionix.de>
Co-authored-by: aw <aw@pionix.de>