### PR TITLE
Remove get_instance() logic

### DIFF
--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -12,19 +12,23 @@
 namespace Everest {
 using json = nlohmann::json;
 
+// forward declaration
 class MQTTAbstractionImpl;
 
 ///
 /// \brief Contains a C++ abstraction for using MQTT in EVerest modules
 ///
 class MQTTAbstraction {
-
-private:
+public:
     MQTTAbstraction(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
                     const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix);
-    MQTTAbstractionImpl& mqtt_abstraction;
 
-public:
+    // forbid copy assignment and copy construction
+    MQTTAbstraction(MQTTAbstraction const&) = delete;
+    void operator=(MQTTAbstraction const&) = delete;
+
+    ~MQTTAbstraction();
+
     ///
     /// \copydoc MQTTAbstractionImpl::connect()
     bool connect();
@@ -73,20 +77,8 @@ public:
     /// \copydoc MQTTAbstractionImpl::unregister_handler(const std::string&, const Token&)
     void unregister_handler(const std::string& topic, const Token& token);
 
-    ///
-    /// \returns the instance of the MQTTAbstraction singleton taking a \p mqtt_server_address , \p mqtt_server_port ,
-    /// \p mqtt_everest_prefix and \p mqtt_external_prefix as parameters
-    static MQTTAbstraction& get_instance(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
-                                         const std::string& mqtt_everest_prefix,
-                                         const std::string& mqtt_external_prefix) {
-        static MQTTAbstraction instance(mqtt_server_address, mqtt_server_port, mqtt_everest_prefix,
-                                        mqtt_external_prefix);
-
-        return instance;
-    }
-
-    MQTTAbstraction(MQTTAbstraction const&) = delete;
-    void operator=(MQTTAbstraction const&) = delete;
+private:
+    std::unique_ptr<MQTTAbstractionImpl> mqtt_abstraction;
 };
 } // namespace Everest
 

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -35,36 +35,13 @@ struct MessageWithQOS : Message {
 /// \brief Contains a C++ abstraction of MQTT-C and some convenience functionality for using MQTT in EVerest modules
 ///
 class MQTTAbstractionImpl {
-
-private:
-    bool mqtt_is_connected;
-    std::map<std::string, MessageHandler> message_handlers;
-    std::mutex handlers_mutex;
-    MessageQueue message_queue;
-    std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;
-    std::mutex messages_before_connected_mutex;
-
-    Thread mqtt_mainloop_thread;
-
-    std::string mqtt_server_address;
-    std::string mqtt_server_port;
-    std::string mqtt_everest_prefix;
-    std::string mqtt_external_prefix;
-    struct mqtt_client mqtt_client;
-    uint8_t sendbuf[MQTT_BUF_SIZE];
-    uint8_t recvbuf[MQTT_BUF_SIZE];
-
+public:
     MQTTAbstractionImpl(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
                         const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix);
     ~MQTTAbstractionImpl();
 
-    static int open_nb_socket(const char* addr, const char* port);
-    bool connectBroker(const char* host, const char* port);
-    void on_mqtt_message(std::shared_ptr<Message> message);
-    void on_mqtt_connect();
-    static void on_mqtt_disconnect();
-
-public:
+    MQTTAbstractionImpl(MQTTAbstractionImpl const&) = delete;
+    void operator=(MQTTAbstractionImpl const&) = delete;
     ///
     /// \brief connects to the mqtt broker using the MQTT_SERVER_ADDRESS AND MQTT_SERVER_PORT environment variables
     bool connect();
@@ -126,21 +103,29 @@ public:
     /// \brief callback that is called from the mqtt implementation whenever a message is received
     static void publish_callback(void** unused, struct mqtt_response_publish* published);
 
-    ///
-    /// \returns the instance of the MQTTAbstractionImpl singleton taking a \p mqtt_server_address , \p mqtt_server_port
-    /// , \p mqtt_everest_prefix and \p mqtt_external_prefix as parameters
-    static MQTTAbstractionImpl& get_instance(const std::string& mqtt_server_address,
-                                             const std::string& mqtt_server_port,
-                                             const std::string& mqtt_everest_prefix,
-                                             const std::string& mqtt_external_prefix) {
-        static MQTTAbstractionImpl instance(mqtt_server_address, mqtt_server_port, mqtt_everest_prefix,
-                                            mqtt_external_prefix);
+private:
+    bool mqtt_is_connected;
+    std::map<std::string, MessageHandler> message_handlers;
+    std::mutex handlers_mutex;
+    MessageQueue message_queue;
+    std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;
+    std::mutex messages_before_connected_mutex;
 
-        return instance;
-    }
+    Thread mqtt_mainloop_thread;
 
-    MQTTAbstractionImpl(MQTTAbstractionImpl const&) = delete;
-    void operator=(MQTTAbstractionImpl const&) = delete;
+    std::string mqtt_server_address;
+    std::string mqtt_server_port;
+    std::string mqtt_everest_prefix;
+    std::string mqtt_external_prefix;
+    struct mqtt_client mqtt_client;
+    uint8_t sendbuf[MQTT_BUF_SIZE];
+    uint8_t recvbuf[MQTT_BUF_SIZE];
+
+    static int open_nb_socket(const char* addr, const char* port);
+    bool connectBroker(const char* host, const char* port);
+    void on_mqtt_message(std::shared_ptr<Message> message);
+    void on_mqtt_connect();
+    static void on_mqtt_disconnect();
 };
 } // namespace Everest
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -24,8 +24,7 @@ const std::array<std::string, 3> TELEMETRY_RESERVED_KEYS = {{"connector_id"}};
 Everest::Everest(std::string module_id, Config config, bool validate_data_with_schema,
                  const std::string& mqtt_server_address, int mqtt_server_port, const std::string& mqtt_everest_prefix,
                  const std::string& mqtt_external_prefix, const std::string& telemetry_prefix, bool telemetry_enabled) :
-    mqtt_abstraction(MQTTAbstraction::get_instance(mqtt_server_address, std::to_string(mqtt_server_port),
-                                                   mqtt_everest_prefix, mqtt_external_prefix)),
+    mqtt_abstraction(mqtt_server_address, std::to_string(mqtt_server_port), mqtt_everest_prefix, mqtt_external_prefix),
     config(std::move(config)),
     module_id(std::move(module_id)),
     remote_cmd_res_timeout(remote_cmd_res_timeout_seconds),

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -8,69 +8,71 @@
 namespace Everest {
 MQTTAbstraction::MQTTAbstraction(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
                                  const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix) :
-    mqtt_abstraction(MQTTAbstractionImpl::get_instance(mqtt_server_address, mqtt_server_port, mqtt_everest_prefix,
-                                                       mqtt_external_prefix)) {
+    mqtt_abstraction(std::make_unique<MQTTAbstractionImpl>(mqtt_server_address, mqtt_server_port, mqtt_everest_prefix,
+                                                           mqtt_external_prefix)) {
     EVLOG_debug << "initialized mqtt_abstraction";
 }
 
+MQTTAbstraction::~MQTTAbstraction() = default;
+
 bool MQTTAbstraction::connect() {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.connect();
+    return mqtt_abstraction->connect();
 }
 
 void MQTTAbstraction::disconnect() {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.disconnect();
+    mqtt_abstraction->disconnect();
 }
 
 void MQTTAbstraction::publish(const std::string& topic, const json& json) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.publish(topic, json);
+    mqtt_abstraction->publish(topic, json);
 }
 
 void MQTTAbstraction::publish(const std::string& topic, const json& json, QOS qos) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.publish(topic, json, qos);
+    mqtt_abstraction->publish(topic, json, qos);
 }
 
 void MQTTAbstraction::publish(const std::string& topic, const std::string& data) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.publish(topic, data);
+    mqtt_abstraction->publish(topic, data);
 }
 
 void MQTTAbstraction::publish(const std::string& topic, const std::string& data, QOS qos) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.publish(topic, data, qos);
+    mqtt_abstraction->publish(topic, data, qos);
 }
 
 void MQTTAbstraction::subscribe(const std::string& topic) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.subscribe(topic);
+    mqtt_abstraction->subscribe(topic);
 }
 
 void MQTTAbstraction::subscribe(const std::string& topic, QOS qos) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.subscribe(topic, qos);
+    mqtt_abstraction->subscribe(topic, qos);
 }
 
 void MQTTAbstraction::unsubscribe(const std::string& topic) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.unsubscribe(topic);
+    mqtt_abstraction->unsubscribe(topic);
 }
 
 std::future<void> MQTTAbstraction::spawn_main_loop_thread() {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction.spawn_main_loop_thread();
+    return mqtt_abstraction->spawn_main_loop_thread();
 }
 
 void MQTTAbstraction::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler, QOS qos) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.register_handler(topic, handler, qos);
+    mqtt_abstraction->register_handler(topic, handler, qos);
 }
 
 void MQTTAbstraction::unregister_handler(const std::string& topic, const Token& token) {
     BOOST_LOG_FUNCTION();
-    mqtt_abstraction.unregister_handler(topic, token);
+    mqtt_abstraction->unregister_handler(topic, token);
 }
 
 } // namespace Everest

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -356,9 +356,9 @@ int ModuleLoader::initialize() {
         }
         Logging::update_process_name(module_identifier);
 
-        Everest& everest = Everest::Everest::get_instance(
-            this->module_id, config, rs->validate_schema, rs->mqtt_broker_host, rs->mqtt_broker_port,
-            rs->mqtt_everest_prefix, rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
+        auto everest = Everest(this->module_id, config, rs->validate_schema, rs->mqtt_broker_host,
+                                        rs->mqtt_broker_port, rs->mqtt_everest_prefix, rs->mqtt_external_prefix,
+                                        rs->telemetry_prefix, rs->telemetry_enabled);
 
         // module import
         EVLOG_debug << fmt::format("Initializing module {}...", module_identifier);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -592,8 +592,9 @@ int boot(const po::variables_map& vm) {
     // create StatusFifo object
     auto status_fifo = StatusFifo::create_from_path(vm["status-fifo"].as<std::string>());
 
-    MQTTAbstraction& mqtt_abstraction = MQTTAbstraction::get_instance(
-        rs.mqtt_broker_host, std::to_string(rs.mqtt_broker_port), rs.mqtt_everest_prefix, rs.mqtt_external_prefix);
+    auto mqtt_abstraction = MQTTAbstraction(rs.mqtt_broker_host, std::to_string(rs.mqtt_broker_port),
+                                            rs.mqtt_everest_prefix, rs.mqtt_external_prefix);
+
     if (!mqtt_abstraction.connect()) {
         EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", rs.mqtt_broker_host, rs.mqtt_broker_port);
         return EXIT_FAILURE;


### PR DESCRIPTION
- the classes Everest, MQTTAbstraction and MQTTAbstractionImpl are no longer singletons, which makes it possible to create multiple sessions to Everest within one process