### PR TITLE
Allow setting user for all modules and capabilities per module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,7 +70,7 @@ cc_binary(
     name = "manager",
     srcs = [
         "src/manager.cpp",
-        "src/*.hpp",
+        "src/system_unix.hpp",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,10 +68,12 @@ cc_binary(
 
 cc_binary(
     name = "manager",
-    srcs = [
-        "src/manager.cpp",
-        "src/system_unix.hpp",
-    ],
+    srcs = glob(
+        [
+            "src/*.cpp",
+            "src/*.hpp",
+        ],
+    ),
     visibility = ["//visibility:public"],
     deps = [
         ":controller-ipc",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,7 @@ genrule(
 cc_library(
     name = "framework",
     srcs = glob(["lib/*.cpp"]),
-    hdrs = glob(["include/**/*.hpp"]) + [":compile_time_settings"] + glob(["src/*.hpp"]),
+    hdrs = glob(["include/**/*.hpp"]) + [":compile_time_settings"],
     copts = ["-std=c++17"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
@@ -70,6 +70,7 @@ cc_binary(
     name = "manager",
     srcs = [
         "src/manager.cpp",
+        "src/*.hpp",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,7 @@ genrule(
 cc_library(
     name = "framework",
     srcs = glob(["lib/*.cpp"]),
-    hdrs = glob(["include/**/*.hpp"]) + [":compile_time_settings"],
+    hdrs = glob(["include/**/*.hpp"]) + [":compile_time_settings"] + glob(["src/*.hpp"]),
     copts = ["-std=c++17"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,13 @@ find_package(Boost
     REQUIRED
 )
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libcap
+    REQUIRED
+    IMPORTED_TARGET
+    libcap
+)
+
 if(NOT DISABLE_EDM)
     evc_setup_edm()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.8.1
+    VERSION 0.9
     DESCRIPTION "The open operating system for e-mobility charging stations"
 	LANGUAGES CXX C
 )

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -116,6 +116,8 @@ struct RuntimeSettings {
     std::string telemetry_prefix;
     bool telemetry_enabled;
 
+    std::string run_as_user;
+
     nlohmann::json config;
 
     bool validate_schema;

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -341,6 +341,7 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
     } else {
         validate_schema = defaults::VALIDATE_SCHEMA;
     }
+    run_as_user = settings.value("run_as_user", "");
 }
 
 ModuleCallbacks::ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -63,6 +63,8 @@ properties:
         type: boolean
       validate_schema:
         type: boolean
+      run_as_user:
+        type: string
     additionalProperties: false
   active_modules:
     type: object
@@ -78,6 +80,11 @@ properties:
             type: string
             #  module name
             pattern: ^[a-zA-Z_][a-zA-Z0-9_-]*$
+          capabilities:
+            description: Linux capabilities required to run this module
+            type: array
+            items:
+              type: string
           config_module:
             description: Config map for the module
             $ref: '#/$defs/config_map'

--- a/schemas/manifest.yaml
+++ b/schemas/manifest.yaml
@@ -32,14 +32,6 @@ properties:
   description:
     type: string
     minLength: 2
-  capabilities:
-    description: linux capabilities this module should have (allowlist)
-    type: array
-    minItems: 0
-    items:
-      type: string
-      minLength: 6
-    default: []
   config:
     description: >-
       Config set for this module (and possibly default values) declared

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,15 @@
-add_executable(manager manager.cpp)
+add_executable(manager)
+target_sources(manager
+    PRIVATE
+        system_unix.cpp
+        manager.cpp
+)
 
 target_link_libraries(manager
     PRIVATE
         everest::framework
         Boost::program_options
+        PkgConfig::libcap
 )
 
 if (EVEREST_ENABLE_ADMIN_PANEL_BACKEND)

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -636,8 +636,8 @@ int boot(const po::variables_map& vm) {
     int wstatus;
 
     // switch to system user
-#warning "need to add this back"
-    // set_user_and_capabilities(rs->run_as_user, "");
+#warning "allow manager to switch back to root user to restart modules if needed"
+    Everest::system::set_real_user(rs->run_as_user);
 
     while (true) {
         // check if anyone died
@@ -677,8 +677,10 @@ int boot(const po::variables_map& vm) {
         }
 
         if (module_handles.size() == 0 && restart_modules) {
+            // FIXME: switch to root user
             module_handles = start_modules(*config, mqtt_abstraction, ignored_modules, standalone_modules, rs,
                                            status_fifo, err_manager);
+            // FIXME: switch to regular user again
             restart_modules = false;
             modules_started = true;
         }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -235,7 +235,6 @@ static std::map<pid_t, std::string> spawn_modules(const std::vector<ModuleStartI
             try {
                 exec_module(rs, module, proc_handle);
             } catch (const std::exception& err) {
-                // FIXME (aw): seems like other processes don't get killed, when this happens
                 proc_handle.send_error_and_exit(err.what());
             }
         }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -514,6 +514,8 @@ int boot(const po::variables_map& vm) {
         EVLOG_info << "EVerest will run as system user: " << rs->run_as_user;
     }
 
+    auto controller_handle = start_controller(rs);
+
     EVLOG_verbose << fmt::format("EVerest prefix was set to {}", rs->prefix.string());
 
     // dump all manifests if requested and terminate afterwards
@@ -624,10 +626,10 @@ int boot(const po::variables_map& vm) {
         mqtt_abstraction.register_handler(rs->mqtt_everest_prefix + topic, token, QOS::QOS2);
     };
     std::string request_clear_error_topic = "request-clear-error";
+
     error::ErrorManager err_manager = error::ErrorManager(send_json_message, register_call_handler,
                                                           register_error_handler, request_clear_error_topic);
 
-    auto controller_handle = start_controller(rs);
     auto module_handles =
         start_modules(*config, mqtt_abstraction, ignored_modules, standalone_modules, rs, status_fifo, err_manager);
     bool modules_started = true;

--- a/src/system_unix.cpp
+++ b/src/system_unix.cpp
@@ -129,7 +129,6 @@ std::string set_real_user(const std::string& user_name) {
 }
 
 void SubProcess::send_error_and_exit(const std::string& message) {
-    // FIXME (aw): howto do asserts?
     assert(pid == 0);
 
     write(fd, message.c_str(), std::min(message.size(), MAX_PIPE_MESSAGE_SIZE - 1));
@@ -137,7 +136,6 @@ void SubProcess::send_error_and_exit(const std::string& message) {
     _exit(EXIT_FAILURE);
 }
 
-// FIXME (aw): this function should be callable only once
 pid_t SubProcess::check_child_executed() {
     assert(pid != 0);
 

--- a/src/system_unix.cpp
+++ b/src/system_unix.cpp
@@ -79,7 +79,6 @@ std::string set_caps(const std::vector<std::string>& capabilities) {
         }
     }
 
-    // FIXME (aw): error handling!
     auto cap_ctx = cap_get_proc();
     if (cap_set_flag(cap_ctx, CAP_INHERITABLE, capability_values.size(), capability_values.data(), CAP_SET) != 0) {
         return "Failed to add capability flags to CAP_INHERITABLE";
@@ -141,6 +140,11 @@ void SubProcess::send_error_and_exit(const std::string& message) {
 // FIXME (aw): this function should be callable only once
 pid_t SubProcess::check_child_executed() {
     assert(pid != 0);
+
+    if (check_child_executed_done) {
+        return pid;
+    }
+    check_child_executed_done = true;
 
     std::string message(MAX_PIPE_MESSAGE_SIZE, 0);
 

--- a/src/system_unix.cpp
+++ b/src/system_unix.cpp
@@ -179,9 +179,12 @@ SubProcess SubProcess::create(const std::string& run_as_user, const std::vector<
             }
 
             // Set real user for child process
-            auto error = system::set_real_user(run_as_user);
-            if (not error.empty()) {
-                throw std::runtime_error(fmt::format("Failed to set real user to: {}", run_as_user));
+            std::string error;
+            if (not run_as_user.empty()) {
+                error = system::set_real_user(run_as_user);
+                if (not error.empty()) {
+                    throw std::runtime_error(fmt::format("Failed to set real user to: {}", run_as_user));
+                }
             }
 
             // Set capabilities for child process

--- a/src/system_unix.cpp
+++ b/src/system_unix.cpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include "system_unix.hpp"
+
+#include <cassert>
+#include <stdexcept>
+
+#include <fcntl.h>
+#include <grp.h>
+#include <linux/securebits.h>
+#include <pwd.h>
+#include <signal.h>
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+#include <fmt/core.h>
+
+namespace Everest::system {
+
+const auto PARENT_DIED_SIGNAL = SIGTERM;
+
+struct GetPasswdEntryResult {
+    explicit GetPasswdEntryResult(const std::string& error_) : error(error_) {
+    }
+
+    GetPasswdEntryResult(uid_t uid_, gid_t gid_, const std::vector<gid_t>& groups_) : uid(uid_), gid(gid_), groups(groups_) {
+    }
+
+    std::string error;
+    uid_t uid;
+    gid_t gid;
+    std::vector<gid_t> groups;
+
+    operator bool() const {
+        return this->error.empty();
+    }
+};
+
+static GetPasswdEntryResult get_passwd_entry(const std::string& user_name) {
+    // Assuming that a user does not have more than 50 groups
+    constexpr int max_supplementary_groups = 50;
+
+    const auto entry = getpwnam(user_name.c_str());
+
+    if (not entry) {
+        return GetPasswdEntryResult("Could not get passwd entry for user name: " + user_name);
+    }
+
+    // get supplementary groups for this user
+    int max_ngroups = max_supplementary_groups;
+    gid_t groups[max_supplementary_groups];
+
+    int ngroups = getgrouplist(user_name.c_str(), entry->pw_gid, groups, &max_ngroups);
+    if (ngroups < 0) {
+        return GetPasswdEntryResult("Could not get supplementary groups for user name: " + user_name);
+    }
+
+    return GetPasswdEntryResult(entry->pw_uid, entry->pw_gid, std::vector<gid_t>(groups, groups + ngroups));
+}
+
+bool keep_caps() {
+    return (0 == cap_set_secbits(SECBIT_KEEP_CAPS));
+}
+
+std::string set_caps(const std::vector<std::string>& capabilities) {
+
+    std::vector<cap_value_t> capability_values;
+    capability_values.resize(capabilities.size());
+
+    for (const auto& cap_name : capabilities) {
+        auto& cap_value = capability_values.emplace_back();
+        const auto error = cap_from_name(cap_name.c_str(), &cap_value);
+
+        if (error) {
+            return fmt::format("Failed to get capability value for capability name {}", cap_name);
+        }
+    }
+
+    // FIXME (aw): error handling!
+    auto cap_ctx = cap_get_proc();
+    cap_set_flag(cap_ctx, CAP_INHERITABLE, capability_values.size(), capability_values.data(), CAP_SET);
+    cap_set_proc(cap_ctx);
+    cap_free(cap_ctx);
+
+    for (const auto cap_value : capability_values) {
+        cap_set_ambient(cap_value, CAP_SET);
+    }
+
+    return {};
+}
+
+std::string set_real_user(const std::string& user_name) {
+    // Set special capabilities if required by module
+
+    const auto entry = get_passwd_entry(user_name);
+
+    if (not entry) {
+        return entry.error;
+    }
+
+    const auto set_groups_failed = setgroups(entry.groups.size(), entry.groups.data());
+    if (set_groups_failed) {
+        return "setgroups failed";
+    }
+
+    const auto set_gid_failed = setgid(entry.gid);
+    if (set_gid_failed) {
+        return "setgid failed";
+    }
+
+    const auto set_uid_failed = setuid(entry.uid);
+    if (set_uid_failed) {
+        return "setuid failed";
+    }
+
+    return {};
+}
+
+void SubProcess::send_error_and_exit(const std::string& message) {
+    // FIXME (aw): howto do asserts?
+    assert(pid == 0);
+
+    write(fd, message.c_str(), std::min(message.size(), MAX_PIPE_MESSAGE_SIZE - 1));
+    close(fd);
+    _exit(EXIT_FAILURE);
+}
+
+// FIXME (aw): this function should be callable only once
+pid_t SubProcess::check_child_executed() {
+    assert(pid != 0);
+
+    std::string message(MAX_PIPE_MESSAGE_SIZE, 0);
+
+    auto retval = read(fd, message.data(), MAX_PIPE_MESSAGE_SIZE);
+    if (retval == -1) {
+        throw std::runtime_error(fmt::format(
+            "Failed to communicate via pipe with forked child process. Syscall to read() failed ({}), exiting",
+            strerror(errno)));
+    } else if (retval > 0) {
+        throw std::runtime_error(fmt::format("Forked child process did not complete exec():\n{}", message.c_str()));
+    }
+
+    close(fd);
+    return pid;
+}
+
+SubProcess SubProcess::create(bool set_pdeathsig) {
+    int pipefd[2];
+
+    if (pipe2(pipefd, O_CLOEXEC | O_DIRECT)) {
+        throw std::runtime_error(fmt::format("Syscall pipe2() failed ({}), exiting", strerror(errno)));
+    }
+
+    const auto reading_end_fd = pipefd[0];
+    const auto writing_end_fd = pipefd[1];
+
+    const auto parent_pid = getpid();
+
+    pid_t pid = fork();
+
+    if (pid == -1) {
+        throw std::runtime_error(fmt::format("Syscall fork() failed ({}), exiting", strerror(errno)));
+    }
+
+    if (pid == 0) {
+        // close read end in child
+        close(reading_end_fd);
+
+        SubProcess handle{writing_end_fd, pid};
+
+        // if (not capabilities.empty()) {
+        //     set_caps(capabilities);
+        // }
+
+        // if (not effective_user.empty()) {
+        //     set_user(effective_user);
+        // }
+
+        if (set_pdeathsig) {
+            // FIXME (aw): how does the the forked process does cleanup when receiving PARENT_DIED_SIGNAL compared to
+            //             _exit() before exec() has been called?
+            if (prctl(PR_SET_PDEATHSIG, PARENT_DIED_SIGNAL)) {
+                handle.send_error_and_exit(fmt::format("Syscall prctl() failed ({}), exiting", strerror(errno)));
+            }
+
+            if (getppid() != parent_pid) {
+                // kill ourself, with the same handler as we would have
+                // happened when the parent process died
+                kill(getpid(), PARENT_DIED_SIGNAL);
+            }
+        }
+
+        return handle;
+    } else {
+        close(writing_end_fd);
+        return {reading_end_fd, pid};
+    }
+}
+
+} // namespace Everest::system

--- a/src/system_unix.cpp
+++ b/src/system_unix.cpp
@@ -81,12 +81,22 @@ std::string set_caps(const std::vector<std::string>& capabilities) {
 
     // FIXME (aw): error handling!
     auto cap_ctx = cap_get_proc();
-    cap_set_flag(cap_ctx, CAP_INHERITABLE, capability_values.size(), capability_values.data(), CAP_SET);
-    cap_set_proc(cap_ctx);
-    cap_free(cap_ctx);
+    if (cap_set_flag(cap_ctx, CAP_INHERITABLE, capability_values.size(), capability_values.data(), CAP_SET) != 0) {
+        return "Failed to add capability flags to CAP_INHERITABLE";
+    }
+
+    if (cap_set_proc(cap_ctx) != 0) {
+        return "Failed to set capabilities for process";
+    };
+
+    if (cap_free(cap_ctx) != 0) {
+        return "Failed free memory for capability flags";
+    };
 
     for (const auto cap_value : capability_values) {
-        cap_set_ambient(cap_value, CAP_SET);
+        if (cap_set_ambient(cap_value, CAP_SET) != 0) {
+            return "Failed to add capabilities to ambient set";
+        }
     }
 
     return {};

--- a/src/system_unix.hpp
+++ b/src/system_unix.hpp
@@ -12,7 +12,7 @@ namespace Everest::system {
 
 class SubProcess {
 public:
-    static SubProcess create(bool set_pdeathsig = true);
+    static SubProcess create(const std::string& run_as_user, const std::vector<std::string>& capabilities = {});
     bool is_child() const {
         return this->pid == 0;
     }

--- a/src/system_unix.hpp
+++ b/src/system_unix.hpp
@@ -35,4 +35,6 @@ std::string set_caps(const std::vector<std::string>& capabilities);
 
 std::string set_real_user(const std::string& user_name);
 
+std::string set_user_and_capabilities(const std::string& run_as_user, const std::vector<std::string>& capabilities);
+
 } // namespace Everest::system

--- a/src/system_unix.hpp
+++ b/src/system_unix.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <sys/types.h>
+
+namespace Everest::system {
+
+class SubProcess {
+public:
+    static SubProcess create(bool set_pdeathsig = true);
+    bool is_child() const {
+        return this->pid == 0;
+    }
+
+    void send_error_and_exit(const std::string& message);
+
+    // FIXME (aw): this function should be callable only once
+    pid_t check_child_executed();
+
+private:
+    const size_t MAX_PIPE_MESSAGE_SIZE = 1024;
+    SubProcess(int fd, pid_t pid) : fd(fd), pid(pid){};
+    int fd{};
+    pid_t pid{};
+};
+
+bool keep_caps();
+
+std::string set_caps(const std::vector<std::string>& capabilities);
+
+std::string set_real_user(const std::string& user_name);
+
+} // namespace Everest::system

--- a/src/system_unix.hpp
+++ b/src/system_unix.hpp
@@ -19,14 +19,14 @@ public:
 
     void send_error_and_exit(const std::string& message);
 
-    // FIXME (aw): this function should be callable only once
     pid_t check_child_executed();
 
 private:
     const size_t MAX_PIPE_MESSAGE_SIZE = 1024;
     SubProcess(int fd, pid_t pid) : fd(fd), pid(pid){};
     int fd{};
-    pid_t pid{};
+    pid_t pid{0};
+    bool check_child_executed_done{false};
 };
 
 bool keep_caps();


### PR DESCRIPTION
When setting system_user="myuser" property under settings in a config file all modules are started as this user and its default gid.

After starting all modules the manager also switches to this user.

For each module, special Linux capabilities can be specified with e.g. capabilities: "cap_chown+ep"
in the module section.

The manager will need to start as root or sufficient capabilities to do that. If no user/capabilities are specified no change happens.