### PR TITLE
Remove interface parent functionality

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -41,7 +41,6 @@ private:
     json manifests;
     json interfaces;
     json interface_definitions;
-    json base_interfaces;
     schemas _schemas;
 
     ///
@@ -56,7 +55,7 @@ private:
     /// would be overwritten
     ///
     /// \returns the resulting interface definiion
-    json resolve_interface(const std::string& intf_name, std::set<std::string>& seen_interfaces);
+    json resolve_interface(const std::string& intf_name);
 
     ///
     /// \brief extracts information about the provided module given via \p module_id from the config and manifest

--- a/schemas/interface.json
+++ b/schemas/interface.json
@@ -103,14 +103,6 @@
             "type": "string",
             "minLength": 2
         },
-        "parent": {
-            "description": "This defines the parent interface for inheritance",
-            "type": [
-                "string"
-            ],
-            "pattern": "^[a-zA-Z_][a-zA-Z0-9_.-]*$",
-            "minLength": 3
-        },
         "cmds": {
             "description": "This describes a list of commands for this unit having arguments and result declared as json schema",
             "type": "object",


### PR DESCRIPTION
- the functionality for "inheriting" all cmds and var from "parent"
  interfaces has been dropped due to lack of usage and unnecessary
  complexity that might show up in future features
- some similar functionality might be implemented using composition or
  concepts instead of inheritance

Signed-off-by: aw <aw@pionix.de>