### PR TITLE
Refactoring config schema and command line parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ else()
     include(find-mqttc)
 endif()
 
+set(EVEREST_FRAMEWORK_GENERATED_INC_DIR ${PROJECT_BINARY_DIR}/generated)
+configure_file(
+    include/compile_time_settings.hpp.in
+    ${EVEREST_FRAMEWORK_GENERATED_INC_DIR}/everest/compile_time_settings.hpp
+)
+
 # library code
 add_subdirectory(lib)
 

--- a/everestjs/index.js
+++ b/everestjs/index.js
@@ -27,13 +27,8 @@ const helpers = {
 const EverestModule = function EverestModule(handler_setup, user_settings) {
   const env_settings = {
     module: process.env.EV_MODULE,
-    main_dir: process.env.EV_MAIN_DIR,
-    schemas_dir: process.env.EV_SCHEMAS_DIR,
-    modules_dir: process.env.EV_MODULES_DIR,
-    interfaces_dir: process.env.EV_INTERFACES_DIR,
-    types_dir: process.env.EV_TYPES_DIR,
+    prefix: process.env.EV_PREFIX,
     config_file: process.env.EV_CONF_FILE,
-    log_config_file: process.env.EV_LOG_CONF_FILE,
     mqtt_server_address: process.env.MQTT_SERVER_ADDRESS,
     mqtt_server_port: process.env.MQTT_SERVER_PORT,
   };
@@ -44,16 +39,10 @@ const EverestModule = function EverestModule(handler_setup, user_settings) {
     throw new Error('parameter "module" is missing');
   }
 
-  const main_dir = helpers.get_default(settings, 'main_dir', './');
   const config = {
     module: settings.module,
-    main_dir,
-    schemas_dir: helpers.get_default(settings, 'schemas_dir', `${main_dir}/share/everest/schemas`),
-    modules_dir: helpers.get_default(settings, 'modules_dir', `${main_dir}/libexec/everest/modules`),
-    interfaces_dir: helpers.get_default(settings, 'interfaces_dir', `${main_dir}/share/everest/interfaces`),
-    types_dir: helpers.get_default(settings, 'types_dir', `${main_dir}/share/everest/types`),
-    config_file: helpers.get_default(settings, 'config_file', `${main_dir}/conf/config.json`),
-    log_config_file: helpers.get_default(settings, 'log_config_file', `${main_dir}/conf/logging.ini`),
+    prefix: settings.prefix,
+    config_file: settings.config_file,
     validate_schema: helpers.get_default(settings, 'validate_schema', true),
     mqtt_server_address: helpers.get_default(settings, 'mqtt_server_address', 'localhost'),
     mqtt_server_port: helpers.get_default(settings, 'mqtt_server_port', '1883'),

--- a/include/compile_time_settings.hpp.in
+++ b/include/compile_time_settings.hpp.in
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef FRAMEWORK_COMPILE_TIME_SETTINGS_HPP
+#define FRAMEWORK_COMPILE_TIME_SETTINGS_HPP
+
+#cmakedefine CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+
+#ifndef CMAKE_INSTALL_PREFIX
+#define EVEREST_INSTALL_PREFIX ("/usr")
+#else
+#define EVEREST_INSTALL_PREFIX (CMAKE_INSTALL_PREFIX)
+#endif
+
+// FIXME (aw): this could be also compile time selectable
+#define EVEREST_NAMESPACE ("everest")
+
+#endif // FRAMEWORK_COMPILE_TIME_SETTINGS_HPP

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -2,17 +2,24 @@
 #define FRAMEWORK_EVEREST_RUNTIME_HPP
 
 #include <filesystem>
+#include <string>
 
-#include <boost/program_options.hpp>
 #include <everest/logging.hpp>
 #include <fmt/color.h>
 #include <fmt/core.h>
 #include <framework/ModuleAdapter.hpp>
 #include <sys/prctl.h>
 
+#include <utils/yaml_loader.hpp>
+
+#include <everest/compile_time_settings.hpp>
+
+namespace boost::program_options {
+class variables_map; // forward declaration
+}
+
 namespace Everest {
 
-namespace po = boost::program_options;
 namespace fs = std::filesystem;
 
 // FIXME (aw): should be everest wide or defined in liblog
@@ -21,22 +28,71 @@ const int DUMP_INDENT = 4;
 // FIXME (aw): we should also define all other config keys and default
 //             values here as string literals
 
+// FIXME (aw): this needs to be made available by
+namespace defaults {
+
+// defaults:
+//   PREFIX: set by cmake
+//   EVEREST_NAMESPACE: everest
+//   BIN_DIR: ${PREFIX}/bin
+//   LIBEXEC_DIR: ${PREFIX}/libexec
+//   LIB_DIR: ${PREFIX}/lib
+//   SYSCONF_DIR: /etc, if ${PREFIX}==/usr, otherwise ${PREFIX}/etc
+//   LOCALSTATE_DIR: /var, if ${PREFIX}==/usr, otherwise ${PREFIX}/var
+//   DATAROOT_DIR: ${PREFIX}/share
+//
+//   modules_dir: ${LIBEXEC_DIR}${EVEREST_NAMESPACE}
+//   types_dir: ${DATAROOT_DIR}${EVEREST_NAMESPACE}/types
+//   interfaces_dir: ${DATAROOT_DIR}${EVEREST_NAMESPACE}/interfaces
+//   schemas_dir: ${DATAROOT_DIR}${EVEREST_NAMESPACE}/schemas
+//   configs_dir: ${SYSCONF_DIR}${EVEREST_NAMESPACE}
+//
+//   config_path: ${SYSCONF_DIR}${EVEREST_NAMESPACE}/default.yaml
+//   logging_config_path: ${SYSCONF_DIR}${EVEREST_NAMESPACE}/default_logging.cfg
+
+inline constexpr auto PREFIX = EVEREST_INSTALL_PREFIX;
+inline constexpr auto NAMESPACE = EVEREST_NAMESPACE;
+
+inline constexpr auto BIN_DIR = "bin";
+inline constexpr auto LIB_DIR = "lib";
+inline constexpr auto LIBEXEC_DIR = "libexec";
+inline constexpr auto SYSCONF_DIR = "etc";
+inline constexpr auto LOCALSTATE_DIR = "var";
+inline constexpr auto DATAROOT_DIR = "share";
+
+inline constexpr auto MODULES_DIR = "modules";
+inline constexpr auto TYPES_DIR = "types";
+inline constexpr auto INTERFACES_DIR = "interfaces";
+inline constexpr auto SCHEMAS_DIR = "schemas";
+inline constexpr auto CONFIG_NAME = "default.yaml";
+inline constexpr auto LOGGING_CONFIG_NAME = "default_logging.cfg";
+
+} // namespace defaults
+
+std::string parse_string_option(const boost::program_options::variables_map& vm, const char* option);
+
 const auto TERMINAL_STYLE_ERROR = fmt::emphasis::bold | fg(fmt::terminal_color::red);
 const auto TERMINAL_STYLE_OK = fmt::emphasis::bold | fg(fmt::terminal_color::green);
 
+struct BootException : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 struct RuntimeSettings {
-    fs::path main_dir;
-    fs::path main_binary;
+    fs::path prefix;
     fs::path configs_dir;
     fs::path schemas_dir;
     fs::path modules_dir;
     fs::path interfaces_dir;
     fs::path types_dir;
-    fs::path logging_config;
+    fs::path logging_config_file;
     fs::path config_file;
+
+    nlohmann::json config;
+
     bool validate_schema;
 
-    explicit RuntimeSettings(const po::variables_map& vm);
+    explicit RuntimeSettings(const std::string& prefix, const std::string& config);
 };
 
 struct ModuleCallbacks {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(framework
 
 target_include_directories(framework
     PUBLIC
+        $<BUILD_INTERFACE:${EVEREST_FRAMEWORK_GENERATED_INC_DIR}>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/everest>
 )

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -18,70 +18,97 @@ $defs:
     default: {}
     additionalProperties: false
 type: object
-patternProperties:
-  # module id
-  ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
-    description: This are the required properties for every module id entry
-    required:
-      - module
+required:
+  - active_modules
+additionalProperties: false
+properties:
+  settings:
+    type: object
     properties:
-      module:
-        description: Module name (e.g. directory name in the modules subdirectory)
+      prefix:
         type: string
-        #  module name
-        pattern: ^[a-zA-Z_][a-zA-Z0-9_-]*$
-      config_module:
-        description: Config map for the module
-        $ref: '#/$defs/config_map'
-      config_implementation:
-        description: List of config maps for each implementation
-        type: object
-        patternProperties:
-          # implementation id
-          ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
-            description: Config map for this implementation.
-            # arbitrary implementation config validated by our schema in the module manifest later on
+      config_file:
+        type: string
+      configs_dir:
+        type: string
+      schemas_dir:
+        type: string
+      modules_dir:
+        type: string
+      interfaces_dir:
+        type: string
+      types_dir:
+        type: string
+      config_logging_file:
+        type: string
+    additionalProperties: false
+  active_modules:
+    type: object
+    patternProperties:
+      # module id
+      ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
+        description: This are the required properties for every module id entry
+        required:
+          - module
+        properties:
+          module:
+            description: Module name (e.g. directory name in the modules subdirectory)
+            type: string
+            #  module name
+            pattern: ^[a-zA-Z_][a-zA-Z0-9_-]*$
+          config_module:
+            description: Config map for the module
             $ref: '#/$defs/config_map'
-        # add empty config if not already present
-        default: {}
+          config_implementation:
+            description: List of config maps for each implementation
+            type: object
+            patternProperties:
+              # implementation id
+              ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
+                description: Config map for this implementation.
+                # arbitrary implementation config validated by our schema in the module manifest later on
+                $ref: '#/$defs/config_map'
+            # add empty config if not already present
+            default: {}
+            # don't allow arbitrary additional properties
+            additionalProperties: false
+          connections:
+            type: object
+            description: >-
+              List of requirements: a mapping of all requirement ids listed
+              in the module's manifest to module_id (declared in this file) and implementation_id
+              (declared in manifest).
+            patternProperties:
+              # requirement id
+              ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - module_id
+                    - implementation_id
+                  properties:
+                    module_id:
+                      description: module_id this requirement id maps to
+                      type: string
+                      # reference to module id
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_.-]*$
+                    implementation_id:
+                      description: implementation_id this requirement id maps to
+                      type: string
+                      # reference to implementation id
+                      pattern: ^[a-zA-Z_][a-zA-Z0-9_.-]*$
+                  # don't allow arbitrary additional properties
+                  additionalProperties: false
+            # add empty config if not already present
+            default: {}
+            # don't allow arbitrary additional properties
+            additionalProperties: false
         # don't allow arbitrary additional properties
         additionalProperties: false
-      connections:
-        type: object
-        description: >-
-          List of requirements: a mapping of all requirement ids listed
-          in the module's manifest to module_id (declared in this file) and implementation_id
-          (declared in manifest).
-        patternProperties:
-          # requirement id
-          ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
-            type: array
-            items:
-              type: object
-              required:
-                - module_id
-                - implementation_id
-              properties:
-                module_id:
-                  description: module_id this requirement id maps to
-                  type: string
-                  # reference to module id
-                  pattern: ^[a-zA-Z_][a-zA-Z0-9_.-]*$
-                implementation_id:
-                  description: implementation_id this requirement id maps to
-                  type: string
-                  # reference to implementation id
-                  pattern: ^[a-zA-Z_][a-zA-Z0-9_.-]*$
-              # don't allow arbitrary additional properties
-              additionalProperties: false
-        # add empty config if not already present
-        default: {}
-        # don't allow arbitrary additional properties
-        additionalProperties: false
-      x-view-model: {}
+    # add empty config dict if not already present
+    default: {}
     # don't allow arbitrary additional properties
     additionalProperties: false
-# add empty config dict if not already present
-default: {}
-# don't allow arbitrary additional properties
-additionalProperties: false
+  
+  x-module-layout: {}


### PR DESCRIPTION
- only prefix and config command line options are left for path/file specific settings
- everything else can be set in the config yaml
- config schema changes:
  - x-layout-* stuff moved to a separate section
  - plain module configuration is now under active_modules
  - config settings can be specified under settings
- implementation is still very inefficient, because the config gets loaded twice for each module, this will/could be reduced to only a single load
- compile time CMAKE_INSTALL_PREFIX gets included in the framework, so it will look for a good default

Signed-off-by: aw <aw@pionix.de>