### PR TITLE
Fix 'null' type handling

### DIFF
--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -402,6 +402,10 @@ json Config::load_interface_file(const std::string& intf_name) {
 json Config::resolve_requirement(const std::string& module_id, const std::string& requirement_id) {
     BOOST_LOG_FUNCTION();
 
+    // FIXME (aw): this function should throw, if the requirement id
+    //             isn't even listed in the module manifest
+    // FIXME (aw): the following if doesn't check for the requirement id
+    //             at all
     if (!this->main.contains(module_id)) {
         EVLOG_AND_THROW(EVEXCEPTION(EverestApiError, "Requested requirement id '", requirement_id, "' of module ",
                                     printable_identifier(module_id), " not found in config!"));

--- a/schemas/interface.json
+++ b/schemas/interface.json
@@ -14,17 +14,21 @@
             "properties": {
                 "type": {
                     "type": [
-                        "array",
-                        "string"
-                    ]
+                        "string",
+                        "array"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
                 },
                 "description": {
                     "type": "string",
                     "minLength": 2
                 },
-                "default": false            // we don't allow default values
+                "default": false // we don't allow default values
             },
-            "additionalProperties": true    // allow all sorts of entries (should be a json schema!)
+            "additionalProperties": true // allow all sorts of entries (should be a json schema!)
         },
         "cmd_arguments_subschema": {
             "type": "object",
@@ -40,18 +44,23 @@
                             "type": [
                                 "array",
                                 "string"
-                            ]
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true,
+                            "pattern": "^(?!null).*$"
                         },
                         "description": {
                             "type": "string",
                             "minLength": 2
                         },
-                        "default": false            // we don't allow default values
+                        "default": false // we don't allow default values
                     },
-                    "additionalProperties": true    // allow all sorts of entries (should be a json schema!)
+                    "additionalProperties": true // allow all sorts of entries (should be a json schema!)
                 }
             },
-            "additionalProperties": false,          // only allow argument names conforming to our pattern above
+            "additionalProperties": false, // only allow argument names conforming to our pattern above
             "default": {}
         },
         "cmd_result_subschema": {
@@ -65,15 +74,20 @@
                     "type": [
                         "array",
                         "string"
-                    ]
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "pattern": "^(?!null).*$"
                 },
                 "description": {
                     "type": "string",
                     "minLength": 2
                 },
-                "default": false             // we don't allow default values
+                "default": false // we don't allow default values
             },
-            "additionalProperties": true,    // allow all sorts of entries (should be a json schema!)
+            "additionalProperties": true, // allow all sorts of entries (should be a json schema!)
             "default": {
                 "type": "null",
                 "description": "This returns nothing"


### PR DESCRIPTION
- changed interface schema:
  - arguments types to a function and return types of type 'null' are not
    allowed anymore
  - if no return value is wished, just leave out the result property
  - for published vars, the null type is still allowed, meaning that no
    value will be passed, this will be handled in the corresponding
    ev-cli changes
  - for variant types, the 'null' type is still allowed, having the
    meaning, that the variant is empty
- the 'null' type is represented by boost::blank, the corresponding
  changes have been done to the conversions.cpp

Signed-off-by: aw <aw@pionix.de>