### PR TITLE
Add everest prefix dir to module_info

### DIFF
--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -74,6 +74,7 @@ struct ModuleInfo {
     std::vector<std::string> authors;
     std::string license;
     std::string id;
+    std::string everest_prefix;
 };
 
 struct Requirement {

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -310,7 +310,8 @@ int ModuleLoader::initialize() {
         }
 
         auto module_configs = config.get_module_configs(this->module_id);
-        const auto module_info = config.get_module_info(this->module_id);
+        auto module_info = config.get_module_info(this->module_id);
+        module_info.everest_prefix = rs->prefix.string();
 
         this->callbacks.init(module_configs, module_info);
 


### PR DESCRIPTION
The prefix dir is handy for modules that need to access the filesystem. This solution is not the best.  It will be refactored in the upcoming module interface refactor.

Signed-off-by: aw <aw@pionix.de>