### PR TITLE
Dump json value of retval in debug message.

### DIFF
--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -546,7 +546,7 @@ void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name,
             }
         }
 
-        EVLOG(debug) << fmt::format("RETVAL: {}", res_publish_data["retval"]);
+        EVLOG(debug) << fmt::format("RETVAL: {}", res_publish_data["retval"].dump());
         res_publish_data["origin"] = this->module_id;
         this->mqtt_abstraction.publish(res_topic.str(), res_publish_data);
     };


### PR DESCRIPTION
This fixes the following exception:
Dynamic exception type: nlohmann::detail::type_error
std::exception::what: [json.exception.type_error.302] type must be string, but is null
terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.302] type must be string, but is null

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>