### PR TITLE
Enhanced ModuleInfos path properties

### DIFF
--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -522,6 +522,10 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
 
         // config property
         json module_config = config->get_module_json_config(module_id);
+
+        auto module_info = config->get_module_info(module_id);
+        populate_module_info_path_from_runtime_settings(module_info, rs);
+
         auto module_config_prop = Napi::Object::New(env);
         auto module_config_impl_prop = Napi::Object::New(env);
 
@@ -542,19 +546,29 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         auto module_info_prop = Napi::Object::New(env);
         // set moduleName property
         module_info_prop.DefineProperty(
-            Napi::PropertyDescriptor::Value("name", Napi::String::New(env, module_name), napi_enumerable));
+            Napi::PropertyDescriptor::Value("name", Napi::String::New(env, module_info.name), napi_enumerable));
 
         // set moduleId property
         module_info_prop.DefineProperty(
-            Napi::PropertyDescriptor::Value("id", Napi::String::New(env, module_id), napi_enumerable));
+            Napi::PropertyDescriptor::Value("id", Napi::String::New(env, module_info.id), napi_enumerable));
 
         // set printable identifier
         module_info_prop.DefineProperty(Napi::PropertyDescriptor::Value(
             "printable_identifier", Napi::String::New(env, module_identifier), napi_enumerable));
 
-        // set everest prefix
-        module_info_prop.DefineProperty(Napi::PropertyDescriptor::Value(
-            "everest_prefix", Napi::String::New(env, prefix), napi_enumerable));
+        auto module_info_paths_prop = Napi::Object::New(env);
+        module_info_paths_prop.DefineProperty(Napi::PropertyDescriptor::Value(
+            "etc", Napi::String::New(env, module_info.paths.etc.string()), napi_enumerable));
+
+        module_info_paths_prop.DefineProperty(Napi::PropertyDescriptor::Value(
+            "libexec", Napi::String::New(env, module_info.paths.libexec.string()), napi_enumerable));
+
+        module_info_paths_prop.DefineProperty(Napi::PropertyDescriptor::Value(
+            "share", Napi::String::New(env, module_info.paths.share.string()), napi_enumerable));
+
+        // add path info property
+        module_info_prop.DefineProperty(
+            Napi::PropertyDescriptor::Value("paths", module_info_paths_prop, napi_enumerable));
 
         // set telemetry_enabled
         module_info_prop.DefineProperty(Napi::PropertyDescriptor::Value(

--- a/everestpy/everestpy.cpp
+++ b/everestpy/everestpy.cpp
@@ -265,7 +265,8 @@ int initialize(const std::string& prefix, const std::string& config_file, const 
 
         auto module_configs = config.get_module_configs(module_id);
         auto module_info = config.get_module_info(module_id);
-        module_info.everest_prefix = rs.prefix.string();
+
+        populate_module_info_path_from_runtime_settings(module_info, rs);
         module_info.telemetry_enabled = everest.is_telemetry_enabled();
 
         everest_py.module_callbacks.init(module_configs, module_info);
@@ -322,13 +323,18 @@ PYBIND11_MODULE(everestpy, m) {
     py::class_<ConfigEntry>(m, "ConfigEntry").def(py::init<>());
     py::class_<ConfigMap>(m, "ConfigMap").def(py::init<>());
     py::class_<ModuleConfigs>(m, "ModuleConfigs").def(py::init<>());
+    py::class_<ModuleInfo::Paths>(m, "ModuleInfoPaths")
+        .def(py::init<>())
+        .def_property_readonly("etc", [](const ModuleInfo::Paths& p) { return p.etc.string(); })
+        .def_property_readonly("libexec", [](const ModuleInfo::Paths& p) { return p.libexec.string(); })
+        .def_property_readonly("share", [](const ModuleInfo::Paths& p) { return p.share.string(); });
     py::class_<ModuleInfo>(m, "ModuleInfo")
         .def(py::init<>())
         .def_readonly("name", &ModuleInfo::name)
         .def_readonly("authors", &ModuleInfo::authors)
         .def_readonly("license", &ModuleInfo::license)
         .def_readonly("id", &ModuleInfo::id)
-        .def_readonly("everest_prefix", &ModuleInfo::everest_prefix)
+        .def_readonly("paths", &ModuleInfo::paths)
         .def_readonly("telemetry_enabled", &ModuleInfo::telemetry_enabled);
     py::class_<CmdWithArguments>(m, "CmdWithArguments")
         .def(py::init<>())

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -90,8 +90,12 @@ struct BootException : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+
+
 struct RuntimeSettings {
     fs::path prefix;
+    fs::path etc_dir;
+    fs::path data_dir;
     fs::path configs_dir;
     fs::path schemas_dir;
     fs::path modules_dir;
@@ -114,6 +118,9 @@ struct RuntimeSettings {
 
     explicit RuntimeSettings(const std::string& prefix, const std::string& config);
 };
+
+// NOTE: this function needs the be called with a pre-initialized ModuleInfo struct
+void populate_module_info_path_from_runtime_settings(ModuleInfo&, const RuntimeSettings& rs);
 
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include <boost/any.hpp>
 #include <boost/optional.hpp>
@@ -68,11 +69,17 @@ enum class QOS {
 };
 
 struct ModuleInfo {
+    struct Paths {
+        std::filesystem::path etc;
+        std::filesystem::path libexec;
+        std::filesystem::path share;
+    };
+
     std::string name;
     std::vector<std::string> authors;
     std::string license;
     std::string id;
-    std::string everest_prefix;
+    Paths paths;
     bool telemetry_enabled;
 };
 


### PR DESCRIPTION
- ModuleInfo now carries a path property which has the sub-properties:
- etc -> determined etc folder
- libexec -> determined {libexec}/everest/modules/ModuleName folder
- share -> determined {share}/everest/modules/ModuleName folder