### PR TITLE
Added optional compile warnings + some fixes

### DIFF
--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -1,20 +1,3 @@
-
-add_library(everestjs SHARED)
-target_sources(everestjs
-    PRIVATE
-        everestjs.cpp
-        conversions.cpp
-        js_exec_ctx.cpp
-)
-
-set_target_properties(everestjs PROPERTIES PREFIX "" SUFFIX ".node")
-
-target_link_libraries(everestjs
-    PRIVATE
-        everest::framework
-        everest::log
-)
-
 find_program(
     NODE
     node
@@ -63,6 +46,25 @@ find_path(NODEJS_INCLUDE_DIR "node_api.h"
     REQUIRED
 )
 
+add_library(everestjs SHARED)
+target_sources(everestjs
+    PRIVATE
+        everestjs.cpp
+        conversions.cpp
+        js_exec_ctx.cpp
+)
+
+target_compile_options(everestjs PRIVATE ${COMPILER_WARNING_OPTIONS})
+
+# define NAPI_VERSION
+target_compile_definitions(everestjs
+    PRIVATE
+        -DNAPI_VERSION=${NODE_API_VERSION_REQUIRED}
+        -DNAPI_CPP_EXCEPTIONS
+)
+
+set_target_properties(everestjs PROPERTIES PREFIX "" SUFFIX ".node")
+
 target_include_directories(everestjs
     PRIVATE
         $<BUILD_INTERFACE:${NODE_ADDON_API_DIR}>
@@ -70,11 +72,10 @@ target_include_directories(everestjs
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# define NAPI_VERSION
-target_compile_definitions(everestjs
+target_link_libraries(everestjs
     PRIVATE
-        -DNAPI_VERSION=${NODE_API_VERSION_REQUIRED}
-        -DNAPI_CPP_EXCEPTIONS
+        everest::framework
+        everest::log
 )
 
 install(

--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -350,8 +350,6 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
             const auto& impl_id = impl_definition.key();
             const auto& impl_intf = module_impls[impl_id];
 
-            auto set_prop = Napi::Object::New(env);
-
             // iterator over every variable, that the interface of this implementation provides
             auto impl_vars_prop = Napi::Object::New(env);
             if (impl_intf.contains("vars")) {

--- a/everestjs/js_exec_ctx.cpp
+++ b/everestjs/js_exec_ctx.cpp
@@ -4,6 +4,8 @@
 #include "utils.hpp"
 
 void JsExecCtx::tramp(Napi::Env env, Napi::Function callback, std::nullptr_t* context, JsExecCtx* this_) {
+    (void) context; // this is unused in this callback
+
     try {
         std::vector<napi_value> args{this_->result_handler_ref.Value()};
         if (this_->arg_func != nullptr) {
@@ -14,7 +16,7 @@ void JsExecCtx::tramp(Napi::Env env, Napi::Function callback, std::nullptr_t* co
             append_args.clear();
         }
 
-        const Napi::Value& retval = callback.Call(args);
+        callback.Call(args);
     } catch (std::exception& e) {
         EVLOG_AND_RETHROW(env);
     }

--- a/everestpy/CMakeLists.txt
+++ b/everestpy/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 pybind11_add_module(everestpy everestpy.cpp)
 
+target_compile_options(everestpy PRIVATE ${COMPILER_WARNING_OPTIONS})
+
 target_link_libraries(everestpy
     PRIVATE
     everest::framework

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -67,8 +67,7 @@ public:
 
     ///
     /// \copydoc MQTTAbstractionImpl::register_handler(const std::string&, std::shared_ptr<TypedHandler>, QOS)
-    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers,
-                          QOS qos);
+    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, QOS qos);
 
     ///
     /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -108,10 +108,8 @@ public:
 
     ///
     /// \brief subscribes to the given \p topic and registers a callback \p handler that is called when a message
-    /// arrives on the topic. If \p allow_multiple_handlers is set to true, multiple handlers can be registered for the
-    /// same topic. With \p qos a MQTT Quality of Service level can be set.
-    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, bool allow_multiple_handlers,
-                          QOS qos);
+    /// arrives on the topic. With \p qos a MQTT Quality of Service level can be set.
+    void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, QOS qos);
 
     ///
     /// \brief unsubscribes a handler identified by its \p token from the given \p topic

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,12 @@ target_sources(framework
         yaml_loader.cpp
 )
 
+# FIXME (aw): c++17 doesn't need necessarily to be public, but our
+#             headers are messed up
+target_compile_features(framework PUBLIC cxx_std_17)
+
+target_compile_options(framework PRIVATE ${COMPILER_WARNING_OPTIONS})
+
 target_include_directories(framework
     PUBLIC
         $<BUILD_INTERFACE:${EVEREST_FRAMEWORK_GENERATED_INC_DIR}>
@@ -50,7 +56,3 @@ target_link_libraries(framework
         mqttc
         ryml::ryml
 )
-
-# FIXME (aw): c++17 doesn't need necessarily to be public, but our
-#             headers are messed up
-target_compile_features(framework PUBLIC cxx_std_17)

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -63,10 +63,9 @@ std::future<void> MQTTAbstraction::spawn_main_loop_thread() {
     return mqtt_abstraction.spawn_main_loop_thread();
 }
 
-void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler,
-                                       bool allow_multiple_handlers, QOS qos) {
+void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, QOS qos) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.register_handler(topic, handler, allow_multiple_handlers, qos);
+    mqtt_abstraction.register_handler(topic, handler, qos);
 }
 
 void MQTTAbstraction::unregister_handler(const std::string& topic, const Token& token) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -278,8 +278,7 @@ void MQTTAbstractionImpl::on_mqtt_disconnect() {
     EVLOG_AND_THROW(EverestInternalError("Lost connection to MQTT broker"));
 }
 
-void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler,
-                                           bool allow_multiple_handlers, QOS qos) {
+void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, QOS qos) {
     BOOST_LOG_FUNCTION();
 
     switch (handler->type) {

--- a/lib/serial.cpp
+++ b/lib/serial.cpp
@@ -117,6 +117,7 @@ uint32_t Serial::crc32(uint8_t* buf, int len) {
 }
 
 void Serial::handlePacket(uint8_t* buf, int len) {
+    // FIXME (aw): why is there no implementation here?
 }
 
 void Serial::cobsDecode(uint8_t* buf, int len) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(manager
         Boost::program_options
 )
 
+target_compile_options(manager PRIVATE ${COMPILER_WARNING_OPTIONS})
+
 target_compile_features(manager PRIVATE cxx_std_17)
 
 install(

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -5,6 +5,8 @@ target_link_libraries(controller-ipc
         nlohmann_json::nlohmann_json
 )
 
+target_compile_options(controller-ipc PRIVATE ${COMPILER_WARNING_OPTIONS})
+
 find_package(Threads REQUIRED)
 
 # FIXME (aw): refactor the yaml_loader into on lib, so it can be shared somehow, similar to the controller-ipc
@@ -19,6 +21,8 @@ add_executable(controller
 target_include_directories(controller PRIVATE
     ${PROJECT_SOURCE_DIR}/include
 )
+
+target_compile_options(controller PRIVATE ${COMPILER_WARNING_OPTIONS})
 
 target_link_libraries(controller
     PRIVATE

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -119,13 +119,32 @@ const lws_protocol_vhost_options Server::Impl::pvo = {nullptr, &pvo_opt, "everes
 
 const lws_protocol_vhost_options Server::Impl::pvo_mime = {nullptr, nullptr, ".mp4", "application/x-mp4"};
 
+// lws_http_mount Server::Impl::mount = {
+//     .mountpoint = "/",
+//     .origin = "/",
+//     .def = "index.html",
+//     .extra_mimetypes = &pvo_mime,
+//     .origin_protocol = LWSMPRO_FILE,
+//     .mountpoint_len = 1,
+// };
 lws_http_mount Server::Impl::mount = {
-    .mountpoint = "/",
-    .origin = "/",
-    .def = "index.html",
-    .extra_mimetypes = &pvo_mime,
-    .origin_protocol = LWSMPRO_FILE,
-    .mountpoint_len = 1,
+    nullptr,      // lws_http_mount *mount_next;
+    "/",          // const char *mountpoint;
+    "/",          // const char *origin;
+    "index.html", // const char *def;
+    nullptr,      // const char *protocol;
+    nullptr,      // const struct lws_protocol_vhost_options *cgienv;
+    &pvo_mime,    // const struct lws_protocol_vhost_options *extra_mimetypes;
+    nullptr,      // const struct lws_protocol_vhost_options *interpret;
+    0,            // int cgi_timeout;
+    0,            // int cache_max_age;
+    0,            // unsigned int auth_mask;
+    0,            // unsigned int cache_reusable:1; /**< set if client cache may reuse this */
+    0,            // unsigned int cache_revalidate:1; /**< set if client cache should revalidate on use */
+    0,            // unsigned int cache_intermediaries:1; /**< set if intermediaries are allowed to cache */
+    LWSMPRO_FILE, // unsigned char origin_protocol; /**< one of enum lws_mount_protocols */
+    1,            // unsigned char mountpoint_len; /**< length of mountpoint string */
+    nullptr,      // const char *basic_auth_login_file;
 };
 
 int Server::Impl::callback(struct lws* wsi, lws_callback_reasons reason, void* user, void* in, size_t len) {
@@ -219,7 +238,7 @@ void Server::Impl::run(const Server::IncomingMessageHandler& handler, const std:
             // should be LLL_ERR or LLL_WARN
             EVLOG_info << line;
         }
-        });
+    });
 
     EVLOG_info << fmt::format("Launching controller service on port {}\n", info.port);
 

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -119,14 +119,6 @@ const lws_protocol_vhost_options Server::Impl::pvo = {nullptr, &pvo_opt, "everes
 
 const lws_protocol_vhost_options Server::Impl::pvo_mime = {nullptr, nullptr, ".mp4", "application/x-mp4"};
 
-// lws_http_mount Server::Impl::mount = {
-//     .mountpoint = "/",
-//     .origin = "/",
-//     .def = "index.html",
-//     .extra_mimetypes = &pvo_mime,
-//     .origin_protocol = LWSMPRO_FILE,
-//     .mountpoint_len = 1,
-// };
 lws_http_mount Server::Impl::mount = {
     nullptr,      // lws_http_mount *mount_next;
     "/",          // const char *mountpoint;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -333,7 +333,7 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
             std::unique_lock<std::mutex> lock(modules_ready_mutex);
             // FIXME (aw): here are race conditions, if the ready handler gets called while modules are shut down!
             modules_ready.at(module_name).ready = json.get<bool>();
-            auto modules_spawned = 0;
+            size_t modules_spawned = 0;
             for (const auto& mod : modules_ready) {
                 std::string text_ready =
                     fmt::format((mod.second.ready) ? TERMINAL_STYLE_OK : TERMINAL_STYLE_ERROR, "ready");
@@ -364,7 +364,7 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
         module_it->second.token =
             std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(module_ready_handler));
 
-        mqtt_abstraction.register_handler(topic, module_it->second.token, false, QOS::QOS2);
+        mqtt_abstraction.register_handler(topic, module_it->second.token, QOS::QOS2);
 
         if (std::any_of(standalone_modules.begin(), standalone_modules.end(),
                         [module_name](const auto& element) { return element == module_name; })) {


### PR DESCRIPTION
- add possibility to specify compiler warnings
- in order to switch on compile warnings for source files, use cmake ... -DCOMPILER_WARNING_OPTIONS="-Wall;-Wextra;-Wpedantic" this will add these flags to all source files of this repository targets
- a few of the resulting warnings have been resolved, some are still there and need to be fixed