### PR TITLE
Improve MQTT message handling

### DIFF
--- a/everestjs/js_exec_ctx.hpp
+++ b/everestjs/js_exec_ctx.hpp
@@ -46,9 +46,9 @@ private:
     ResFuncType res_func;
     // FIXME (aw): will the referenced object be GC'd when the references get destroyed?
     //             and is okay to be destroyed in our async thread?
+    TsfnType tsfn;
     Napi::ObjectReference result_handler_ref;
     Napi::FunctionReference func_ref{};
-    TsfnType tsfn;
     std::mutex exec_mutex;
     std::promise<void> promise;
 };

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -50,8 +50,6 @@ private:
             const std::string& mqtt_server_address, const std::string& mqtt_server_port);
     MQTTAbstraction& mqtt_abstraction;
 
-    void internal_publish(const std::string& topic, const json& json);
-
     void handle_ready(json data);
 
     void heartbeat();

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -38,7 +38,6 @@ private:
     std::map<std::string, Handler> registered_external_mqtt_handlers;
     std::vector<Token> registered_handlers;
     bool ready_received;
-    std::chrono::seconds remote_cmd_ack_timeout;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -36,7 +36,6 @@ private:
     Config config;
     std::map<std::string, std::set<std::string>> registered_cmds;
     std::map<std::string, Handler> registered_external_mqtt_handlers;
-    std::vector<Token> registered_handlers;
     bool ready_received;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -54,6 +54,8 @@ private:
 
     void heartbeat();
 
+    void publish_metadata();
+
     static std::string check_args(const Arguments& func_args, json manifest_args);
     static bool check_arg(ArgumentType arg_types, json manifest_arg);
 

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -32,10 +32,10 @@ struct cmd {
 class Everest {
 
 private:
-    std::string module_id;
+    MQTTAbstraction& mqtt_abstraction;
     Config config;
+    std::string module_id;
     std::map<std::string, std::set<std::string>> registered_cmds;
-    std::map<std::string, Handler> registered_external_mqtt_handlers;
     bool ready_received;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
@@ -47,7 +47,6 @@ private:
 
     Everest(std::string module_id, Config config, bool validate_data_with_schema,
             const std::string& mqtt_server_address, const std::string& mqtt_server_port);
-    MQTTAbstraction& mqtt_abstraction;
 
     void handle_ready(json data);
 

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef UTILS_MESSAGE_QUEUE_HPP
+#define UTILS_MESSAGE_QUEUE_HPP
+
+#include <condition_variable>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include <utils/types.hpp>
+
+namespace Everest {
+using json = nlohmann::json;
+
+/// \brief Contains a payload and the topic it was received on
+struct Message {
+    std::string topic;   ///< The MQTT topic where this message originated from
+    std::string payload; ///< The message payload
+};
+
+/// \brief Simple message queue that takes std::string messages, parsed them and dispatches them to handlers
+class MessageQueue {
+private:
+    std::thread worker_thread;
+    std::queue<std::shared_ptr<Message>> message_queue;
+    std::mutex message_mutex;
+    std::function<void(std::shared_ptr<Message> message)> message_callback;
+    std::condition_variable cv;
+    bool running;
+
+public:
+    /// \brief Creates a message queue with the provided \p message_callback
+    MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback);
+
+    /// \brief Adds a \p message to the message queue which will then be delivered to the message callback
+    void add(std::shared_ptr<Message> message);
+
+    /// \brief Stops the message queue
+    void stop();
+};
+
+/// \brief Contains a message queue driven list of handler callbacks
+class MessageHandler {
+private:
+    std::vector<std::shared_ptr<Handler>> handlers;
+    std::thread handler_thread;
+    std::queue<std::shared_ptr<json>> message_queue;
+    std::mutex message_mutex;
+    std::mutex handlers_mutex;
+    std::condition_variable cv;
+    bool running;
+
+public:
+    /// \brief Creates the message handler
+    MessageHandler();
+
+    /// \brief Adds a \p message to the message queue which will be delivered to the registered handlers
+    void add(std::shared_ptr<json> message);
+
+    /// \brief Stops the message handler
+    void stop();
+
+    /// \brief Adds a \p handler that will receive messages from the queue. This function can be called multiple times
+    /// to add multiple handlers
+    void add_handler(std::shared_ptr<Handler> handler);
+
+    /// \brief Removes a specific \p handler
+    void remove_handler(std::shared_ptr<Handler> handler);
+
+    /// \brief \returns the number of registered handlers
+    size_t count_handlers();
+};
+
+} // namespace Everest
+
+#endif // UTILS_MESSAGE_QUEUE_HPP

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
-#include <vector>
+#include <unordered_set>
 
 #include <nlohmann/json.hpp>
 
@@ -51,7 +51,7 @@ public:
 /// \brief Contains a message queue driven list of handler callbacks
 class MessageHandler {
 private:
-    std::vector<std::shared_ptr<TypedHandler>> handlers;
+    std::unordered_set<std::shared_ptr<TypedHandler>> handlers;
     std::thread handler_thread;
     std::queue<std::shared_ptr<json>> message_queue;
     std::mutex message_mutex;

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -49,7 +49,7 @@ public:
 /// \brief Contains a message queue driven list of handler callbacks
 class MessageHandler {
 private:
-    std::vector<std::shared_ptr<Handler>> handlers;
+    std::vector<std::shared_ptr<TypedHandler>> handlers;
     std::thread handler_thread;
     std::queue<std::shared_ptr<json>> message_queue;
     std::mutex message_mutex;
@@ -67,12 +67,11 @@ public:
     /// \brief Stops the message handler
     void stop();
 
-    /// \brief Adds a \p handler that will receive messages from the queue. This function can be called multiple times
-    /// to add multiple handlers
-    void add_handler(std::shared_ptr<Handler> handler);
+    /// \brief Adds a \p handler that will receive messages from the queue.
+    void add_handler(std::shared_ptr<TypedHandler> handler);
 
     /// \brief Removes a specific \p handler
-    void remove_handler(std::shared_ptr<Handler> handler);
+    void remove_handler(std::shared_ptr<TypedHandler> handler);
 
     /// \brief \returns the number of registered handlers
     size_t count_handlers();

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -24,7 +24,7 @@ struct Message {
     std::string topic;   ///< The MQTT topic where this message originated from
     std::string payload; ///< The message payload
 
-    Message(std::string topic, std::string payload);
+    Message(const std::string& topic, const std::string& payload);
 };
 
 /// \brief Simple message queue that takes std::string messages, parsed them and dispatches them to handlers

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -23,6 +23,8 @@ using json = nlohmann::json;
 struct Message {
     std::string topic;   ///< The MQTT topic where this message originated from
     std::string payload; ///< The message payload
+
+    Message(std::string topic, std::string payload);
 };
 
 /// \brief Simple message queue that takes std::string messages, parsed them and dispatches them to handlers

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -39,7 +39,7 @@ private:
 
 public:
     /// \brief Creates a message queue with the provided \p message_callback
-    MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback);
+    explicit MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback);
 
     /// \brief Adds a \p message to the message queue which will then be delivered to the message callback
     void add(std::shared_ptr<Message> message);

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef UTILS_MQTT_ABSTRACTION_HPP
 #define UTILS_MQTT_ABSTRACTION_HPP
 
@@ -35,12 +35,24 @@ public:
     void publish(const std::string& topic, const json& json);
 
     ///
+    /// \copydoc MQTTAbstractionImpl::publish(const std::string&, const json&, QOS)
+    void publish(const std::string& topic, const json& json, QOS qos);
+
+    ///
     /// \copydoc MQTTAbstractionImpl::publish(const std::string&, const std::string&)
     void publish(const std::string& topic, const std::string& data);
 
     ///
+    /// \copydoc MQTTAbstractionImpl::publish(const std::string&, const std::string&, QOS)
+    void publish(const std::string& topic, const std::string& data, QOS qos);
+
+    ///
     /// \copydoc MQTTAbstractionImpl::subscribe(const std::string&)
     void subscribe(const std::string& topic);
+
+    ///
+    /// \copydoc MQTTAbstractionImpl::subscribe(const std::string&, QOS)
+    void subscribe(const std::string& topic, QOS qos);
 
     ///
     /// \copydoc MQTTAbstractionImpl::unsubscribe(const std::string&)
@@ -57,6 +69,10 @@ public:
     ///
     /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, const Handler&, bool)
     Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers);
+
+    ///
+    /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, const Handler&, bool, QOS)
+    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers, QOS qos);
 
     ///
     /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -67,8 +67,8 @@ public:
     void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers, QOS qos);
 
     ///
-    /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const TypedToken&)
-    void unregister_handler(const std::string& topic, const TypedToken& token);
+    /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)
+    void unregister_handler(const std::string& topic, const Token& token);
 
     ///
     /// \returns the instance of the MQTTAbstraction singleton taking a \p mqtt_server_address and \p mqtt_server_port

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -63,20 +63,12 @@ public:
     void mainloop();
 
     ///
-    /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, const Handler&)
-    Token register_handler(const std::string& topic, const Handler& handler);
+    /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, std::shared_ptr<TypedHandler>, QOS)
+    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers, QOS qos);
 
     ///
-    /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, const Handler&, bool)
-    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers);
-
-    ///
-    /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, const Handler&, bool, QOS)
-    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers, QOS qos);
-
-    ///
-    /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)
-    void unregister_handler(const std::string& topic, const Token& token);
+    /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const TypedToken&)
+    void unregister_handler(const std::string& topic, const TypedToken& token);
 
     ///
     /// \returns the instance of the MQTTAbstraction singleton taking a \p mqtt_server_address and \p mqtt_server_port

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -39,7 +39,7 @@ private:
     bool mqtt_is_connected;
     std::map<std::string, std::shared_ptr<MessageHandler>> message_handlers;
     std::mutex handlers_mutex;
-    std::shared_ptr<MessageQueue> message_queue;
+    MessageQueue message_queue;
     std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;
     std::mutex messages_before_connected_mutex;
 

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -14,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <utils/message_queue.hpp>
 #include <utils/types.hpp>
 
 #define MQTT_BUF_SIZE 150 * 1024
@@ -28,8 +30,9 @@ class MQTTAbstractionImpl {
 
 private:
     bool mqtt_is_connected;
-    std::map<std::string, std::vector<Token>> handlers;
+    std::map<std::string, std::shared_ptr<MessageHandler>> message_handlers;
     std::mutex handlers_mutex;
+    std::shared_ptr<MessageQueue> message_queue;
 
     std::thread mqtt_mainloop_thread;
 
@@ -44,8 +47,7 @@ private:
     static int open_nb_socket(const char* addr, const char* port);
     bool connectBroker(const char* host, const char* port);
     void _mainloop();
-    void on_mqtt_message(std::string topic, std::string payload);
-    void on_mqtt_message_(std::string topic, std::string payload);
+    void on_mqtt_message(std::shared_ptr<Message> message);
     void on_mqtt_connect();
     static void on_mqtt_disconnect();
 

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -94,30 +94,14 @@ public:
 
     ///
     /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message
-    /// arrives on the topic. This function only allows one handler per topic.
-    ///
-    /// \returns a Token with which the handler can be unregistered later
-    Token register_handler(const std::string& topic, const Handler& handler);
-
-    ///
-    /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message
     /// arrives on the topic. If \p allow_multiple_handlers is set to true, multiple handlers can be registered for the
-    /// same topic.
-    ///
-    /// \returns a Token with which the handler can be unregistered later
-    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers);
-
-    ///
-    /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message
-    /// arrives on the topic. If \p allow_multiple_handlers is set to true, multiple handlers can be registered for the
-    /// same topic. With \p qos a MQTT Quality of Servicee level can be set.
-    ///
-    /// \returns a Token with which the handler can be unregistered later
-    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers, QOS qos);
+    /// same topic. With \p qos a MQTT Quality of Service level can be set.
+    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers,
+                          QOS qos);
 
     ///
     /// \brief unsubscribes a handler identified by its \p token from the given \p topic
-    void unregister_handler(const std::string& topic, const Token& token);
+    void unregister_handler(const std::string& topic, const TypedToken& token);
 
     ///
     /// \brief checks if the given \p full_topic matches the given \p wildcard_topic that can contain "+" and "#"

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -110,7 +110,7 @@ public:
 
     ///
     /// \brief unsubscribes a handler identified by its \p token from the given \p topic
-    void unregister_handler(const std::string& topic, const TypedToken& token);
+    void unregister_handler(const std::string& topic, const Token& token);
 
     ///
     /// \brief checks if the given \p full_topic matches the given \p wildcard_topic that can contain "+" and "#"

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -45,11 +45,11 @@ private:
 
     std::thread mqtt_mainloop_thread;
 
+    std::string mqtt_server_address;
+    std::string mqtt_server_port;
     struct mqtt_client mqtt_client;
     uint8_t sendbuf[MQTT_BUF_SIZE];
     uint8_t recvbuf[MQTT_BUF_SIZE];
-    std::string mqtt_server_address;
-    std::string mqtt_server_port;
 
     MQTTAbstractionImpl(std::string mqtt_server_address, std::string mqtt_server_port);
 

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #ifndef UTILS_MQTT_ABSTRACTION_IMPL_HPP
 #define UTILS_MQTT_ABSTRACTION_IMPL_HPP
 
@@ -59,16 +59,28 @@ public:
     void disconnect();
 
     ///
-    /// \brief publishes the given \p json on the given \p topic
+    /// \brief publishes the given \p json on the given \p topic with QOS level 0
     void publish(const std::string& topic, const json& json);
 
     ///
-    /// \brief publishes the given \p data on the given \p topic
+    /// \brief publishes the given \p json on the given \p topic with the given \p qos
+    void publish(const std::string& topic, const json& json, QOS qos);
+
+    ///
+    /// \brief publishes the given \p data on the given \p topic with QOS level 0
     void publish(const std::string& topic, const std::string& data);
 
     ///
-    /// \brief subscribes to the given \p topic
+    /// \brief publishes the given \p data on the given \p topic with the given \p qos
+    void publish(const std::string& topic, const std::string& data, QOS qos);
+
+    ///
+    /// \brief subscribes to the given \p topic with QOS level 0
     void subscribe(const std::string& topic);
+
+    ///
+    /// \brief subscribes to the given \p topic with the given \p qos
+    void subscribe(const std::string& topic, QOS qos);
 
     ///
     /// \brief unsubscribes from the given \p topic
@@ -92,6 +104,14 @@ public:
     ///
     /// \returns a Token with which the handler can be unregistered later
     Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers);
+
+    ///
+    /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message
+    /// arrives on the topic. If \p allow_multiple_handlers is set to true, multiple handlers can be registered for the
+    /// same topic. With \p qos a MQTT Quality of Servicee level can be set.
+    ///
+    /// \returns a Token with which the handler can be unregistered later
+    Token register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers, QOS qos);
 
     ///
     /// \brief unsubscribes a handler identified by its \p token from the given \p topic

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -37,7 +37,7 @@ class MQTTAbstractionImpl {
 
 private:
     bool mqtt_is_connected;
-    std::map<std::string, std::shared_ptr<MessageHandler>> message_handlers;
+    std::map<std::string, MessageHandler> message_handlers;
     std::mutex handlers_mutex;
     MessageQueue message_queue;
     std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -27,7 +27,7 @@ using json = nlohmann::json;
 struct MessageWithQOS : Message {
     QOS qos; ///< The Quality of Service level
 
-    MessageWithQOS(std::string topic, std::string payload, QOS qos);
+    MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos);
 };
 
 ///

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -23,6 +23,13 @@
 namespace Everest {
 using json = nlohmann::json;
 
+/// \brief Contains a payload and the topic it was received on with additional QOS
+struct MessageWithQOS : Message {
+    QOS qos; ///< The Quality of Service level
+
+    MessageWithQOS(std::string topic, std::string payload, QOS qos);
+};
+
 ///
 /// \brief Contains a C++ abstraction of MQTT-C and some convenience functionality for using MQTT in EVerest modules
 ///
@@ -33,6 +40,8 @@ private:
     std::map<std::string, std::shared_ptr<MessageHandler>> message_handlers;
     std::mutex handlers_mutex;
     std::shared_ptr<MessageQueue> message_queue;
+    std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;
+    std::mutex messages_before_connected_mutex;
 
     std::thread mqtt_mainloop_thread;
 

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -33,6 +33,14 @@ using Handler = std::function<void(json)>;
 using StringHandler = std::function<void(std::string)>;
 using Token = std::shared_ptr<Handler>;
 
+/// \brief MQTT Quality of service
+enum class QOS
+{
+    QOS0, ///< At most once delivery
+    QOS1, ///< At least once delivery
+    QOS2  ///< Exactly once delivery
+};
+
 struct ModuleInfo {
     std::string name;
     std::vector<std::string> authors;

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -31,7 +31,6 @@ using Object = json::object_t;
 // TODO (aw): can we pass the handler arguments by const ref?
 using Handler = std::function<void(json)>;
 using StringHandler = std::function<void(std::string)>;
-using Token = std::shared_ptr<Handler>;
 
 enum class HandlerType
 {
@@ -60,7 +59,7 @@ struct TypedHandler {
     }
 };
 
-using TypedToken = std::shared_ptr<TypedHandler>;
+using Token = std::shared_ptr<TypedHandler>;
 
 /// \brief MQTT Quality of service
 enum class QOS

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -33,6 +33,35 @@ using Handler = std::function<void(json)>;
 using StringHandler = std::function<void(std::string)>;
 using Token = std::shared_ptr<Handler>;
 
+enum class HandlerType
+{
+    Call,
+    Result,
+    SubscribeVar,
+    ExternalMQTT,
+    Unknown
+};
+
+struct TypedHandler {
+    std::string name;
+    std::string id;
+    HandlerType type;
+    std::shared_ptr<Handler> handler;
+
+    TypedHandler(std::string name, std::string id, HandlerType type, std::shared_ptr<Handler> handler) :
+        name(name), id(id), type(type), handler(handler) {
+    }
+
+    TypedHandler(std::string name, HandlerType type, std::shared_ptr<Handler> handler) :
+        TypedHandler(name, "", type, handler) {
+    }
+
+    TypedHandler(HandlerType type, std::shared_ptr<Handler> handler) : TypedHandler("", "", type, handler) {
+    }
+};
+
+using TypedToken = std::shared_ptr<TypedHandler>;
+
 /// \brief MQTT Quality of service
 enum class QOS
 {

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -47,11 +47,11 @@ struct TypedHandler {
     HandlerType type;
     std::shared_ptr<Handler> handler;
 
-    TypedHandler(std::string name, std::string id, HandlerType type, std::shared_ptr<Handler> handler) :
+    TypedHandler(const std::string& name, const std::string& id, HandlerType type, std::shared_ptr<Handler> handler) :
         name(name), id(id), type(type), handler(handler) {
     }
 
-    TypedHandler(std::string name, HandlerType type, std::shared_ptr<Handler> handler) :
+    TypedHandler(const std::string& name, HandlerType type, std::shared_ptr<Handler> handler) :
         TypedHandler(name, "", type, handler) {
     }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,6 +2,7 @@ set(HEADERS
     "${PROJECT_SOURCE_DIR}/include/utils/config.hpp"
     "${PROJECT_SOURCE_DIR}/include/utils/exceptions.hpp"
     "${PROJECT_SOURCE_DIR}/include/utils/logging.hpp"
+    "${PROJECT_SOURCE_DIR}/include/utils/message_queue.hpp"
     "${PROJECT_SOURCE_DIR}/include/utils/mqtt_abstraction.hpp"
     "${PROJECT_SOURCE_DIR}/include/utils/types.hpp"
 	"${PROJECT_SOURCE_DIR}/include/utils/conversions.hpp"
@@ -16,6 +17,7 @@ target_sources(everest
     PRIVATE
         config.cpp
         everest.cpp
+        message_queue.cpp
         mqtt_abstraction.cpp
         mqtt_abstraction_impl.cpp
         conversions.cpp

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -704,7 +704,7 @@ json Config::extract_implementation_info(const std::string& module_id, const std
         }
 
         if (!this->manifests[info["module_name"].get<std::string>()]["provides"].contains(impl_id)) {
-            EVTHROW(EverestApiError(fmt::format("Implementaiton id '{}' not defined in manifest of module '{}'!",
+            EVTHROW(EverestApiError(fmt::format("Implementation id '{}' not defined in manifest of module '{}'!",
                                                 impl_id, info["module_name"])));
         }
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -671,19 +671,13 @@ ModuleInfo Config::get_module_info(const std::string& module_id) {
 std::string Config::mqtt_prefix(const std::string& module_id, const std::string& impl_id) {
     BOOST_LOG_FUNCTION();
 
-    json info = extract_implementation_info(module_id, impl_id);
-
-    return fmt::format("everest/{}:{}/{}:{}", info["module_id"].get<std::string>(),
-                       info["module_name"].get<std::string>(), info["impl_id"].get<std::string>(),
-                       info["impl_intf"].get<std::string>());
+    return fmt::format("everest/{}/{}", module_id, impl_id);
 }
 
 std::string Config::mqtt_module_prefix(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
-    json info = extract_implementation_info(module_id);
-
-    return fmt::format("everest/{}:{}", info["module_id"].get<std::string>(), info["module_name"].get<std::string>());
+    return fmt::format("everest/{}", module_id);
 }
 
 json Config::extract_implementation_info(const std::string& module_id, const std::string& impl_id) {

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -54,7 +54,7 @@ void Everest::mainloop() {
 
 void Everest::heartbeat() {
     BOOST_LOG_FUNCTION();
-    std::string heartbeat_topic = fmt::format("{}/heartbeat", this->config.mqtt_module_prefix(this->module_id));
+    const auto heartbeat_topic = fmt::format("{}/heartbeat", this->config.mqtt_module_prefix(this->module_id));
 
     using namespace date;
 
@@ -83,7 +83,7 @@ void Everest::publish_metadata() {
         }
     }
 
-    std::string metadata_topic = fmt::format("{}/metadata", this->config.mqtt_module_prefix(this->module_id));
+    const auto metadata_topic = fmt::format("{}/metadata", this->config.mqtt_module_prefix(this->module_id));
 
     this->mqtt_abstraction.publish(metadata_topic, metadata);
 }
@@ -209,7 +209,7 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
             json::object({{"retval", data["retval"]}, {"origin", data["origin"]}, {"id", data["id"]}}));
     };
 
-    std::string cmd_topic =
+    const auto cmd_topic =
         fmt::format("{}/cmd", this->config.mqtt_prefix(connection["module_id"], connection["implementation_id"]));
 
     std::shared_ptr<TypedHandler> res_token =
@@ -281,7 +281,7 @@ void Everest::publish_var(const std::string& impl_id, const std::string& var_nam
         }
     }
 
-    std::string var_topic = fmt::format("{}/var", this->config.mqtt_prefix(this->module_id, impl_id));
+    const auto var_topic = fmt::format("{}/var", this->config.mqtt_prefix(this->module_id, impl_id));
 
     json var_publish_data = {{"name", var_name}, {"data", json_value}};
 
@@ -337,7 +337,7 @@ void Everest::subscribe_var(const Requirement& req, const std::string& var_name,
         callback(data);
     };
 
-    std::string var_topic = fmt::format("{}/var", this->config.mqtt_prefix(requirement_module_id, requirement_impl_id));
+    const auto var_topic = fmt::format("{}/var", this->config.mqtt_prefix(requirement_module_id, requirement_impl_id));
 
     // TODO(kai): multiple subscription should be perfectly fine here!
     std::shared_ptr<TypedHandler> token =
@@ -399,7 +399,7 @@ void Everest::signal_ready() {
     BOOST_LOG_FUNCTION();
 
     EVLOG(info) << "Sending out module ready signal...";
-    std::string ready_topic = fmt::format("{}/ready", this->config.mqtt_module_prefix(this->module_id));
+    const auto ready_topic = fmt::format("{}/ready", this->config.mqtt_module_prefix(this->module_id));
 
     this->mqtt_abstraction.publish(ready_topic, json(true));
 }
@@ -454,7 +454,7 @@ void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name,
             this->config.printable_identifier(this->module_id, impl_id), cmd_name)));
     }
 
-    std::string cmd_topic = fmt::format("{}/cmd", this->config.mqtt_prefix(this->module_id, impl_id));
+    const auto cmd_topic = fmt::format("{}/cmd", this->config.mqtt_prefix(this->module_id, impl_id));
 
     // define command wrapper
     Handler wrapper = [this, cmd_topic, impl_id, cmd_name, handler, cmd_definition](json data) {

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -173,11 +173,6 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
     std::promise<json> res_promise;
     std::future<json> res_future = res_promise.get_future();
 
-    std::ostringstream res_topic_str;
-    res_topic_str << this->config.mqtt_prefix(connection["module_id"], connection["implementation_id"]) << "/res/"
-                  << cmd_name;
-    std::string res_topic = res_topic_str.str();
-
     Handler res_handler = [this, &res_promise, call_id, connection, cmd_name](json data) {
         if (data["id"] != call_id) {
             EVLOG(debug) << fmt::format("RES: data_id != call_id ({} != {})", data["id"], call_id);
@@ -230,7 +225,7 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
         EVLOG(debug) << "res future ready";
         result = res_future.get();
     }
-    this->mqtt_abstraction.unregister_handler(res_topic, res_token);
+    this->mqtt_abstraction.unregister_handler(cmd_topic, res_token);
 
     return result;
 }

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -367,13 +367,6 @@ void Everest::external_mqtt_publish(const std::string& topic, const std::string&
 void Everest::provide_external_mqtt_handler(const std::string& topic, const StringHandler& handler) {
     BOOST_LOG_FUNCTION();
 
-    if (this->registered_external_mqtt_handlers.count(topic) != 0) {
-        EVLOG_AND_THROW(
-            EverestApiError(fmt::format("{}->external_mqtt_handler<{}>: External MQTT Handler for this topic already "
-                                        "registered (you can not register an external MQTT handler twice)!",
-                                        this->config.printable_identifier(this->module_id), topic)));
-    }
-
     // check if external mqtt is enabled
     if (!this->module_manifest.contains("enable_external_mqtt") &&
         this->module_manifest["enable_external_mqtt"] == false) {

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -53,9 +53,7 @@ void Everest::mainloop() {
 
 void Everest::heartbeat() {
     BOOST_LOG_FUNCTION();
-    std::ostringstream heartbeat_topic_stream;
-    heartbeat_topic_stream << this->config.mqtt_module_prefix(this->module_id) << "/heartbeat";
-    std::string heartbeat_topic = heartbeat_topic_stream.str();
+    std::string heartbeat_topic = fmt::format("{}/heartbeat", this->config.mqtt_module_prefix(this->module_id));
 
     using namespace date;
 
@@ -387,10 +385,9 @@ void Everest::signal_ready() {
     BOOST_LOG_FUNCTION();
 
     EVLOG(info) << "Sending out module ready signal...";
-    std::ostringstream oss;
-    oss << this->config.mqtt_module_prefix(this->module_id) << "/ready";
+    std::string ready_topic = fmt::format("{}/ready", this->config.mqtt_module_prefix(this->module_id));
 
-    this->mqtt_abstraction.publish(oss.str(), json(true));
+    this->mqtt_abstraction.publish(ready_topic, json(true));
 }
 
 ///
@@ -638,7 +635,6 @@ std::string Everest::check_args(const Arguments& func_args, json manifest_args) 
     for (auto const& func_arg : func_args) {
         auto arg_name = func_arg.first;
         auto arg_types = func_arg.second;
-        std::ostringstream oss;
 
         if (!check_arg(arg_types, manifest_args[arg_name])) {
             return arg_name;

--- a/lib/message_queue.cpp
+++ b/lib/message_queue.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <thread>
+
+#include <fmt/format.h>
+
+#include <everest/logging.hpp>
+
+#include <utils/message_queue.hpp>
+
+namespace Everest {
+
+MessageQueue::MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback) :
+    message_callback(message_callback), running(true) {
+    this->worker_thread = std::thread([this]() {
+        while (this->running) {
+            std::shared_ptr<Message> message;
+            std::unique_lock<std::mutex> lock(this->message_mutex);
+            this->cv.wait(lock, [this]() { return !this->message_queue.empty(); });
+
+            message = this->message_queue.front();
+            this->message_queue.pop();
+            lock.unlock();
+
+            // pass the message to the message callback
+            this->message_callback(message);
+        }
+    });
+}
+
+void MessageQueue::add(std::shared_ptr<Message> message) {
+    {
+        std::lock_guard<std::mutex> lock(this->message_mutex);
+        this->message_queue.push(message);
+    }
+    this->cv.notify_all();
+}
+
+void MessageQueue::stop() {
+    this->running = false;
+}
+
+MessageHandler::MessageHandler() : running(true) {
+    this->handler_thread = std::thread([this]() {
+        while (this->running) {
+            std::shared_ptr<json> message;
+            std::unique_lock<std::mutex> lock(this->message_mutex);
+            this->cv.wait(lock, [this]() { return !this->message_queue.empty(); });
+
+            message = this->message_queue.front();
+            this->message_queue.pop();
+            lock.unlock();
+
+            auto data = *message.get();
+
+            // get the registered handlers
+            std::vector<std::shared_ptr<Handler>> local_handlers;
+            {
+                const std::lock_guard<std::mutex> handlers_lock(handlers_mutex);
+                for (auto handler : this->handlers) {
+                    local_handlers.push_back(handler);
+                }
+            }
+
+            // distribute this message to the registered handlers
+            for (auto handler_ : local_handlers) {
+                auto handler = *handler_.get();
+                EVLOG(debug) << fmt::format("calling handler: {}", fmt::ptr(&handler));
+                handler(data);
+                EVLOG(debug) << fmt::format("handler '{}' called", fmt::ptr(&handler));
+            }
+        }
+    });
+}
+
+void MessageHandler::add(std::shared_ptr<json> message) {
+    {
+        std::lock_guard<std::mutex> lock(this->message_mutex);
+        this->message_queue.push(message);
+    }
+    this->cv.notify_all();
+}
+
+void MessageHandler::stop() {
+    this->running = false;
+}
+
+void MessageHandler::add_handler(std::shared_ptr<Handler> handler) {
+    {
+        std::lock_guard<std::mutex> lock(this->handlers_mutex);
+        this->handlers.push_back(handler);
+    }
+}
+
+void MessageHandler::remove_handler(std::shared_ptr<Handler> handler) {
+    {
+        std::lock_guard<std::mutex> lock(this->handlers_mutex);
+        auto it = std::find(this->handlers.begin(), this->handlers.end(), handler);
+        this->handlers.erase(it);
+    }
+}
+
+size_t MessageHandler::count_handlers() {
+    size_t count = 0;
+    {
+        std::lock_guard<std::mutex> lock(this->handlers_mutex);
+        count = this->handlers.size();
+    }
+    return count;
+}
+
+} // namespace Everest

--- a/lib/message_queue.cpp
+++ b/lib/message_queue.cpp
@@ -73,14 +73,16 @@ MessageHandler::MessageHandler() : running(true) {
                     // unpack call
                     if (handler_->name != data.at("name")) {
                         continue;
-                    } else if (data.at("type") == "call") {
+                    }
+                    if (data.at("type") == "call") {
                         handler(data.at("data"));
                     }
                 } else if (handler_->type == HandlerType::Result) {
                     // unpack result
                     if (handler_->name != data.at("name")) {
                         continue;
-                    } else if (data.at("type") == "result") {
+                    }
+                    if (data.at("type") == "result") {
                         // only deliver result to handler with matching id
                         if (handler_->id == data.at("data").at("id")) {
                             handler(data.at("data"));
@@ -90,9 +92,8 @@ MessageHandler::MessageHandler() : running(true) {
                     // unpack var
                     if (handler_->name != data.at("name")) {
                         continue;
-                    } else {
-                        handler(data.at("data"));
                     }
+                    handler(data.at("data"));
                 } else {
                     // external or unknown, no preprocessing
                     handler(data);

--- a/lib/message_queue.cpp
+++ b/lib/message_queue.cpp
@@ -117,7 +117,7 @@ void MessageHandler::stop() {
 void MessageHandler::add_handler(std::shared_ptr<TypedHandler> handler) {
     {
         std::lock_guard<std::mutex> lock(this->handlers_mutex);
-        this->handlers.push_back(handler);
+        this->handlers.insert(handler);
     }
 }
 

--- a/lib/message_queue.cpp
+++ b/lib/message_queue.cpp
@@ -10,7 +10,7 @@
 
 namespace Everest {
 
-Message::Message(std::string topic, std::string payload) : topic(topic), payload(payload) {
+Message::Message(const std::string& topic, const std::string& payload) : topic(topic), payload(payload) {
 }
 
 MessageQueue::MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback) :

--- a/lib/message_queue.cpp
+++ b/lib/message_queue.cpp
@@ -10,6 +10,9 @@
 
 namespace Everest {
 
+Message::Message(std::string topic, std::string payload) : topic(topic), payload(payload) {
+}
+
 MessageQueue::MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback) :
     message_callback(message_callback), running(true) {
     this->worker_thread = std::thread([this]() {

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -66,7 +66,7 @@ void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr
     mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers, qos);
 }
 
-void MQTTAbstraction::unregister_handler(const std::string& topic, const TypedToken& token) {
+void MQTTAbstraction::unregister_handler(const std::string& topic, const Token& token) {
     BOOST_LOG_FUNCTION();
     mqtt_abstraction.unregister_handler(topic, token);
 }

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -61,24 +61,12 @@ void MQTTAbstraction::mainloop() {
     mqtt_abstraction.mainloop();
 }
 
-Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler) {
+void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler,bool allow_multiple_handlers, QOS qos) {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.register_handler(topic, handler);
+    mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers, qos);
 }
 
-Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler,
-                                        bool allow_multiple_handlers) {
-    BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers);
-}
-
-Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers,
-                                        QOS qos) {
-    BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers, qos);
-}
-
-void MQTTAbstraction::unregister_handler(const std::string& topic, const Token& token) {
+void MQTTAbstraction::unregister_handler(const std::string& topic, const TypedToken& token) {
     BOOST_LOG_FUNCTION();
     mqtt_abstraction.unregister_handler(topic, token);
 }

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -26,14 +26,29 @@ void MQTTAbstraction::publish(const std::string& topic, const json& json) {
     mqtt_abstraction.publish(topic, json);
 }
 
+void MQTTAbstraction::publish(const std::string& topic, const json& json, QOS qos) {
+    BOOST_LOG_FUNCTION();
+    mqtt_abstraction.publish(topic, json, qos);
+}
+
 void MQTTAbstraction::publish(const std::string& topic, const std::string& data) {
     BOOST_LOG_FUNCTION();
     mqtt_abstraction.publish(topic, data);
 }
 
+void MQTTAbstraction::publish(const std::string& topic, const std::string& data, QOS qos) {
+    BOOST_LOG_FUNCTION();
+    mqtt_abstraction.publish(topic, data, qos);
+}
+
 void MQTTAbstraction::subscribe(const std::string& topic) {
     BOOST_LOG_FUNCTION();
     mqtt_abstraction.subscribe(topic);
+}
+
+void MQTTAbstraction::subscribe(const std::string& topic, QOS qos) {
+    BOOST_LOG_FUNCTION();
+    mqtt_abstraction.subscribe(topic, qos);
 }
 
 void MQTTAbstraction::unsubscribe(const std::string& topic) {
@@ -46,15 +61,21 @@ void MQTTAbstraction::mainloop() {
     mqtt_abstraction.mainloop();
 }
 
+Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler) {
+    BOOST_LOG_FUNCTION();
+    return mqtt_abstraction.register_handler(topic, handler);
+}
+
 Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler,
                                         bool allow_multiple_handlers) {
     BOOST_LOG_FUNCTION();
     return mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers);
 }
 
-Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler) {
+Token MQTTAbstraction::register_handler(const std::string& topic, const Handler& handler, bool allow_multiple_handlers,
+                                        QOS qos) {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.register_handler(topic, handler);
+    return mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers, qos);
 }
 
 void MQTTAbstraction::unregister_handler(const std::string& topic, const Token& token) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -45,7 +45,7 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::s
 bool MQTTAbstractionImpl::connect() {
     BOOST_LOG_FUNCTION();
 
-    EVLOG(info) << "Connecting to mqtt broker...";
+    EVLOG(info) << fmt::format("Connecting to MQTT broker: {}:{}", this->mqtt_server_address, this->mqtt_server_port);
 
     return connectBroker(this->mqtt_server_address.c_str(), this->mqtt_server_port.c_str());
 }

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -58,7 +58,7 @@ void MQTTAbstractionImpl::disconnect() {
 void MQTTAbstractionImpl::publish(const std::string& topic, const json& json) {
     BOOST_LOG_FUNCTION();
 
-    publish(topic, json, QOS::QOS0);
+    publish(topic, json, QOS::QOS2);
 }
 
 void MQTTAbstractionImpl::publish(const std::string& topic, const json& json, QOS qos) {
@@ -104,7 +104,7 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
 void MQTTAbstractionImpl::subscribe(const std::string& topic) {
     BOOST_LOG_FUNCTION();
 
-    subscribe(topic, QOS::QOS0);
+    subscribe(topic, QOS::QOS2);
 }
 
 void MQTTAbstractionImpl::subscribe(const std::string& topic, QOS qos) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -28,6 +28,7 @@ MessageWithQOS::MessageWithQOS(std::string topic, std::string payload, QOS qos) 
 }
 
 MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::string mqtt_server_port) :
+    message_queue(([this](std::shared_ptr<Message> message) { this->on_mqtt_message(message); })),
     mqtt_server_address(std::move(mqtt_server_address)),
     mqtt_server_port(std::move(mqtt_server_port)),
     mqtt_client{},
@@ -37,12 +38,9 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::s
 
     EVLOG(debug) << "Initializing MQTT abstraction layer...";
 
-    this->message_queue =
-        std::make_shared<MessageQueue>([this](std::shared_ptr<Message> message) { this->on_mqtt_message(message); });
-
     this->mqtt_is_connected = false;
 
-    signalReceived.connect(&MessageQueue::add, this->message_queue);
+    signalReceived.connect(&MessageQueue::add, &this->message_queue);
 }
 
 bool MQTTAbstractionImpl::connect() {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -302,7 +302,7 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
     EVLOG(debug) << fmt::format("#handler[{}] = {}", topic, this->message_handlers[topic]->count_handlers());
 }
 
-void MQTTAbstractionImpl::unregister_handler(const std::string& topic, const TypedToken& token) {
+void MQTTAbstractionImpl::unregister_handler(const std::string& topic, const Token& token) {
     BOOST_LOG_FUNCTION();
 
     EVLOG(debug) << fmt::format("Unregistering handler {} for {}", fmt::ptr(&token), topic);

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -24,7 +24,8 @@ sigslot::signal<std::shared_ptr<Message>> signalReceived;
 const auto mqtt_sync_sleep_milliseconds = 10;
 const auto mqtt_keep_alive = 400;
 
-MessageWithQOS::MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos) : Message(topic, payload), qos(qos) {
+MessageWithQOS::MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos) :
+    Message(topic, payload), qos(qos) {
 }
 
 MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::string mqtt_server_port) :

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -24,7 +24,7 @@ sigslot::signal<std::shared_ptr<Message>> signalReceived;
 const auto mqtt_sync_sleep_milliseconds = 10;
 const auto mqtt_keep_alive = 400;
 
-MessageWithQOS::MessageWithQOS(std::string topic, std::string payload, QOS qos) : Message(topic, payload), qos(qos) {
+MessageWithQOS::MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos) : Message(topic, payload), qos(qos) {
 }
 
 MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::string mqtt_server_port) :

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -100,7 +100,6 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
     }
 
     if (!this->mqtt_is_connected) {
-        EVLOG(critical) << "trying to publish before connected...";
         const std::lock_guard<std::mutex> lock(messages_before_connected_mutex);
         this->messages_before_connected.push_back(std::make_shared<MessageWithQOS>(topic, data, qos));
         return;

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -32,7 +32,7 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(std::string mqtt_server_address, std::s
     recvbuf{} {
     BOOST_LOG_FUNCTION();
 
-    EVLOG(debug) << "Initializing mqtt abstraction layer...";
+    EVLOG(debug) << "Initializing MQTT abstraction layer...";
 
     this->message_queue =
         std::make_shared<MessageQueue>([this](std::shared_ptr<Message> message) { this->on_mqtt_message(message); });
@@ -151,7 +151,7 @@ void MQTTAbstractionImpl::_mainloop() {
         while (this->mqtt_is_connected) {
             MQTTErrors error = mqtt_sync(&this->mqtt_client);
             if (error != MQTT_OK) {
-                EVLOG(error) << fmt::format("Error during mqtt sync: {}", mqtt_error_str(error));
+                EVLOG(error) << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
 
                 on_mqtt_disconnect();
 
@@ -160,11 +160,11 @@ void MQTTAbstractionImpl::_mainloop() {
             std::this_thread::sleep_for(std::chrono::milliseconds(mqtt_sync_sleep_milliseconds));
         }
     } catch (boost::exception& e) {
-        EVLOG(critical) << fmt::format("Caught mqtt mainloop boost::exception:\n{}",
+        EVLOG(critical) << fmt::format("Caught MQTT mainloop boost::exception:\n{}",
                                        boost::diagnostic_information(e, true));
         exit(1);
     } catch (std::exception& e) {
-        EVLOG(critical) << fmt::format("Caught mqtt mainloop std::exception:\n{}",
+        EVLOG(critical) << fmt::format("Caught MQTT mainloop std::exception:\n{}",
                                        boost::diagnostic_information(e, true));
         exit(1);
     }
@@ -210,11 +210,11 @@ void MQTTAbstractionImpl::on_mqtt_message(std::shared_ptr<Message> message) {
                 EverestInternalError(fmt::format("Internal error: topic '{}' should have a matching handler!", topic)));
         }
     } catch (boost::exception& e) {
-        EVLOG(critical) << fmt::format("Caught mqtt on_message boost::exception:\n{}",
+        EVLOG(critical) << fmt::format("Caught MQTT on_message boost::exception:\n{}",
                                        boost::diagnostic_information(e, true));
         exit(1);
     } catch (std::exception& e) {
-        EVLOG(critical) << fmt::format("Caught mqtt on_message std::exception:\n{}",
+        EVLOG(critical) << fmt::format("Caught MQTT on_message std::exception:\n{}",
                                        boost::diagnostic_information(e, true));
         exit(1);
     }
@@ -223,10 +223,10 @@ void MQTTAbstractionImpl::on_mqtt_message(std::shared_ptr<Message> message) {
 void MQTTAbstractionImpl::on_mqtt_connect() {
     BOOST_LOG_FUNCTION();
 
-    EVLOG(info) << "Connected to mqtt broker";
+    EVLOG(info) << "Connected to MQTT broker";
 
     // subscribe to all topics needed by currently registered handlers
-    EVLOG(info) << "Subscribing to needed mqtt topics...";
+    EVLOG(info) << "Subscribing to needed MQTT topics...";
     const std::lock_guard<std::mutex> lock(handlers_mutex);
     for (auto const& ha : this->message_handlers) {
         std::string topic = ha.first;
@@ -241,7 +241,7 @@ void MQTTAbstractionImpl::on_mqtt_connect() {
 void MQTTAbstractionImpl::on_mqtt_disconnect() {
     BOOST_LOG_FUNCTION();
 
-    EVLOG_AND_THROW(EverestInternalError("Lost connection to mqtt broker"));
+    EVLOG_AND_THROW(EverestInternalError("Lost connection to MQTT broker"));
 }
 
 Token MQTTAbstractionImpl::register_handler(const std::string& topic, const Handler& handler) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -457,12 +457,10 @@ void MQTTAbstractionImpl::publish_callback(void** /*unused*/, struct mqtt_respon
     // note that message.topic_name is NOT null-terminated
     // (here we'll change it to a std::string which will take care of this particular conversion)
 
-    Message msg =
-        Message(std::string(static_cast<const char*>(message.topic_name), message.topic_name_size),
-                std::string(static_cast<const char*>(message.application_message), message.application_message_size));
-
     // emit a copy of published results
-    signalReceived(std::make_shared<Message>(msg));
+    signalReceived(std::make_shared<Message>(
+        std::string(static_cast<const char*>(message.topic_name), message.topic_name_size),
+        std::string(static_cast<const char*>(message.application_message), message.application_message_size)));
 }
 
 } // namespace Everest

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -246,9 +246,7 @@ int main(int argc, char* argv[]) {
             lock.unlock();
         };
 
-        std::string module_id = config->printable_identifier(module_name);
-
-        std::string topic = fmt::format("everest/{}/ready", module_id);
+        std::string topic = fmt::format("{}/ready", config->mqtt_module_prefix(module_name));
 
         Token token = mqtt_abstraction.register_handler(topic, module_ready_handler);
         tokens.push_back(token);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
     std::vector<ModuleInfo> modules_to_start;
     std::map<std::string, bool> modules_ready;
     std::mutex modules_ready_mutex;
-    std::vector<Token> tokens;
+    std::vector<TypedToken> tokens;
 
     auto main_config = config->get_main_config();
     modules_to_start.reserve(main_config.size());
@@ -248,7 +248,9 @@ int main(int argc, char* argv[]) {
 
         std::string topic = fmt::format("{}/ready", config->mqtt_module_prefix(module_name));
 
-        Token token = mqtt_abstraction.register_handler(topic, module_ready_handler);
+        auto token = std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(module_ready_handler));
+
+        mqtt_abstraction.register_handler(topic, token, false, QOS::QOS2);
         tokens.push_back(token);
 
         if (std::any_of(standalone_modules.begin(), standalone_modules.end(),

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
     std::vector<ModuleInfo> modules_to_start;
     std::map<std::string, bool> modules_ready;
     std::mutex modules_ready_mutex;
-    std::vector<TypedToken> tokens;
+    std::vector<Token> tokens;
 
     auto main_config = config->get_main_config();
     modules_to_start.reserve(main_config.size());


### PR DESCRIPTION
- Support for MQTT Quality of Service
- Removal of now superfluous "ack" mechanism for commands
- Add message queues to make sure variables and commands are delivered in the order they were received via MQTT
- Additionally merge all command and variable topics of a (sub)module into a "cmd" and  "var" topic to make sure there are not raceconditions between topics
- Use of shorter MQTT prefixes consisting only of the (sub)module name
- To make sure no information about the loaded modules is lost publish metadata containing information about the module type and its provided interfaces via MQTT
- Cache messages that are published before a connection to the MQTT broker is established and send them then
- Various smaller cleanups
