### PR TITLE
Fixing tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ if(NOT DISABLE_EDM)
         EXPORT nlohmann_json_schema_validatorTargets
     )
 
+    # FIXME (aw): add catch2's cmake folder
+    list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/contrib")
 else()
     find_package(date REQUIRED)
     find_package(nlohmann_json REQUIRED)
@@ -50,6 +52,10 @@ else()
     find_package(websocketpp REQUIRED)
     find_package(fmt REQUIRED)
     find_package(everest-log REQUIRED)
+
+    if (BUILD_TESTING)
+        find_package(Catch2 REQUIRED)
+    endif()
 
     include(find-mqttc)
 endif()
@@ -95,8 +101,6 @@ endif ()
 # testing
 # FIXME (aw): move testing logic into tests/CMakeLists.txt
 if(BUILD_TESTING)
-    find_package(Catch2 REQUIRED)
-
     include(CTest)
     set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -16,8 +16,7 @@ namespace Everest {
 
 class ConfigParseException : public std::exception {
 public:
-    enum ParseErrorType
-    {
+    enum ParseErrorType {
         NOT_DEFINED,
         MISSING_ENTRY,
         SCHEMA
@@ -103,7 +102,8 @@ static json parse_config_map(const json& config_map_schema, const json& config_m
     return parsed_config_map;
 }
 
-Config::Config(std::string schemas_dir, std::string config_file, std::string modules_dir, std::string interfaces_dir, std::string types_dir) {
+Config::Config(std::string schemas_dir, std::string config_file, std::string modules_dir, std::string interfaces_dir,
+               std::string types_dir) {
     BOOST_LOG_FUNCTION();
 
     this->schemas_dir = schemas_dir;
@@ -161,8 +161,7 @@ Config::Config(std::string schemas_dir, std::string config_file, std::string mod
 
     // load type files
     auto types_path = fs::path(this->types_dir);
-    for (auto const& types_entry : fs::recursive_directory_iterator(types_path))
-    {
+    for (auto const& types_entry : fs::recursive_directory_iterator(types_path)) {
         auto const& type_file_path = types_entry.path();
         if (fs::is_regular_file(type_file_path) && type_file_path.extension() == ".json") {
             auto type_path = std::string("/") + fs::relative(type_file_path, types_path).stem().string();
@@ -211,7 +210,8 @@ Config::Config(std::string schemas_dir, std::string config_file, std::string mod
                 this->manifests[module_name] = this->manifests[module_name].patch(patch);
             }
         } catch (const std::exception& e) {
-            EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse manifest file {}: {}", fs::canonical(manifest_path).string(), e.what())));
+            EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse manifest file {}: {}",
+                                                           fs::weakly_canonical(manifest_path).string(), e.what())));
         }
 
         // validate user-defined default values for the config meta-schemas
@@ -364,7 +364,8 @@ json Config::load_interface_file(const std::string& intf_name) {
 
         return interface_json;
     } catch (const std::exception& e) {
-        EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse interface file {}: {}", fs::canonical(intf_path).string(), e.what())));
+        EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse interface file {}: {}",
+                                                       fs::weakly_canonical(intf_path).string(), e.what())));
     }
 }
 
@@ -611,7 +612,7 @@ void Config::format_checker(const std::string& format, const std::string& value)
             EVTHROW(std::invalid_argument("URI does not contain :// - invalid"));
         }
     } else if (format == "uri-reference") {
-        if(!std::regex_match(value, type_uri_regex)) {
+        if (!std::regex_match(value, type_uri_regex)) {
             EVTHROW(std::invalid_argument("Type URI is malformed."));
         }
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,64 +1,43 @@
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
 add_executable(tests main.cpp test_config.cpp)
 
 target_link_libraries(tests
     PRIVATE
-        everest ${CMAKE_DL_LIBS}
+        everest::framework
         everest::log
         Catch2::Catch2
 )
 
 catch_discover_tests(tests)
 
-configure_file(test_configs/valid_config.json ${CMAKE_CURRENT_BINARY_DIR}/valid/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/valid/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/valid/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/valid/schemes/interface.json COPYONLY)
+# NOTE: using configure_file() here, because file(COPY) can't rename
 
-# missing config.json
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/missing_config/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/missing_config/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/missing_config/schemes/interface.json COPYONLY)
+# valid config.json
+configure_file(test_configs/valid_config.json valid/config.json COPYONLY)
 
 # broken config.json
-configure_file(test_configs/broken_config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_config/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_config/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/broken_config/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/broken_config/schemes/interface.json COPYONLY)
+configure_file(test_configs/broken_config.json broken_config/config.json COPYONLY)
 
 # missing module config.json
-configure_file(test_configs/missing_module_config.json ${CMAKE_CURRENT_BINARY_DIR}/missing_module_config/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/missing_module_config/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/missing_module_config/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/missing_module_config/schemes/interface.json COPYONLY)
+configure_file(test_configs/missing_module_config.json missing_module_config/config.json COPYONLY)
 
 # broken manifest.json
-configure_file(test_configs/broken_manifest_config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest/schemes/interface.json COPYONLY)
-file(COPY test_modules/TESTBrokenManifest DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest/modules)
+configure_file(test_configs/broken_manifest_config.json broken_manifest/config.json COPYONLY)
+file(COPY test_modules/TESTBrokenManifest DESTINATION broken_manifest/modules)
 
 # broken manifest.json
-configure_file(test_configs/broken_manifest2_config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest2/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest2/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest2/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest2/schemes/interface.json COPYONLY)
-file(COPY test_modules/TESTBrokenManifest2 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/broken_manifest2/modules)
+configure_file(test_configs/broken_manifest2_config.json broken_manifest2/config.json COPYONLY)
+file(COPY test_modules/TESTBrokenManifest2 DESTINATION broken_manifest2/modules)
 
 # valid manifest.json, missing interface
-configure_file(test_configs/valid_manifest_missing_interface_config.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_missing_interface/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_missing_interface/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_missing_interface/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_missing_interface/schemes/interface.json COPYONLY)
-file(COPY test_modules/TESTValidManifestMissingInterface DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_missing_interface/modules)
+configure_file(test_configs/valid_manifest_missing_interface_config.json valid_manifest_missing_interface/config.json COPYONLY)
+file(COPY test_modules/TESTValidManifestMissingInterface DESTINATION valid_manifest_missing_interface/modules)
 
 # valid manifest.json, valid interface
-configure_file(test_interfaces/TESTmissinginterface.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/interfaces/TESTmissinginterface.json COPYONLY)
-configure_file(test_configs/valid_manifest_missing_interface_config.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/config.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/schemes/config.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/manifest.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/schemes/manifest.json COPYONLY)
-configure_file(${PROJECT_SOURCE_DIR}/schemas/interface.json ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/schemes/interface.json COPYONLY)
-file(COPY test_modules/TESTValidManifestMissingInterface DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/valid_manifest_valid_interface/modules)
+configure_file(test_interfaces/TESTmissinginterface.json valid_manifest_valid_interface/interfaces/TESTmissinginterface.json COPYONLY)
+configure_file(test_configs/valid_manifest_missing_interface_config.json valid_manifest_valid_interface/config.json COPYONLY)
+file(COPY test_modules/TESTValidManifestMissingInterface DESTINATION valid_manifest_valid_interface/modules)
+
+# create dummy directory for types
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/dummy_types")

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -7,7 +7,7 @@
 SCENARIO("Check config parser", "[!throws]") {
     GIVEN("An empty config") {
         Everest::Config config =
-            Everest::Config("../../schemas", "valid/config.json", "test_modules", "test_interfaces");
+            Everest::Config("../../schemas", "valid/config.json", "test_modules", "test_interfaces", "dummy_types");
         THEN("It should not contain some module") {
             CHECK(!config.contains("some_module"));
         }
@@ -18,14 +18,14 @@ SCENARIO("Check config parser", "[!throws]") {
     //             by proper ExceptionTypes)
     GIVEN("An invalid main dir") {
         THEN("It should throw Everest::EverestConfigError") {
-            CHECK_THROWS_AS(Everest::Config("../../schemas", "wrong_maindir", "test_modules", "test_interfaces"),
+            CHECK_THROWS_AS(Everest::Config("../../schemas", "wrong_maindir", "test_modules", "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
 
     GIVEN("A non existing config file") {
         THEN("It should throw Everest::EverestConfigError") {
-            CHECK_THROWS_AS(Everest::Config("../../schemas", "missing_config", "test_modules", "test_interfaces"),
+            CHECK_THROWS_AS(Everest::Config("../../schemas", "missing_config", "test_modules", "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
@@ -33,7 +33,7 @@ SCENARIO("Check config parser", "[!throws]") {
     GIVEN("A broken config file") {
         THEN("It should throw Everest::EverestConfigError") {
             CHECK_THROWS_AS(
-                Everest::Config("../../schemas", "broken_config/config.json", "test_modules", "test_interfaces"),
+                Everest::Config("../../schemas", "broken_config/config.json", "test_modules", "test_interfaces", "dummy_types"),
                 Everest::EverestConfigError);
         }
     }
@@ -41,7 +41,7 @@ SCENARIO("Check config parser", "[!throws]") {
     GIVEN("A config file referencing a non existend module") {
         THEN("It should throw Everest::EverestConfigError") {
             CHECK_THROWS_AS(Everest::Config("../../schemas", "missing_module_config/config.json", "test_modules",
-                                            "test_interfaces"),
+                                            "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
@@ -49,7 +49,7 @@ SCENARIO("Check config parser", "[!throws]") {
     GIVEN("A config file referencing a non existend module") {
         THEN("It should throw Everest::EverestConfigError") {
             CHECK_THROWS_AS(Everest::Config("../../schemas", "missing_module_config/config.json", "test_modules",
-                                            "test_interfaces"),
+                                            "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
@@ -57,10 +57,10 @@ SCENARIO("Check config parser", "[!throws]") {
     GIVEN("A config file using a module with broken manifest") {
         THEN("It should throw Everest::EverestConfigError") {
             CHECK_THROWS_AS(Everest::Config("../../schemas", "broken_manifest/config.json", "broken_manifest/modules",
-                                            "test_interfaces"),
+                                            "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
             CHECK_THROWS_AS(Everest::Config("../../schemas", "broken_manifest2/config.json", "broken_manifest2/modules",
-                                            "test_interfaces"),
+                                            "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
@@ -68,7 +68,7 @@ SCENARIO("Check config parser", "[!throws]") {
     GIVEN("A config file using a module with a valid manifest referencing an invalid interface") {
         THEN("It should throw Everest::EverestConfigError") {
             CHECK_THROWS_AS(Everest::Config("../../schemas", "valid_manifest_missing_interface/config.json",
-                                            "valid_manifest_missing_interface/modules", "test_interfaces"),
+                                            "valid_manifest_missing_interface/modules", "test_interfaces", "dummy_types"),
                             Everest::EverestConfigError);
         }
     }
@@ -77,7 +77,7 @@ SCENARIO("Check config parser", "[!throws]") {
         THEN("It should not throw at all") {
             CHECK_NOTHROW(Everest::Config("../../schemas", "valid_manifest_valid_interface/config.json",
                                           "valid_manifest_valid_interface/modules",
-                                          "valid_manifest_valid_interface/interfaces"));
+                                          "valid_manifest_valid_interface/interfaces", "dummy_types"));
         }
     }
 }


### PR DESCRIPTION
- correct CMake catch2 handling
- incorporate config api changes (types)
- converted from boost::filesystem::canonical to boost::filesystem::weakly_canonical (otherwise exception will be thrown again in exception handler)
- formatting

Signed-off-by: aw <aw@pionix.de>