### PR TITLE
add support for NVM node nvm- no version manager

### DIFF
--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -44,6 +44,8 @@ find_path(NODEJS_INCLUDE_DIR "node_api.h"
         "node19"
         "node20"
         "nodejs/src"
+    HINTS
+        "$ENV{HOME}/.nvm/versions/node/${NODE_VERSION}/include"
     REQUIRED
 )
 


### PR DESCRIPTION
updated cmake to find node api header when node version manager is in use
Add a hint after search for default path failed 