### PR TITLE
Proper linking of controller-ipc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(manager manager.cpp)
 target_link_libraries(manager
     PRIVATE
         everest::framework
-        $<TARGET_OBJECTS:controller-ipc>
+        controller-ipc
         Boost::program_options
 )
 

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(controller
     rpc.cpp
     server.cpp
     ${PROJECT_SOURCE_DIR}/lib/yaml_loader.cpp
-    $<TARGET_OBJECTS:controller-ipc>
 )
 
 target_include_directories(controller PRIVATE
@@ -26,7 +25,7 @@ target_link_libraries(controller
     PRIVATE
         Threads::Threads
 
-        nlohmann_json::nlohmann_json
+        controller-ipc
 
         websockets_shared
         fmt::fmt


### PR DESCRIPTION
- the controller-ipc object library was linked in a unnecessary complex way which lead CMake to loose track of the order of dependencies and build problems

Signed-off-by: aw <aw@pionix.de>