### PR TITLE
Let controller bind to localhost

### DIFF
--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -39,7 +39,7 @@ public:
         uint16_t port = 8849;
         EVLOG_info << fmt::format("Running controller service on port {}\n", port);
 
-        endpoint.listen(port);
+        endpoint.listen("localhost", std::to_string(port));
         endpoint.start_accept();
 
         try {


### PR DESCRIPTION
- by default, the websocket listen function doesn't seem to always use the localhost, which leads to bind errors in some situations

Signed-off-by: aw <aw@pionix.de>