### PR TITLE
Dump json variables before calling fmt::format

### DIFF
--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -432,7 +432,7 @@ void Everest::signal_ready() {
 void Everest::handle_ready(json data) {
     BOOST_LOG_FUNCTION();
 
-    EVLOG(debug) << fmt::format("handle_ready: {}", data);
+    EVLOG(debug) << fmt::format("handle_ready: {}", data.dump());
 
     bool ready = false;
 

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -131,7 +131,7 @@ void MQTTAbstractionImpl::on_mqtt_message_(std::string topic, std::string payloa
     try {
         json data;
         if (topic.find("everest/") == 0) {
-            EVLOG(debug) << "topic starts with everest/";
+            EVLOG(debug) << fmt::format("topic {} starts with everest/", topic);
             try {
                 data = json::parse(payload);
             } catch (nlohmann::detail::parse_error& e) {
@@ -169,7 +169,7 @@ void MQTTAbstractionImpl::on_mqtt_message_(std::string topic, std::string payloa
 
         if (!found) {
             EVLOG_AND_THROW(
-                EverestInternalError(fmt::format("Internal error: topic '{}' should have a matching handler!")));
+                EverestInternalError(fmt::format("Internal error: topic '{}' should have a matching handler!", topic)));
         }
     } catch (boost::exception& e) {
         EVLOG(critical) << fmt::format("Caught mqtt on_message boost::exception:\n{}",
@@ -210,7 +210,7 @@ Token MQTTAbstractionImpl::register_handler(const std::string& topic, const Hand
                                             bool allow_multiple_handlers) {
     BOOST_LOG_FUNCTION();
 
-    EVLOG(debug) << fmt::format("Registering handler {} for ", fmt::ptr(&handler), topic);
+    EVLOG(debug) << fmt::format("Registering handler {} for {}", fmt::ptr(&handler), topic);
 
     const std::lock_guard<std::mutex> lock(handlers_mutex);
     if (!this->handlers[topic].empty() && !allow_multiple_handlers) {

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[]) {
 
         Handler module_ready_handler = [module_name, &modules_ready, &modules_ready_mutex,
                                         &mqtt_abstraction](nlohmann::json json) {
-            EVLOG(debug) << fmt::format("received module ready signal for module: {}({})", module_name, json);
+            EVLOG(debug) << fmt::format("received module ready signal for module: {}({})", module_name, json.dump());
             std::unique_lock<std::mutex> lock(modules_ready_mutex);
             modules_ready[module_name] = json.get<bool>();
             for (const auto& mod : modules_ready) {


### PR DESCRIPTION
You have to call dump() on a json variable before fmt::format-ting it.

Otherwise this might lead to very obscure exceptions like:
```
Dynamic exception type: nlohmann::detail::type_error
std::exception::what: [json.exception.type_error.302] type must be string, but is boolean
terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.302] type must be string, but is boolean
```