### PR TITLE
Increase version to 0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.3
+    VERSION 0.4
     DESCRIPTION "The open operating system for e-mobility charging stations"
 	LANGUAGES CXX C
 )

--- a/everestjs/package.json
+++ b/everestjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "everestjs",
   "main": "index.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "EVerest API for node.js",
   "dependencies": {
     "node-addon-api": "^3.2.1"

--- a/everestpy/everestpy.cpp
+++ b/everestpy/everestpy.cpp
@@ -354,5 +354,5 @@ PYBIND11_MODULE(everestpy, m) {
     m.def("register_pre_init_callback", &register_pre_init_callback);
     m.def("register_ready_callback", &register_ready_callback);
 
-    m.attr("__version__") = "0.3";
+    m.attr("__version__") = "0.4";
 }


### PR DESCRIPTION
There have been a few changes to the API of everestjs and everestpy as well as the addition of new settings variables. I think this requires a new version number, so we can properly reference these changes in everest-core