### PR TITLE
Refactor process spawning / handling / termination

### DIFF
--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -310,7 +310,7 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
 
         ctx->js_module_ref = Napi::Persistent(module_this);
 
-        std::thread([]() { ctx->everest.mainloop(); }).detach();
+        ctx->everest.spawn_main_loop_thread();
 
         ctx->js_cb = std::make_unique<JsExecCtx>(env, callback_wrapper);
 

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -4,6 +4,7 @@
 #define FRAMEWORK_EVEREST_HPP
 
 #include <chrono>
+#include <future>
 #include <map>
 #include <set>
 #include <thread>
@@ -42,6 +43,7 @@ private:
     std::unique_ptr<std::function<void()>> on_ready;
     std::thread heartbeat_thread;
     std::string module_name;
+    std::future<void> main_loop_end{};
     json module_manifest;
     json module_classes;
 
@@ -114,9 +116,14 @@ public:
     void disconnect();
 
     ///
-    /// \brief Calls the mainloop method of the MQTTAbstraction to start the MQTT mainloop
+    /// \brief Initiates spawning the MQTT main loop thread
     ///
-    void mainloop();
+    void spawn_main_loop_thread();
+
+    ///
+    /// \brief Wait for main loop thread to end
+    ///
+    void wait_for_main_loop_end();
 
     ///
     /// \brief Ready Handler for local readyness (e.g. this module is now ready)

--- a/include/utils/message_queue.hpp
+++ b/include/utils/message_queue.hpp
@@ -32,7 +32,7 @@ class MessageQueue {
 private:
     std::thread worker_thread;
     std::queue<std::shared_ptr<Message>> message_queue;
-    std::mutex message_mutex;
+    std::mutex queue_ctrl_mutex;
     std::function<void(std::shared_ptr<Message> message)> message_callback;
     std::condition_variable cv;
     bool running;
@@ -40,6 +40,7 @@ private:
 public:
     /// \brief Creates a message queue with the provided \p message_callback
     explicit MessageQueue(const std::function<void(std::shared_ptr<Message> message)>& message_callback);
+    ~MessageQueue();
 
     /// \brief Adds a \p message to the message queue which will then be delivered to the message callback
     void add(std::shared_ptr<Message> message);
@@ -54,14 +55,17 @@ private:
     std::unordered_set<std::shared_ptr<TypedHandler>> handlers;
     std::thread handler_thread;
     std::queue<std::shared_ptr<json>> message_queue;
-    std::mutex message_mutex;
-    std::mutex handlers_mutex;
+    std::mutex handler_ctrl_mutex;
+    std::mutex handler_list_mutex;
     std::condition_variable cv;
     bool running;
 
 public:
     /// \brief Creates the message handler
     MessageHandler();
+
+    /// \brief Destructor
+    ~MessageHandler();
 
     /// \brief Adds a \p message to the message queue which will be delivered to the registered handlers
     void add(std::shared_ptr<json> message);

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -3,6 +3,8 @@
 #ifndef UTILS_MQTT_ABSTRACTION_HPP
 #define UTILS_MQTT_ABSTRACTION_HPP
 
+#include <future>
+
 #include <nlohmann/json.hpp>
 
 #include <utils/types.hpp>
@@ -59,12 +61,13 @@ public:
     void unsubscribe(const std::string& topic);
 
     ///
-    /// \copydoc MQTTAbstractionImpl::mainloop()
-    void mainloop();
+    /// \copydoc MQTTAbstractionImpl::spawn_main_loop_thread()
+    std::future<void> spawn_main_loop_thread();
 
     ///
     /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, std::shared_ptr<TypedHandler>, QOS)
-    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers, QOS qos);
+    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers,
+                          QOS qos);
 
     ///
     /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -4,6 +4,7 @@
 #define UTILS_MQTT_ABSTRACTION_IMPL_HPP
 
 #include <functional>
+#include <future>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -50,10 +51,10 @@ private:
     uint8_t recvbuf[MQTT_BUF_SIZE];
 
     MQTTAbstractionImpl(std::string mqtt_server_address, std::string mqtt_server_port);
+    ~MQTTAbstractionImpl();
 
     static int open_nb_socket(const char* addr, const char* port);
     bool connectBroker(const char* host, const char* port);
-    void _mainloop();
     void on_mqtt_message(std::shared_ptr<Message> message);
     void on_mqtt_connect();
     static void on_mqtt_disconnect();
@@ -96,8 +97,9 @@ public:
     void unsubscribe(const std::string& topic);
 
     ///
-    /// \brief starts the mqtt main loop in its own tread and immediately joins it, making this a blocking operation
-    void mainloop();
+    /// \brief Spawn a thread running the mqtt main loop
+    /// \returns a future, which will be fulfilled on thread termination
+    std::future<void> spawn_main_loop_thread();
 
     ///
     /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -45,10 +45,21 @@ Everest::Everest(std::string module_id, Config config, bool validate_data_with_s
     this->publish_metadata();
 }
 
-void Everest::mainloop() {
+void Everest::spawn_main_loop_thread() {
     BOOST_LOG_FUNCTION();
 
-    this->mqtt_abstraction.mainloop();
+    // FIXME (aw): check if mainloop has not been started yet
+    assert(!this->main_loop_end.valid());
+    this->main_loop_end = this->mqtt_abstraction.spawn_main_loop_thread();
+}
+
+void Everest::wait_for_main_loop_end() {
+    BOOST_LOG_FUNCTION();
+
+    // FIXME (aw): check if mainloop has been started, simple assert for now
+    assert(this->main_loop_end.valid());
+
+    this->main_loop_end.get();
 }
 
 void Everest::heartbeat() {

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <everest/logging.hpp>
 
 #include <utils/mqtt_abstraction.hpp>
@@ -56,9 +56,9 @@ void MQTTAbstraction::unsubscribe(const std::string& topic) {
     mqtt_abstraction.unsubscribe(topic);
 }
 
-void MQTTAbstraction::mainloop() {
+std::future<void> MQTTAbstraction::spawn_main_loop_thread() {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.mainloop();
+    return mqtt_abstraction.spawn_main_loop_thread();
 }
 
 void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler,bool allow_multiple_handlers, QOS qos) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
         auto module_init = boost::dll::import_alias<void(ModuleConfigs, ModuleInfo)>(path, "init");
         module_init(module_configs, module_info);
 
-        std::thread mainloop_thread = std::thread(&Everest::Everest::mainloop, &everest);
+        everest.spawn_main_loop_thread();
 
         auto module_ready = boost::dll::import_alias<void()>(path, "ready");
 
@@ -221,7 +221,7 @@ int main(int argc, char* argv[]) {
         // the module should now be ready
         everest.signal_ready();
 
-        mainloop_thread.join();
+        everest.wait_for_main_loop_end();
 
         EVLOG(info) << "Exiting...";
     } catch (boost::exception& e) {


### PR DESCRIPTION
- fork / exec flow has been prepared to also spawn other processes (not
  just modules)
- if in between fork and exec (exec including) something fails, this is
  messaged to the parent process (the manager) via a pipe and not by
  using the shared resources (like stdout etc.) from the parent process
  in order to not call any destructors twice.  Finally the "failed" child
  process exits via _exit()
- helper function arguments_to_exec_argv has been introduced to easily
  get the correct argv type for exec from a list of std::string arguments
- forked child processes will now terminate too, if the parent (the
  manager) exits
- for getting the exception handling to work in manager.cpp, some
  classes needed proper teardown (terminating threads)
  - MQTTAbstractionImpl
  - MessageQueue
  - MessageHandler
- furthermore, the functions called mainloop in MQTTAbstractionImpl have
  been replaced by spawn_main_loop_thread, which now creates directly a
  new thread and returns a future which gets resolved, when the thread
  ends

Signed-off-by: aw <aw@pionix.de>