### PR TITLE
Refactored tests and code coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,16 @@ if(BUILD_TESTING)
 
     setup_target_for_coverage_gcovr_html(
         NAME gcovr_coverage
-        EXECUTABLE test_config
-        DEPENDENCIES test_config everest
+        EXECUTABLE ctest --output-on-failure
+        EXCLUDE "${CMAKE_SOURCE_DIR}/tests" "${CMAKE_BINARY_DIR}"
+        DEPENDENCIES tests everest
     )
 
     setup_target_for_coverage_lcov(
         NAME lcov_coverage
-        EXECUTABLE test_config
-        DEPENDENCIES test_config everest
+        EXECUTABLE ctest --output-on-failure
+        EXCLUDE "${CMAKE_SOURCE_DIR}/tests" "${CMAKE_BINARY_DIR}"
+        DEPENDENCIES tests everest
     )
 else()
     message("Not running unit tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,16 @@
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
-add_executable(test_config test_config.cpp)
+add_executable(tests main.cpp test_config.cpp)
 
-target_link_libraries(test_config
+target_link_libraries(tests
     PRIVATE
         everest ${CMAKE_DL_LIBS}
         everest::log
         Catch2::Catch2
 )
 
-catch_discover_tests(test_config)
+catch_discover_tests(tests)
 
 configure_file(test_configs/valid_config.json ${CMAKE_CURRENT_BINARY_DIR}/valid/config.json COPYONLY)
 configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/valid/schemes/config.json COPYONLY)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <catch2/catch.hpp>
 
 #include <framework/everest.hpp>

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
 #include <framework/everest.hpp>


### PR DESCRIPTION
- catch2 tests are now split into one main and the specific test case
  compilation units
- code coverage now uses ctest as the executable and excludes the build
  and tests directories for coverage reports

Signed-off-by: aw <aw@pionix.de>