### PR TITLE
Added status notification support via named pipe

### DIFF
--- a/include/utils/status_fifo.hpp
+++ b/include/utils/status_fifo.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+#ifndef STATUS_FIFO_HPP
+#define STATUS_FIFO_HPP
+
+#include <string>
+
+namespace Everest {
+
+class StatusFifo {
+public:
+    // defined messages
+    static constexpr auto ALL_MODULES_STARTED = "ALL_MODULES_STARTED\n";
+
+    static StatusFifo create_from_path(const std::string&);
+    void update(const std::string&);
+
+    StatusFifo(StatusFifo const&) = delete;
+    StatusFifo& operator=(StatusFifo const&) = delete;
+    // NOTE (aw): the move constructor could be implementented, but we don't need it for now
+    StatusFifo(StatusFifo&&) = delete;
+    StatusFifo& operator=(StatusFifo&&) = delete;
+    ~StatusFifo();
+
+private:
+    StatusFifo() = default;
+    explicit StatusFifo(int fd_) : fd(fd_), disabled(false), opened(true){};
+
+    int fd{-1};
+    bool disabled{true};
+    bool opened{false};
+};
+
+} // namespace Everest
+
+#endif // STATUS_FIFO_HPP

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(framework
         conversions.cpp
         thread.cpp
         serial.cpp
+        status_fifo.cpp
         date.cpp
         runtime.cpp
         yaml_loader.cpp

--- a/lib/status_fifo.cpp
+++ b/lib/status_fifo.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+#include <utils/status_fifo.hpp>
+
+#include <stdexcept>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace Everest {
+
+StatusFifo StatusFifo::create_from_path(const std::string& fifo_path) {
+    if (fifo_path.length() == 0) {
+        return StatusFifo();
+    }
+
+    // try to open the file
+    auto fd = open(fifo_path.c_str(), O_WRONLY | O_NONBLOCK);
+
+    // note: for fifo files, opening for write only in non-blocking mode will fail with ENXIO if the other end hasn't
+    // opened the file yet
+    if (fd == -1) {
+        if (errno == ENXIO) {
+            auto msg = std::string("Failed to open status fifo at ") + fifo_path + " (fifo not opened for read?)";
+            throw std::runtime_error(msg);
+        } else {
+            auto msg =
+                std::string("Failed to open status fifo at ") + fifo_path + " (fifo file not created with mkfifo?)";
+            throw std::runtime_error(msg);
+        }
+    }
+
+    return StatusFifo(fd);
+}
+
+void StatusFifo::update(const std::string& message) {
+    if (disabled) {
+        return;
+    }
+
+    const auto ret = write(fd, message.c_str(), message.length());
+    if (ret == -1) {
+        // NOTE (aw): if we fail to write, we might assume, that the reader of the fifo is not interested in us anymore
+        // so we won't send any further messages
+        disabled = true;
+    }
+}
+
+StatusFifo::~StatusFifo() {
+    if (opened) {
+        close(fd);
+    }
+}
+} // namespace Everest


### PR DESCRIPTION
- for better control, especially when testing, the manager now supports the option "status-fifo", which shall be a path to a named pipe (created via mkfifo)
- this file needs to be opened for reading (in order to listen on status updates of the manager), when the manager gets started, otherwise it will terminate assuming that the caller did something unintended
- on status updates like "all modules started" or similar, the manager will print simple strings on this pipe
- the manager does not read from this pipe
- if the caller stops reading from the pipe, the manager continues running but stops writing to the pipe when it becomes aware of that there is no reader anymore on the pipe