### PR TITLE
Added controller backend service

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,8 @@
 ---
+websocketpp:
+  git: https://github.com/zaphoyd/websocketpp.git
+  git_tag: 0.8.2
+  prevent_install: true
 nlohmann_json:
   git: https://github.com/nlohmann/json
   git_tag: v3.10.5

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -39,13 +39,17 @@ RuntimeSettings::RuntimeSettings(const po::variables_map& vm) : main_dir(vm["mai
 
     // make all paths canonical
     std::reference_wrapper<fs::path> list[] = {
-        main_dir, configs_dir, schemas_dir, modules_dir, interfaces_dir, logging_config, config_file,
+        main_dir, schemas_dir, modules_dir, interfaces_dir, logging_config, config_file,
     };
 
     for (auto ref_wrapped_item : list) {
         auto& item = ref_wrapped_item.get();
         item = fs::canonical(item);
     }
+
+    // FIXME (aw): we don't have a way yet, to specify to configs dir, so by default we're using the folder, which
+    // contains the config file
+    configs_dir = config_file.parent_path();
 }
 
 ModuleCallbacks::ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -79,7 +79,8 @@
                     },
                     "default": {}, // add empty config if not already present
                     "additionalProperties": false // don't allow arbitrary additional properties
-                }
+                },
+                "x-view-model": {}
             },
             "additionalProperties": false // don't allow arbitrary additional properties
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,12 @@
+add_subdirectory(controller)
+
 add_executable(manager manager.cpp)
 
 target_link_libraries(manager
     PRIVATE
         everest ${CMAKE_DL_LIBS}
         everest::log
+        $<TARGET_OBJECTS:controller-ipc>
         Boost::thread
         Boost::program_options
         fmt::fmt
@@ -13,5 +16,4 @@ target_link_libraries(manager
 # needs c++ 14
 target_compile_features(manager PRIVATE cxx_std_14)
 
-install(TARGETS manager
-        RUNTIME)
+install(TARGETS manager RUNTIME)

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_library(controller-ipc OBJECT ipc.cpp)
+
+target_link_libraries(controller-ipc
+    PUBLIC
+        nlohmann_json::nlohmann_json
+)
+
+find_package(Threads REQUIRED)
+find_package(Boost COMPONENTS filesystem REQUIRED)
+
+add_executable(controller 
+    controller.cpp
+    command_api.cpp
+    rpc.cpp
+    server.cpp
+    $<TARGET_OBJECTS:controller-ipc>
+)
+
+target_include_directories(controller PRIVATE
+    ${websocketpp_SOURCE_DIR}
+)
+
+target_link_libraries(controller PRIVATE
+    Threads::Threads
+    nlohmann_json::nlohmann_json
+    ${Boost_FILESYSTEM_LIBRARY}
+    fmt::fmt
+    everest::log
+)
+
+target_compile_features(controller PRIVATE cxx_std_14)
+
+install(TARGETS controller RUNTIME)

--- a/src/controller/command_api.cpp
+++ b/src/controller/command_api.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include "command_api.hpp"
+
+#include <fstream>
+
+#include "fmt/core.h"
+
+#include "rpc.hpp"
+
+using json = nlohmann::json;
+namespace fs = boost::filesystem;
+
+CommandApi::CommandApi(const Config& config, RPC& rpc) : config(config), rpc(rpc) {
+}
+
+nlohmann::json CommandApi::handle(const std::string& cmd, const json& params) {
+    // fmt::print("Handling command {}\n", cmd);
+
+    if (cmd == "get_modules") {
+        auto modules_list = json::object();
+
+        for (auto item : fs::directory_iterator(this->config.module_dir)) {
+            if (!fs::is_directory(item)) {
+                continue;
+            }
+            const auto module_path = item.path();
+            const auto module_name = module_path.filename().string();
+
+            // fetch the manifest
+            const auto manifest_path = module_path / "manifest.json";
+            if (!fs::is_regular_file(manifest_path)) {
+                continue;
+            }
+
+            modules_list[module_name] = json::parse(std::ifstream(manifest_path.string()));
+        }
+
+        return modules_list;
+    } else if (cmd == "get_configs") {
+        auto config_list = json::object();
+
+        for (auto item : fs::directory_iterator(this->config.config_dir)) {
+            if (!fs::is_regular_file(item)) {
+                continue;
+            }
+            if (item.path().extension() != std::string(".json")) {
+                continue;
+            }
+
+            const auto config_name = item.path().stem().string();
+
+            config_list[config_name] = json::parse(std::ifstream(item.path().string()));
+        }
+
+        return config_list;
+    } else if (cmd == "get_interfaces") {
+        auto interface_list = json::object();
+
+        for (auto item : fs::directory_iterator(this->config.interface_dir)) {
+
+            if (!fs::is_regular_file(item)) {
+                continue;
+            }
+            if (item.path().extension() != std::string(".json")) {
+                continue;
+            }
+
+            const auto interface_name = item.path().stem().string();
+
+            interface_list[interface_name] = json::parse(std::ifstream(item.path().string()));
+        }
+
+        return interface_list;
+    } else if (cmd == "save_config") {
+        // FIXME (aw): this is quite hacky
+        if (!params.contains("name") || !params.at("name").is_string()) {
+            throw CommandApiParamsError("The save_config needs a 'name' parameter for the config file of type string");
+        }
+
+        auto config_json = params.value("config", json::object());
+        const auto configs_path = fs::path(this->config.config_dir);
+        auto check_config_file_path = configs_path / fmt::format("_{}.json", params.at("name"));
+        std::ofstream(check_config_file_path.string()) << config_json.dump(2);
+
+        auto result = this->rpc.ipc_request("check_config", check_config_file_path.string(), false);
+
+        if (result.is_string()) {
+            fs::remove(check_config_file_path);
+            throw CommandApiParamsError(result);
+        }
+
+        fs::rename(check_config_file_path, configs_path / fmt::format("{}.json", params.at("name")));
+
+        return true;
+    } else if (cmd == "restart_modules") {
+        this->rpc.ipc_request("restart_modules", nullptr, true);
+
+        return nullptr;
+    }
+
+    throw CommandApiMethodNotFound(fmt::format("Command '{}' unknown", cmd));
+}

--- a/src/controller/command_api.hpp
+++ b/src/controller/command_api.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef CONTROLLER_COMMAND_API_HPP
+#define CONTROLLER_COMMAND_API_HPP
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+// forward declaration
+class RPC;
+
+class CommandApiParamsError : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+class CommandApiMethodNotFound : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+class CommandApi {
+public:
+    struct Config {
+        std::string module_dir;
+        std::string interface_dir;
+        std::string config_dir;
+    };
+
+    CommandApi(const Config& config, RPC& rpc);
+
+    nlohmann::json handle(const std::string& cmd, const nlohmann::json& params);
+
+private:
+    Config config;
+    RPC& rpc;
+};
+
+#endif // CONTROLLER_COMMAND_API_HPP

--- a/src/controller/controller.cpp
+++ b/src/controller/controller.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <thread>
+
+#include <boost/filesystem.hpp>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <everest/logging.hpp>
+
+#include "command_api.hpp"
+#include "ipc.hpp"
+#include "rpc.hpp"
+#include "server.hpp"
+
+using json = nlohmann::json;
+
+int main(int argc, char* argv[]) {
+    namespace fs = boost::filesystem;
+
+    if (strcmp(argv[0], MAGIC_CONTROLLER_ARG0)) {
+        fmt::print(stderr, "This binary does not yet support to be started manually\n");
+        return EXIT_FAILURE;
+    }
+
+    auto socket_fd = STDIN_FILENO;
+
+    const auto message = Everest::controller_ipc::receive_message(socket_fd);
+
+    if (message.status != Everest::controller_ipc::MESSAGE_RETURN_STATUS::OK) {
+        throw std::runtime_error("Controller process could not read initial config message");
+    }
+
+    // FIXME (aw): validation
+    const auto config_params = message.json.at("params");
+
+    const std::string module_dir = config_params.at("module_dir");
+    const std::string interface_dir = config_params.at("interface_dir");
+    const std::string config_dir = config_params.at("config_dir");
+    const std::string logging_config_file = config_params.at("logging_config_file");
+
+    // if (!fs::is_directory(module_dir) || !fs::is_directory(config_dir) || !fs::is_directory(interface_dir)) {
+    //     throw std::runtime_error("One or more of the passed directories are not valid");
+    // }
+
+    Everest::Logging::init(logging_config_file, "everest_ctrl");
+
+    EVLOG_info << "everest controller process started ...";
+
+    CommandApi::Config config{
+        module_dir,
+        interface_dir,
+        config_dir,
+    };
+
+    RPC rpc(socket_fd, config);
+    Server backend;
+
+    std::thread(&Server::run, &backend, [&rpc](const nlohmann::json& request) {
+        return rpc.handle_json_rpc(request);
+    }).detach();
+
+    while (true) {
+        rpc.run([&backend](const nlohmann::json& notification) { backend.push(notification); });
+    }
+
+    return 0;
+}

--- a/src/controller/ipc.cpp
+++ b/src/controller/ipc.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include "ipc.hpp"
+
+#include <errno.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+// FIXME (aw): this needs be done better!
+static char raw_message_buffer[16*1024];
+
+namespace Everest {
+namespace controller_ipc {
+
+void set_read_timeout(int fd, int timeout_in_ms) {
+
+    const int seconds = timeout_in_ms / 1000;
+    const int u_seconds = (timeout_in_ms - seconds * 1000) * 1000;
+
+    struct timeval socket_timeout {
+        seconds, u_seconds
+    };
+
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, static_cast<void*>(&socket_timeout), sizeof(socket_timeout));
+}
+
+void send_message(int fd, const nlohmann::json& msg) {
+    auto raw = nlohmann::json::to_bson(msg);
+    write(fd, raw.data(), raw.size());
+}
+
+// FIXME (aw): recv should be buffered and memory is not that costly here!
+Message receive_message(int fd) {
+    auto retval = read(fd, raw_message_buffer, sizeof(raw_message_buffer));
+
+    if (retval == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return {MESSAGE_RETURN_STATUS::TIMEOUT, nullptr};
+        }
+
+        return {MESSAGE_RETURN_STATUS::ERROR, {{"error", strerror(errno)}}};
+    }
+
+    const auto& msg_size = retval;
+
+    return {MESSAGE_RETURN_STATUS::OK, nlohmann::json::from_bson(raw_message_buffer, raw_message_buffer + msg_size)};
+}
+
+} // namespace controller
+} // namespace everest

--- a/src/controller/ipc.hpp
+++ b/src/controller/ipc.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef CONTROLLER_IPC_HPP
+#define CONTROLLER_IPC_HPP
+
+#include <nlohmann/json.hpp>
+
+#define MAGIC_CONTROLLER_ARG0 "MT.EVEREST"
+
+namespace Everest {
+namespace controller_ipc {
+
+enum class MESSAGE_RETURN_STATUS
+{
+    OK,
+    ERROR,
+    TIMEOUT,
+};
+
+struct Message {
+    Message(MESSAGE_RETURN_STATUS status, nlohmann::json json) : status(status), json(std::move(json)){};
+    const MESSAGE_RETURN_STATUS status;
+    const nlohmann::json json;
+};
+
+// FIXME (aw): add return value for failed set_timeout
+void set_read_timeout(int fd, int timeout_in_ms);
+
+// FIXME (aw): add return value for failed send
+void send_message(int fd, const nlohmann::json& msg);
+Message receive_message(int fd);
+
+} // namespace controller
+} // namespace everest
+
+#endif // CONTROLLER_IPC_HPP

--- a/src/controller/rpc.cpp
+++ b/src/controller/rpc.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include "rpc.hpp"
+
+#include "command_api.hpp"
+#include "ipc.hpp"
+
+enum class RPCRequestErrorCode
+{
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603
+};
+
+class RPCRequestError : public std::runtime_error {
+public:
+    RPCRequestError(RPCRequestErrorCode error_code, const std::string& message, const nlohmann::json& id) :
+        std::runtime_error(
+            "Error code: " + std::to_string(static_cast<std::underlying_type_t<RPCRequestErrorCode>>(error_code)) +
+            "\n" + message),
+        error_code(error_code),
+        message(message),
+        id(id) {
+    }
+
+    RPCRequestErrorCode get_error_code() const {
+        return error_code;
+    }
+
+    const std::string& get_message() const {
+        return this->message;
+    }
+
+    const nlohmann::json& get_id() const {
+        return this->id;
+    }
+
+private:
+    RPCRequestErrorCode error_code;
+    std::string message;
+    nlohmann::json id;
+};
+
+class RPCRequest {
+public:
+    RPCRequest(const std::string& request_string) {
+        const auto request = nlohmann::json::parse(request_string, nullptr, false, false);
+
+        if (request.is_discarded()) {
+            throw RPCRequestError(RPCRequestErrorCode::ParseError, "", nullptr);
+        }
+
+        this->id = request.value("id", nlohmann::json(nullptr));
+
+        if (!this->id.is_number() && !this->id.is_string() && !this->id.is_null()) {
+            throw RPCRequestError(RPCRequestErrorCode::InvalidRequest, "Invalid ID type", nullptr);
+        }
+
+        if (!request.contains("method") || !request.at("method").is_string()) {
+            throw RPCRequestError(RPCRequestErrorCode::InvalidRequest, "Missing 'method' key or invalid type",
+                                  this->id);
+        }
+
+        this->method = request.at("method");
+        this->params = request.value("params", nlohmann::json(nullptr));
+    }
+
+    bool is_notification() const {
+        return this->id.is_null();
+    }
+
+    std::string get_method() const {
+        return this->method;
+    }
+
+    const nlohmann::json& get_params() const {
+        return this->params;
+    }
+
+    const nlohmann::json& get_id() const {
+        return this->id;
+    }
+
+private:
+    nlohmann::json id;
+    std::string method;
+    nlohmann::json params;
+};
+
+RPC::RPC(int ipc_fd, const CommandApi::Config& config) : ipc_fd(ipc_fd) {
+    this->api = std::make_unique<CommandApi>(config, *this);
+}
+
+void RPC::run(const NotificationHandler& notification_handler) {
+    if (!notification_handler) {
+        throw std::runtime_error("Could not run the RPC loop with a null notification handler");
+    }
+
+    while (true) {
+        // polling on command api ..
+        auto msg = Everest::controller_ipc::receive_message(this->ipc_fd);
+
+        if (msg.status != Everest::controller_ipc::MESSAGE_RETURN_STATUS::OK) {
+            // FIXME (aw): proper error handling!
+            continue;
+        }
+
+        const auto& payload = msg.json;
+        if (!payload.contains("id")) {
+            // probably only a simple notification
+            this->notification_handler(payload);
+        }
+
+        // otherwise a result
+        const std::mt19937::result_type id = payload.at("id");
+
+        const std::lock_guard<std::mutex> lock(this->ipc_mutex);
+        auto call = this->ipc_calls.find(id);
+
+        if (call == this->ipc_calls.end()) {
+            // does not exists (anymore)
+            continue;
+        }
+
+        try {
+            call->second.set_value(payload.value("result", nlohmann::json(nullptr)));
+        } catch (const std::future_error& e) {
+            if (e.code() == std::future_errc::promise_already_satisfied) {
+                // this could, but should not happen
+                continue;
+            }
+            throw;
+        }
+    }
+}
+
+nlohmann::json RPC::handle_json_rpc(const std::string& payload) {
+    // FIXME (aw): these nested tries look like code smell
+    try {
+        const auto rpc_request = RPCRequest(payload);
+
+        try {
+            nlohmann::json reply{
+                {"id", rpc_request.get_id()},
+                {"result", this->api->handle(rpc_request.get_method(), rpc_request.get_params())},
+            };
+
+            if (rpc_request.is_notification()) {
+                return nullptr;
+            } else {
+                return reply;
+            }
+        } catch (const CommandApiParamsError& e) {
+            throw RPCRequestError(RPCRequestErrorCode::InvalidParams, e.what(), rpc_request.get_id());
+        } catch (const CommandApiMethodNotFound& e) {
+            throw RPCRequestError(RPCRequestErrorCode::MethodNotFound, e.what(), rpc_request.get_id());
+        } catch (const std::exception& e) {
+            throw RPCRequestError(RPCRequestErrorCode::InternalError, e.what(), rpc_request.get_id());
+        }
+    } catch (const RPCRequestError& e) {
+        const auto error_code = e.get_error_code();
+        const auto error_code_int = static_cast<std::underlying_type_t<RPCRequestErrorCode>>(error_code);
+        return {
+            {"error",
+             {
+                 {"code", error_code_int},
+                 {"message", e.get_message()},
+             }},
+            {"id", e.get_id()},
+        };
+    }
+}
+
+nlohmann::json RPC::ipc_request(const std::string& method, const nlohmann::json& params, bool only_notify) {
+    if (only_notify) {
+        Everest::controller_ipc::send_message(this->ipc_fd, {{"method", method}, {"params", params}});
+        return nullptr;
+    }
+
+    std::unique_lock<std::mutex> lock(this->ipc_mutex);
+    auto new_call = this->ipc_calls.emplace(this->rng(), std::promise<nlohmann::json>());
+    while (!new_call.second) {
+        new_call = this->ipc_calls.emplace(this->rng(), std::promise<nlohmann::json>());
+    }
+
+    auto id = new_call.first->first;
+    auto call_result_future = std::move(new_call.first->second.get_future());
+
+    lock.unlock();
+
+    Everest::controller_ipc::send_message(this->ipc_fd, {{"method", method}, {"params", params}, {"id", id}});
+
+    // FIXME (aw): timeout constant!
+    auto status = call_result_future.wait_for(std::chrono::milliseconds(500));
+
+    lock.lock();
+    this->ipc_calls.erase(new_call.first);
+    lock.unlock();
+
+    if (status == std::future_status::timeout) {
+        throw std::runtime_error("Promise timeout");
+    }
+
+    return call_result_future.get();
+}

--- a/src/controller/rpc.hpp
+++ b/src/controller/rpc.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef CONTROLLER_RPC_HPP
+#define CONTROLLER_RPC_HPP
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <unordered_map>
+
+#include <boost/filesystem.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include "command_api.hpp"
+
+class RPC {
+public:
+    using NotificationHandler = std::function<void(const nlohmann::json&)>;
+
+    RPC(int ipc_fd, const CommandApi::Config& config);
+
+    nlohmann::json handle_json_rpc(const std::string& request_string);
+    nlohmann::json ipc_request(const std::string& method, const nlohmann::json& params, bool only_notify);
+
+    void run(const NotificationHandler& handler);
+
+private:
+    int ipc_fd;
+    std::unique_ptr<CommandApi> api;
+    NotificationHandler notification_handler;
+
+    // FIXME (aw): what type of cafe?
+    std::mt19937 rng{0xcafe};
+    std::unordered_map<std::mt19937::result_type, std::promise<nlohmann::json>> ipc_calls{};
+    std::mutex ipc_mutex{};
+};
+
+#endif // CONTROLLER_RPC_HPP

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include "server.hpp"
+
+#include <fstream>
+#include <set>
+#include <sstream>
+
+#include <fmt/core.h>
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+
+#include <everest/logging.hpp>
+
+class Server::Impl {
+public:
+    using ConnectionHandle = websocketpp::connection_hdl;
+    using WSServer = websocketpp::server<websocketpp::config::asio>;
+    using MessagePtr = WSServer::message_ptr;
+
+    Impl() {
+        endpoint.init_asio();
+        endpoint.set_reuse_addr(true);
+        endpoint.set_http_handler([this](ConnectionHandle handle) { on_http(handle); });
+        endpoint.set_message_handler(
+            [this](ConnectionHandle handle, MessagePtr msg_ptr) { on_message(handle, msg_ptr); });
+        endpoint.set_open_handler([this](ConnectionHandle handle) { on_open(handle); });
+        endpoint.set_close_handler([this](ConnectionHandle handle) { on_close(handle); });
+        endpoint.clear_access_channels(websocketpp::log::alevel::all);
+    }
+
+    void run(const Server::IncomingMessageHandler& handler) {
+        if (!handler) {
+            throw std::runtime_error("Could not run the the server with a null incoming message handler");
+        }
+
+        this->message_in_handler = handler;
+        uint16_t port = 8849;
+        EVLOG_info << fmt::format("Running controller service on port {}\n", port);
+
+        endpoint.listen(port);
+        endpoint.start_accept();
+
+        try {
+            endpoint.run();
+        } catch (websocketpp::exception const& e) {
+            EVLOG_error << fmt::format("websocketpp exception: {}", e.what());
+        }
+    }
+
+    void push(const nlohmann::json& msg) {
+        for (auto& connection : connections) {
+            endpoint.send(connection, msg.dump(), websocketpp::frame::opcode::text);
+        }
+    }
+
+private:
+    using ConnectionList = std::set<ConnectionHandle, std::owner_less<ConnectionHandle>>;
+    using ConnectionPtr = WSServer::connection_ptr;
+
+    void on_message(ConnectionHandle handle, MessagePtr msg) {
+        const auto retval = this->message_in_handler(msg->get_payload());
+        if (!retval.is_null()) {
+            endpoint.send(handle, retval.dump(), websocketpp::frame::opcode::text);
+        }
+    }
+
+    void on_open(ConnectionHandle handle) {
+        connections.insert(handle);
+    }
+
+    void on_close(ConnectionHandle handle) {
+        connections.erase(handle);
+    }
+
+    // FIXME (aw): hack for getting correct content type
+    static void add_content_type(ConnectionPtr& conn, const std::string& filename) {
+        auto ends_with = [](const std::string& filename, const std::string& ending) -> bool {
+            if (ending.size() > filename.size()) {
+                return false;
+            }
+            return std::equal(filename.begin() + filename.size() - ending.size(), filename.end(), ending.begin());
+        };
+
+        if (ends_with(filename, ".js")) {
+            conn->append_header("Content-Type", "application/javascript; charset=utf-8");
+        }
+    }
+
+    void on_http(ConnectionHandle handle) {
+        auto connection = endpoint.get_con_from_hdl(handle);
+        auto resource = connection->get_resource();
+
+        if (resource == "/") {
+            resource = "index.html";
+        } else {
+            resource = resource.substr(1);
+        }
+
+        std::ifstream file;
+        std::stringstream response;
+
+        auto accept_header = connection->get_request_header("Accept-encoding");
+        if (accept_header.compare("gzip, deflate") == 0) {
+            // check if we have the file gzipped
+            auto gz_resource = resource + ".gz";
+            file.open(gz_resource.c_str(), std::ios::in);
+        }
+
+        if (file) {
+            response << file.rdbuf();
+            add_content_type(connection, resource);
+            connection->append_header("Content-Encoding", "gzip");
+            connection->set_body(response.str());
+            connection->set_status(websocketpp::http::status_code::ok);
+            return;
+        }
+
+        file.open(resource.c_str(), std::ios::in);
+        if (!file) {
+            connection->set_body(fmt::format("<!doctype html><html><head>"
+                                             "<title>Error 404 (Resource not found)</title><body>"
+                                             "<h1>Error 404</h1>"
+                                             "<p>The requested URL {} was not found on this server.</p>"
+                                             "</body></head></html>",
+                                             resource));
+            connection->set_status(websocketpp::http::status_code::not_found);
+            return;
+        }
+
+        response << file.rdbuf();
+        add_content_type(connection, resource);
+        connection->set_body(response.str());
+        connection->set_status(websocketpp::http::status_code::ok);
+    }
+
+    IncomingMessageHandler message_in_handler;
+
+    WSServer endpoint;
+    ConnectionList connections;
+
+    WSServer::timer_ptr timer;
+};
+
+Server::Server() : pimpl(std::make_unique<Impl>()) {
+}
+
+Server::~Server() = default;
+
+void Server::run(const IncomingMessageHandler& handler) {
+    pimpl->run(handler);
+}
+
+void Server::push(const nlohmann::json& msg) {
+    pimpl->push(msg);
+}

--- a/src/controller/server.hpp
+++ b/src/controller/server.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef CONTROLLER_SERVER_HPP
+#define CONTROLLER_SERVER_HPP
+
+#include <memory>
+#include <functional>
+
+#include <nlohmann/json.hpp>
+
+#include "command_api.hpp"
+
+
+class Server {
+public:
+    using IncomingMessageHandler = std::function<nlohmann::json(const nlohmann::json&)>;
+    Server();
+    ~Server();
+    void run(const IncomingMessageHandler& handler);
+    void push(const nlohmann::json& msg);
+
+private:
+    class Impl; // forward declaration
+    std::unique_ptr<Impl> pimpl;
+};
+
+#endif // CONTROLLER_SERVER_HPP

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/prctl.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -26,12 +27,15 @@
 #include <utils/config.hpp>
 #include <utils/mqtt_abstraction.hpp>
 
+#include "controller/ipc.hpp"
+
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 using namespace Everest;
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
+const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
 
 class SubprocessHandle {
 public:
@@ -74,6 +78,31 @@ private:
     pid_t pid{};
 
     friend SubprocessHandle create_subprocess(bool set_pdeathsig);
+};
+
+class ControllerHandle {
+public:
+    ControllerHandle(pid_t pid, int socket_fd) : pid(pid), socket_fd(socket_fd) {
+        // we do "non-blocking" read
+        controller_ipc::set_read_timeout(socket_fd, CONTROLLER_IPC_READ_TIMEOUT_MS);
+    }
+
+    void send_message(const nlohmann::json& msg) {
+        controller_ipc::send_message(socket_fd, msg);
+    }
+
+    controller_ipc::Message receive_message() {
+        return controller_ipc::receive_message(socket_fd);
+    }
+
+    void shutdown() {
+        // FIXME (aw): tbd
+    }
+
+    const pid_t pid;
+
+private:
+    const int socket_fd;
 };
 
 SubprocessHandle create_subprocess(bool set_pdeathsig = true) {
@@ -216,9 +245,9 @@ static SubprocessHandle exec_javascript_module(const ModuleStartInfo& module_inf
     return handle;
 }
 
-static const std::map<pid_t, std::string> start_modules(const std::vector<ModuleStartInfo>& modules,
-                                                        const RuntimeSettings& rs) {
-    std::map<pid_t, std::string> children;
+static std::map<pid_t, std::string> spawn_modules(const std::vector<ModuleStartInfo>& modules,
+                                                  const RuntimeSettings& rs) {
+    std::map<pid_t, std::string> started_modules;
     for (const auto& module : modules) {
 
         auto handle = [&module, &rs]() -> SubprocessHandle {
@@ -237,18 +266,185 @@ static const std::map<pid_t, std::string> start_modules(const std::vector<Module
         // we can only come here, if we're the parent!
         auto child_pid = handle.check_child_executed();
 
-        EVLOG_verbose << fmt::format("Forked module {} with pid: {}", module.name, child_pid);
-        children[child_pid] = module.name;
+        EVLOG_debug << fmt::format("Forked module {} with pid: {}", module.name, child_pid);
+        started_modules[child_pid] = module.name;
     }
 
-    return children;
+    return started_modules;
+}
+
+struct ModuleReadyInfo {
+    bool ready;
+    std::shared_ptr<TypedHandler> token;
+};
+
+// FIXME (aw): these are globals here, because they are used in the ready callback handlers
+std::map<std::string, ModuleReadyInfo> modules_ready;
+std::mutex modules_ready_mutex;
+
+static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstraction& mqtt_abstraction,
+                                                  const std::vector<std::string>& ignored_modules,
+                                                  const std::vector<std::string>& standalone_modules,
+                                                  const RuntimeSettings& rs) {
+
+    std::vector<ModuleStartInfo> modules_to_spawn;
+
+    auto main_config = config.get_main_config();
+    modules_to_spawn.reserve(main_config.size());
+
+    for (const auto& module : main_config.items()) {
+        std::string module_name = module.key();
+        if (std::any_of(ignored_modules.begin(), ignored_modules.end(),
+                        [module_name](const auto& element) { return element == module_name; })) {
+            EVLOG_info << fmt::format("Ignoring module: {}", module_name);
+            continue;
+        }
+        std::string module_type = main_config[module_name]["module"];
+        // FIXME (aw): implicitely adding ModuleReadyInfo and setting its ready member
+        auto module_it = modules_ready.emplace(module_name, ModuleReadyInfo{false, nullptr}).first;
+
+        Handler module_ready_handler = [module_name, &mqtt_abstraction](nlohmann::json json) {
+            EVLOG_debug << fmt::format("received module ready signal for module: {}({})", module_name, json.dump());
+            std::unique_lock<std::mutex> lock(modules_ready_mutex);
+            // FIXME (aw): here are race conditions, if the ready handler gets called while modules are shut down!
+            modules_ready.at(module_name).ready = json.get<bool>();
+            for (const auto& mod : modules_ready) {
+                std::string text_ready =
+                    fmt::format((mod.second.ready) ? TERMINAL_STYLE_OK : TERMINAL_STYLE_ERROR, "ready");
+                EVLOG_debug << fmt::format("  {}: {}", mod.first, text_ready);
+            }
+            if (std::all_of(modules_ready.begin(), modules_ready.end(),
+                            [](const auto& element) { return element.second.ready; })) {
+                EVLOG_info << "all modules are ready";
+                mqtt_abstraction.publish("everest/ready", nlohmann::json(true));
+            }
+        };
+
+        std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
+
+        module_it->second.token =
+            std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(module_ready_handler));
+
+        mqtt_abstraction.register_handler(topic, module_it->second.token, false, QOS::QOS2);
+
+        if (std::any_of(standalone_modules.begin(), standalone_modules.end(),
+                        [module_name](const auto& element) { return element == module_name; })) {
+            EVLOG_info << fmt::format("Not starting standalone module: {}", module_name);
+            continue;
+        }
+
+        std::string binary_filename = fmt::format("{}", module_type);
+        std::string javascript_library_filename = "index.js";
+        boost::filesystem::path module_path = rs.modules_dir / module_type;
+        const auto printable_module_name = config.printable_identifier(module_name);
+        boost::filesystem::path binary_path = module_path / binary_filename;
+        boost::filesystem::path javascript_library_path = module_path / javascript_library_filename;
+
+        if (boost::filesystem::exists(binary_path)) {
+            EVLOG_debug << fmt::format("module: {} ({}) provided as binary", module_name, module_type);
+            modules_to_spawn.emplace_back(module_name, printable_module_name, ModuleStartInfo::Language::cpp,
+                                          binary_path);
+        } else if (boost::filesystem::exists(javascript_library_path)) {
+            EVLOG_debug << fmt::format("module: {} ({}) provided as javascript library", module_name, module_type);
+            modules_to_spawn.emplace_back(module_name, printable_module_name, ModuleStartInfo::Language::javascript,
+                                          boost::filesystem::canonical(javascript_library_path));
+        } else {
+            throw std::runtime_error(fmt::format("module: {} ({}) cannot be loaded because no C++ or JavaScript "
+                                                 "library has been found\n"
+                                                 "  checked paths:\n"
+                                                 "    cpp: {}\n"
+                                                 "    js:  {}\n",
+                                                 module_name, module_type, binary_path.string(),
+                                                 javascript_library_path.string()));
+        }
+    }
+
+    return spawn_modules(modules_to_spawn, rs);
+}
+
+static void shutdown_modules(const std::map<pid_t, std::string>& modules, Config& config,
+                             MQTTAbstraction& mqtt_abstraction) {
+
+    {
+        const std::lock_guard<std::mutex> lck(modules_ready_mutex);
+
+        for (const auto& module : modules_ready) {
+            const auto& ready_info = module.second;
+            const auto& module_name = module.first;
+            const std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
+            mqtt_abstraction.unregister_handler(topic, ready_info.token);
+        }
+
+        modules_ready.clear();
+    }
+
+    for (const auto& child : modules) {
+        auto retval = kill(child.first, SIGTERM);
+        // FIXME (aw): supply errno strings
+        if (retval != 0) {
+            EVLOG_critical << fmt::format("SIGTERM of child: {} (pid: {}) {}: {}. Escalating to SIGKILL", child.second,
+                                          child.first, fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
+            retval = kill(child.first, SIGKILL);
+            if (retval != 0) {
+                EVLOG_critical << fmt::format("SIGKILL of child: {} (pid: {}) {}: {}.", child.second, child.first,
+                                              fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
+            } else {
+                EVLOG_info << fmt::format("SIGKILL of child: {} (pid: {}) {}.", child.second, child.first,
+                                          fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+            }
+        } else {
+            EVLOG_info << fmt::format("SIGTERM of child: {} (pid: {}) {}.", child.second, child.first,
+                                      fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+        }
+    }
+}
+
+static ControllerHandle start_controller(const RuntimeSettings& rs) {
+    int socket_pair[2];
+
+    // FIXME (aw): destroy this socketpair somewhere
+    auto retval = socketpair(AF_UNIX, SOCK_DGRAM, 0, socket_pair);
+    const int manager_socket = socket_pair[0];
+    const int controller_socket = socket_pair[1];
+
+    auto handle = create_subprocess();
+
+    auto controller_binary = rs.main_dir / "bin/controller";
+
+    if (handle.is_child()) {
+        close(manager_socket);
+        dup2(controller_socket, STDIN_FILENO);
+        close(controller_socket);
+
+        execl(controller_binary.c_str(), MAGIC_CONTROLLER_ARG0, NULL);
+
+        // exec failed
+        handle.send_error_and_exit(
+            fmt::format("Syscall to execl() with \"{} {}\" failed ({})", controller_binary.string(), strerror(errno)));
+    }
+
+    close(controller_socket);
+
+    // send initial config to controller
+    controller_ipc::send_message(manager_socket, {
+                                                     {"method", "boot"},
+                                                     {"params",
+                                                      {
+                                                          {"module_dir", rs.modules_dir.string()},
+                                                          {"interface_dir", rs.interfaces_dir.string()},
+                                                          {"config_dir", rs.configs_dir.string()},
+                                                          {"logging_config_file", rs.logging_config.string()},
+                                                      }},
+                                                 });
+
+    return {handle.check_child_executed(), manager_socket};
 }
 
 int boot(const po::variables_map& vm) {
     bool check = (vm.count("check") != 0);
     RuntimeSettings rs(vm);
 
-    ::Everest::Logging::init(rs.logging_config.string());
+    Logging::init(rs.logging_config.string());
 
     EVLOG_info << "8< 8< 8< ------------------------------------------------------------------------------ 8< 8< 8<";
     EVLOG_info << "EVerest manager starting using " << rs.config_file.string();
@@ -261,7 +457,7 @@ int boot(const po::variables_map& vm) {
         boost::filesystem::path dumpmanifests_path = boost::filesystem::path(vm["dumpmanifests"].as<std::string>());
         EVLOG_debug << fmt::format("Dumping all known validated manifests into '{}'", dumpmanifests_path.string());
 
-        auto manifests = ::Everest::Config::load_all_manifests(rs.modules_dir.string(), rs.schemas_dir.string());
+        auto manifests = Config::load_all_manifests(rs.modules_dir.string(), rs.schemas_dir.string());
 
         for (const auto& module : manifests.items()) {
             std::string filename = module.key() + ".json";
@@ -274,12 +470,12 @@ int boot(const po::variables_map& vm) {
         return EXIT_SUCCESS;
     }
 
-    ::Everest::Config* config = nullptr;
+    std::unique_ptr<Config> config;
     try {
         // FIXME (aw): we should also use boost::filesystem::path here as argument types
-        config = new ::Everest::Config(rs.schemas_dir.string(), rs.config_file.string(), rs.modules_dir.string(),
-                                       rs.interfaces_dir.string());
-    } catch (::Everest::EverestInternalError& e) {
+        config = std::make_unique<Config>(rs.schemas_dir.string(), rs.config_file.string(),
+                                                   rs.modules_dir.string(), rs.interfaces_dir.string());
+    } catch (EverestInternalError& e) {
         EVLOG_error << fmt::format("Failed to load and validate config!\n{}", boost::diagnostic_information(e, true));
         return EXIT_FAILURE;
     } catch (boost::exception& e) {
@@ -342,8 +538,8 @@ int boot(const po::variables_map& vm) {
         mqtt_server_port = "1883";
     }
 
-    ::Everest::MQTTAbstraction& mqtt_abstraction =
-        ::Everest::MQTTAbstraction::get_instance(mqtt_server_address, mqtt_server_port);
+    MQTTAbstraction& mqtt_abstraction =
+        MQTTAbstraction::get_instance(mqtt_server_address, mqtt_server_port);
     if (!mqtt_abstraction.connect()) {
         EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", mqtt_server_address, mqtt_server_port);
         return EXIT_FAILURE;
@@ -351,126 +547,85 @@ int boot(const po::variables_map& vm) {
 
     mqtt_abstraction.spawn_main_loop_thread();
 
-    std::vector<ModuleStartInfo> modules_to_start;
-    std::map<std::string, bool> modules_ready;
-    std::mutex modules_ready_mutex;
-    std::vector<Token> tokens;
+    auto controller_handle = start_controller(rs);
+    auto module_handles = start_modules(*config, mqtt_abstraction, ignored_modules, standalone_modules, rs);
+    bool modules_started = true;
+    bool restart_modules = false;
 
-    auto main_config = config->get_main_config();
-    modules_to_start.reserve(main_config.size());
+    int wstatus;
 
-    for (const auto& module : main_config.items()) {
-        std::string module_name = module.key();
-        if (std::any_of(ignored_modules.begin(), ignored_modules.end(),
-                        [module_name](const auto& element) { return element == module_name; })) {
-            EVLOG_info << fmt::format("Ignoring module: {}", module_name);
-            continue;
-        }
-        std::string module_type = main_config[module_name]["module"];
-        modules_ready[module_name] = false;
+    while (true) {
+        // check if anyone died
+        auto pid = waitpid(-1, &wstatus, WNOHANG);
 
-        Handler module_ready_handler = [module_name, &modules_ready, &modules_ready_mutex,
-                                        &mqtt_abstraction](nlohmann::json json) {
-            EVLOG_verbose << fmt::format("received module ready signal for module: {}({})", module_name, json.dump());
-            std::unique_lock<std::mutex> lock(modules_ready_mutex);
-            modules_ready[module_name] = json.get<bool>();
-            for (const auto& mod : modules_ready) {
-                std::string text_ready = fmt::format((mod.second) ? TERMINAL_STYLE_OK : TERMINAL_STYLE_ERROR, "ready");
-                EVLOG_verbose << fmt::format("  {}: {}", mod.first, text_ready);
-            }
-            if (std::all_of(modules_ready.begin(), modules_ready.end(),
-                            [](const auto& element) { return element.second; })) {
-                EVLOG_info << ">>> \033[1;32mAll modules are initialized. EVerest up and running\033[1;0m <<<";
-                mqtt_abstraction.publish("everest/ready", nlohmann::json(true));
-            }
-            // FIXME (aw): this unlock shouldn't be necessary because lock will get destroyed here anyway
-            lock.unlock();
-        };
-
-        std::string topic = fmt::format("{}/ready", config->mqtt_module_prefix(module_name));
-
-        auto token =
-            std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(module_ready_handler));
-
-        mqtt_abstraction.register_handler(topic, token, false, QOS::QOS2);
-        tokens.push_back(token);
-
-        if (std::any_of(standalone_modules.begin(), standalone_modules.end(),
-                        [module_name](const auto& element) { return element == module_name; })) {
-            EVLOG_info << fmt::format("Not starting standalone module: {}", module_name);
-            continue;
-        }
-
-        std::string binary_filename = fmt::format("{}", module_type);
-        std::string javascript_library_filename = "index.js";
-        boost::filesystem::path module_path = rs.modules_dir / module_type;
-        const auto printable_module_name = config->printable_identifier(module_name);
-        boost::filesystem::path binary_path = module_path / binary_filename;
-        boost::filesystem::path javascript_library_path = module_path / javascript_library_filename;
-
-        if (boost::filesystem::exists(binary_path)) {
-            EVLOG_verbose << fmt::format("module: {} ({}) provided as binary", module_name, module_type);
-            modules_to_start.emplace_back(module_name, printable_module_name, ModuleStartInfo::Language::cpp,
-                                          binary_path);
-        } else if (boost::filesystem::exists(javascript_library_path)) {
-            EVLOG_verbose << fmt::format("module: {} ({}) provided as javascript library", module_name, module_type);
-            modules_to_start.emplace_back(module_name, printable_module_name, ModuleStartInfo::Language::javascript,
-                                          boost::filesystem::canonical(javascript_library_path));
+        if (pid == 0) {
+            // nothing new from our child process
+        } else if (pid == -1) {
+            throw std::runtime_error(fmt::format("Syscall to waitpid() failed ({})", strerror(errno)));
         } else {
-            EVLOG_error << fmt::format(
-                "module: {} ({}) cannot be loaded because no C++ or JavaScript library has been found", module_name,
-                module_type);
-            EVLOG_error << fmt::format("  checked paths:");
-            EVLOG_error << fmt::format("    cpp: {}", binary_path.string());
-            EVLOG_error << fmt::format("    js:  {}", javascript_library_path.string());
-
-            return EXIT_FAILURE;
-        }
-    }
-
-    const auto children = start_modules(modules_to_start, rs);
-
-    int status = 0;
-    bool running = true;
-    while (running) {
-        pid_t child_pid = waitpid(-1, &status, 0);
-        std::string child_name = "manager";
-        if (child_pid != -1 && children.count(child_pid) != 0) {
-            child_name = children.at(child_pid);
-        }
-        EVLOG_critical << fmt::format("Something happened to child: {} (pid: {}). Status: {}. EVerest exiting...",
-                                      child_name, child_pid, status);
-        running = false;
-        for (const auto& child : children) {
-            if (child.first == -1) {
-                EVLOG_error << "Child with pid -1 in list of children, this cannot be correct and won't be "
-                               "terminated.";
-                continue;
+            // one of our children exited (first check controller, then modules)
+            if (pid == controller_handle.pid) {
+                // FIXME (aw): what to do, if the controller exited? Restart it?
+                throw std::runtime_error("The controller process exited.");
             }
 
-            // don't try to kill the child that is already dead
-            if (child.first == child_pid)
-                continue;
+            auto module_iter = module_handles.find(pid);
+            if (module_iter == module_handles.end()) {
+                throw std::runtime_error(fmt::format("Unkown child width pid ({}) died.", pid));
+            }
 
-            int result = kill(child.first, SIGTERM);
-            if (result != 0) {
-                EVLOG_critical << fmt::format("SIGTERM of child: {} (pid: {}) {}: {}. Escalating to SIGKILL",
-                                              child.second, child.first, fmt::format(TERMINAL_STYLE_ERROR, "failed"),
-                                              result);
-                result = kill(child.first, SIGKILL);
-                if (result != 0) {
-                    EVLOG_critical << fmt::format("SIGKILL of child: {} (pid: {}) {}: {}.", child.second, child.first,
-                                                  fmt::format(TERMINAL_STYLE_ERROR, "failed"), result);
-                } else {
-                    EVLOG_info << fmt::format("SIGKILL of child: {} (pid: {}) {}.", child.second, child.first,
-                                              fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+            const auto module_name = module_iter->second;
+            module_handles.erase(module_iter);
+            // one of our modules died -> kill 'em all
+            if (modules_started) {
+                EVLOG_critical << fmt::format("Module {} (pid: {}) exited with status: {}. Terminating all modules.",
+                                              module_name, pid, wstatus);
+                shutdown_modules(module_handles, *config, mqtt_abstraction);
+                modules_started = false;
+            } else {
+                EVLOG_info << fmt::format("Module {} (pid: {}) exited with status: {}.", module_name, pid, wstatus);
+            }
+        }
+
+        if (module_handles.size() == 0 && restart_modules) {
+            module_handles = start_modules(*config, mqtt_abstraction, ignored_modules, standalone_modules, rs);
+            restart_modules = false;
+            modules_started = true;
+        }
+
+        // check for news from the controller
+        auto msg = controller_handle.receive_message();
+        if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::OK) {
+            // FIXME (aw): implement all possible messages here, for now just log them
+            const auto& payload = msg.json;
+            if (payload.at("method") == "restart_modules") {
+                shutdown_modules(module_handles, *config, mqtt_abstraction);
+                config = std::make_unique<Config>(rs.schemas_dir.string(), rs.config_file.string(),
+                                                           rs.modules_dir.string(), rs.interfaces_dir.string());
+                modules_started = false;
+                restart_modules = true;
+            } else if (payload.at("method") == "check_config") {
+                const std::string check_config_file_path = payload.at("params");
+
+                try {
+                    // check the config
+                    Config(rs.schemas_dir.string(), check_config_file_path, rs.modules_dir.string(),
+                                    rs.interfaces_dir.string());
+                    controller_handle.send_message({{"id", payload.at("id")}});
+                } catch (const std::exception& e) {
+                    controller_handle.send_message({{"result", e.what()}, {"id", payload.at("id")}});
                 }
             } else {
-                EVLOG_debug << fmt::format("SIGTERM of child: {} (pid: {}) {}.", child.second, child.first,
-                                           fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+                // unknown payload
+                EVLOG_error << fmt::format("Received unkown command via controller ipc:\n{}\n... ignoring",
+                                           payload.dump(DUMP_INDENT));
             }
+        } else if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::ERROR) {
+            fmt::print("Error in IPC communication with controller: {}\nExiting\n", msg.json.at("error").dump(2));
+            return EXIT_FAILURE;
+        } else {
+            // TIMEOUT fall-through
         }
-        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
- the controller backend service gets spawned by the manager and talks
  to the manager via IPC (udp file socket)
- it can issue various commands to the manager, like restarting all
  modules or request config file checks
- furthermore the controller backend service can talk via JSON RPC to a
  frontend client through a websocket on port 8849, there is can serve
  config files, manifests and other information
- some refactoring regarding starting and handling the modules has been
  done

Signed-off-by: aw <aw@pionix.de>