### PR TITLE
Only load & validate type files in manager or when validate_schemas set

### DIFF
--- a/everestjs/index.js
+++ b/everestjs/index.js
@@ -31,6 +31,7 @@ const EverestModule = function EverestModule(handler_setup, user_settings) {
     config_file: process.env.EV_CONF_FILE,
     mqtt_server_address: process.env.MQTT_SERVER_ADDRESS,
     mqtt_server_port: process.env.MQTT_SERVER_PORT,
+    validate_schema: process.env.EV_VALIDATE_SCHEMA,
   };
 
   const settings = { ...env_settings, ...user_settings };
@@ -43,7 +44,7 @@ const EverestModule = function EverestModule(handler_setup, user_settings) {
     module: settings.module,
     prefix: settings.prefix,
     config_file: settings.config_file,
-    validate_schema: helpers.get_default(settings, 'validate_schema', true),
+    validate_schema: helpers.get_default(settings, 'validate_schema', false),
   };
 
   function callbackWrapper(on, request, ...args) {

--- a/everestpy/src/everest/misc.cpp
+++ b/everestpy/src/everest/misc.cpp
@@ -24,18 +24,16 @@ static std::string get_ev_conf_file_from_env() {
 }
 
 RuntimeSession::RuntimeSession(const std::string& prefix, const std::string& config_file) :
-    rs(prefix, config_file), config(create_config_instance(rs)) {
+    rs(std::make_shared<Everest::RuntimeSettings>(prefix, config_file)), config(create_config_instance(rs)) {
 }
 
 RuntimeSession::RuntimeSession() : RuntimeSession(get_ev_prefix_from_env(), get_ev_conf_file_from_env()) {
 }
 
-std::unique_ptr<Everest::Config> RuntimeSession::create_config_instance(const Everest::RuntimeSettings& rs) {
+std::unique_ptr<Everest::Config> RuntimeSession::create_config_instance(std::shared_ptr<Everest::RuntimeSettings> rs) {
     // FIXME (aw): where to initialize the logger?
-    Everest::Logging::init(rs.logging_config_file);
-    return std::make_unique<Everest::Config>(rs.schemas_dir.string(), rs.config_file.string(), rs.modules_dir.string(),
-                                             rs.interfaces_dir.string(), rs.types_dir.string(), rs.mqtt_everest_prefix,
-                                             rs.mqtt_external_prefix);
+    Everest::Logging::init(rs->logging_config_file);
+    return std::make_unique<Everest::Config>(rs);
 }
 
 ModuleSetup create_setup_from_config(const std::string& module_id, Everest::Config& config) {

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -13,7 +13,7 @@ public:
 
     RuntimeSession();
 
-    const Everest::RuntimeSettings& get_runtime_settings() const {
+    std::shared_ptr<Everest::RuntimeSettings> get_runtime_settings() const {
         return rs;
     }
 
@@ -22,10 +22,10 @@ public:
     }
 
 private:
-    Everest::RuntimeSettings rs;
+    std::shared_ptr<Everest::RuntimeSettings> rs;
     std::unique_ptr<Everest::Config> config;
 
-    static std::unique_ptr<Everest::Config> create_config_instance(const Everest::RuntimeSettings& rs);
+    static std::unique_ptr<Everest::Config> create_config_instance(std::shared_ptr<Everest::RuntimeSettings> rs);
 };
 
 struct Fulfillment {

--- a/everestpy/src/everest/module.cpp
+++ b/everestpy/src/everest/module.cpp
@@ -7,9 +7,9 @@
 std::unique_ptr<Everest::Everest> Module::create_everest_instance(const std::string& module_id,
                                                                   const RuntimeSession& session) {
     const auto& rs = session.get_runtime_settings();
-    return std::make_unique<Everest::Everest>(module_id, session.get_config(), true /* FIXME */, rs.mqtt_broker_host,
-                                              rs.mqtt_broker_port, rs.mqtt_everest_prefix, rs.mqtt_external_prefix,
-                                              rs.telemetry_prefix, rs.telemetry_enabled);
+    return std::make_unique<Everest::Everest>(module_id, session.get_config(), rs->validate_schema,
+                                              rs->mqtt_broker_host, rs->mqtt_broker_port, rs->mqtt_everest_prefix,
+                                              rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
 }
 
 static std::string get_ev_module_from_env() {

--- a/everestrs/everestrs_sys/everestrs_sys.cpp
+++ b/everestrs/everestrs_sys/everestrs_sys.cpp
@@ -8,19 +8,17 @@
 namespace {
 
 std::unique_ptr<Everest::Everest> create_everest_instance(const std::string& module_id,
-                                                          const Everest::RuntimeSettings& rs,
+                                                          std::shared_ptr<RuntimeSettings> rs,
                                                           const Everest::Config& config) {
-    return std::make_unique<Everest::Everest>(module_id, config, true /* FIXME */, rs.mqtt_broker_host,
-                                              rs.mqtt_broker_port, rs.mqtt_everest_prefix, rs.mqtt_external_prefix,
-                                              rs.telemetry_prefix, rs.telemetry_enabled);
+    return std::make_unique<Everest::Everest>(module_id, config, , rs->validate_schema, rs->mqtt_broker_host,
+                                              rs->mqtt_broker_port, rs->mqtt_everest_prefix, rs->mqtt_external_prefix,
+                                              rs->telemetry_prefix, rs->telemetry_enabled);
 }
 
-std::unique_ptr<Everest::Config> create_config_instance(const Everest::RuntimeSettings& rs) {
+std::unique_ptr<Everest::Config> create_config_instance(std::shared_ptr<RuntimeSettings> rs) {
     // FIXME (aw): where to initialize the logger?
-    Everest::Logging::init(rs.logging_config_file);
-    return std::make_unique<Everest::Config>(rs.schemas_dir.string(), rs.config_file.string(), rs.modules_dir.string(),
-                                             rs.interfaces_dir.string(), rs.types_dir.string(), rs.mqtt_everest_prefix,
-                                             rs.mqtt_external_prefix);
+    Everest::Logging::init(rs->logging_config_file);
+    return std::make_unique<Everest::Config>(rs);
 }
 
 JsonBlob json2blob(const json& j) {

--- a/everestrs/everestrs_sys/everestrs_sys.hpp
+++ b/everestrs/everestrs_sys/everestrs_sys.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
     const std::string module_id_;
-    Everest::RuntimeSettings rs_;
+    std::shared_ptr<Everest::RuntimeSettings> rs_;
     std::unique_ptr<Everest::Config> config_;
     std::unique_ptr<Everest::Everest> handle_;
 };

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -36,7 +36,7 @@ using TelemetryMap = std::map<std::string, TelemetryEntry>;
 ///
 class Everest {
 public:
-    Everest(std::string module_id, Config config, bool validate_data_with_schema,
+    Everest(std::string module_id, const Config& config, bool validate_data_with_schema,
             const std::string& mqtt_server_address, int mqtt_server_port, const std::string& mqtt_everest_prefix,
             const std::string& mqtt_external_prefix, const std::string& telemetry_prefix, bool telemetry_enabled);
 

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -79,6 +79,7 @@ inline constexpr auto MQTT_EVEREST_PREFIX = "everest";
 inline constexpr auto MQTT_EXTERNAL_PREFIX = "";
 inline constexpr auto TELEMETRY_PREFIX = "everest-telemetry";
 inline constexpr auto TELEMETRY_ENABLED = false;
+inline constexpr auto VALIDATE_SCHEMA = false;
 
 } // namespace defaults
 
@@ -120,7 +121,7 @@ struct RuntimeSettings {
 };
 
 // NOTE: this function needs the be called with a pre-initialized ModuleInfo struct
-void populate_module_info_path_from_runtime_settings(ModuleInfo&, const RuntimeSettings& rs);
+void populate_module_info_path_from_runtime_settings(ModuleInfo&, std::shared_ptr<RuntimeSettings> rs);
 
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;
@@ -138,7 +139,7 @@ struct ModuleCallbacks {
 
 class ModuleLoader {
 private:
-    std::unique_ptr<RuntimeSettings> runtime_settings;
+    std::shared_ptr<RuntimeSettings> runtime_settings;
     std::string module_id;
     std::string original_process_name;
     ModuleCallbacks callbacks;

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -87,6 +87,7 @@ std::string parse_string_option(const boost::program_options::variables_map& vm,
 
 const auto TERMINAL_STYLE_ERROR = fmt::emphasis::bold | fg(fmt::terminal_color::red);
 const auto TERMINAL_STYLE_OK = fmt::emphasis::bold | fg(fmt::terminal_color::green);
+const auto TERMINAL_STYLE_BLUE = fmt::emphasis::bold | fg(fmt::terminal_color::blue);
 
 struct BootException : public std::runtime_error {
     using std::runtime_error::runtime_error;

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -21,6 +21,7 @@ using json_uri = nlohmann::json_uri;
 using json_validator = nlohmann::json_schema::json_validator;
 namespace fs = std::filesystem;
 
+struct RuntimeSettings;
 ///
 /// \brief A structure that contains all available schemas
 ///
@@ -41,12 +42,8 @@ const static std::regex type_uri_regex{R"(^((?:\/[a-zA-Z0-9\-\_]+)+#\/[a-zA-Z0-9
 ///
 class Config {
 private:
-    std::string schemas_dir;
-    std::string modules_dir;
-    std::string interfaces_dir;
-    std::string types_dir;
-    std::string mqtt_everest_prefix;
-    std::string mqtt_external_prefix;
+    std::shared_ptr<RuntimeSettings> rs;
+    bool manager;
 
     json main;
 
@@ -98,11 +95,9 @@ public:
     bool module_provides(const std::string& module_name, const std::string& impl_id);
     json get_module_cmds(const std::string& module_name, const std::string& impl_id);
     ///
-    /// \brief creates a new Config object, looking for the config.json and schemes folder relative to the provided \p
-    /// main_dir
-    explicit Config(std::string schemas_dir, std::string config_file, std::string modules_dir,
-                    std::string interfaces_dir, std::string types_dir, const std::string& mqtt_everest_prefix,
-                    const std::string& mqtt_external_prefix);
+    /// \brief creates a new Config object
+    explicit Config(std::shared_ptr<RuntimeSettings> rs);
+    explicit Config(std::shared_ptr<RuntimeSettings> rs, bool manager);
 
     ///
     /// \brief checks if the given \p module_id provides the requirement given in \p requirement_id
@@ -185,7 +180,7 @@ public:
     /// the provided \p schemas_dir
     ///
     /// \returns the config and manifest schemas
-    static schemas load_schemas(std::string schemas_dir);
+    static schemas load_schemas(const fs::path& schemas_dir);
 
     ///
     /// \brief loads and validates a json schema at the provided \p path
@@ -197,7 +192,7 @@ public:
     /// \brief loads all module manifests relative to the \p main_dir
     ///
     /// \returns all module manifests as a json object
-    static json load_all_manifests(std::string modules_dir, std::string schemas_dir);
+    static json load_all_manifests(const std::string& modules_dir, const std::string& schemas_dir);
 
     ///
     /// \brief Extracts the keys of the provided json \p object

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -10,6 +10,7 @@
 #include <everest/exceptions.hpp>
 #include <everest/logging.hpp>
 
+#include <framework/runtime.hpp>
 #include <utils/config.hpp>
 #include <utils/formatter.hpp>
 #include <utils/yaml_loader.hpp>
@@ -239,7 +240,7 @@ void Config::load_and_validate_manifest(const std::string& module_id, const json
     EVLOG_debug << fmt::format("Found module {}, loading and verifying manifest...", printable_identifier(module_id));
 
     // load and validate module manifest.json
-    fs::path manifest_path = fs::path(modules_dir) / module_name / "manifest.yaml";
+    fs::path manifest_path = this->rs->modules_dir / module_name / "manifest.yaml";
     try {
         EVLOG_debug << fmt::format("Loading module manifest file at: {}", fs::canonical(manifest_path).string());
 
@@ -364,42 +365,36 @@ void Config::load_and_validate_manifest(const std::string& module_id, const json
     }
 }
 
-Config::Config(std::string schemas_dir, std::string config_file, std::string modules_dir, std::string interfaces_dir,
-               std::string types_dir, const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix) {
-    BOOST_LOG_FUNCTION();
+Config::Config(std::shared_ptr<RuntimeSettings> rs) : Config(rs, false) {
+}
 
-    this->schemas_dir = schemas_dir;
-    this->modules_dir = modules_dir;
-    this->interfaces_dir = interfaces_dir;
-    this->types_dir = types_dir;
-    this->mqtt_everest_prefix = mqtt_everest_prefix;
-    this->mqtt_external_prefix = mqtt_external_prefix;
+Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), manager(manager) {
+    BOOST_LOG_FUNCTION();
 
     this->manifests = json({});
     this->interfaces = json({});
     this->interface_definitions = json({});
     this->types = json({});
-
-    this->_schemas = Config::load_schemas(this->schemas_dir);
+    this->_schemas = Config::load_schemas(this->rs->schemas_dir);
 
     // load and process config file
-    fs::path config_path = config_file;
+    fs::path config_path = rs->config_file;
 
     try {
-        EVLOG_debug << fmt::format("Loading config file at: {}", fs::canonical(config_path).string());
-
+        if (manager) {
+            EVLOG_info << fmt::format("Loading config file at: {}", fs::canonical(config_path).string());
+        }
         auto complete_config = load_yaml(config_path);
-
         // try to load user config from a directory "user-config" that might be in the same parent directory as the
         // config_file. The config is supposed to have the same name as the parent config.
         // TODO(kai): introduce a parameter that can overwrite the location of the user config?
         // TODO(kai): or should we introduce a "meta-config" that references all configs that should be merged here?
         auto user_config_path = config_path.parent_path() / "user-config" / config_path.filename();
         if (fs::exists(user_config_path)) {
-            EVLOG_debug << fmt::format("Loading user-config file at: {}", fs::canonical(user_config_path).string());
-
+            if (manager) {
+                EVLOG_info << fmt::format("Loading user-config file at: {}", fs::canonical(user_config_path).string());
+            }
             auto user_config = load_yaml(user_config_path);
-
             EVLOG_debug << "Augmenting main config with user-config entries";
             complete_config.merge_patch(user_config);
         } else {
@@ -421,25 +416,37 @@ Config::Config(std::string schemas_dir, std::string config_file, std::string mod
     }
 
     // load type files
-    auto types_path = fs::path(this->types_dir);
-    for (auto const& types_entry : fs::recursive_directory_iterator(types_path)) {
-        auto const& type_file_path = types_entry.path();
-        if (fs::is_regular_file(type_file_path) && type_file_path.extension() == ".yaml") {
-            auto type_path = std::string("/") + fs::relative(type_file_path, types_path).stem().string();
-            try {
-                // load and validate type file, store validated result in this->types
-                EVLOG_verbose << fmt::format("Loading type file at: {}", fs::canonical(type_file_path).c_str());
+    if (manager or rs->validate_schema) {
+        for (auto const& types_entry : fs::recursive_directory_iterator(this->rs->types_dir)) {
+            auto start_time = std::chrono::system_clock::now();
+            auto const& type_file_path = types_entry.path();
+            if (fs::is_regular_file(type_file_path) && type_file_path.extension() == ".yaml") {
+                auto type_path = std::string("/") + fs::relative(type_file_path, this->rs->types_dir).stem().string();
 
-                json type_json = load_yaml(type_file_path);
-                json_validator validator(Config::loader, Config::format_checker);
-                validator.set_root_schema(this->_schemas.type);
-                validator.validate(type_json);
+                try {
+                    // load and validate type file, store validated result in this->types
+                    EVLOG_verbose << fmt::format("Loading type file at: {}", fs::canonical(type_file_path).c_str());
+                    json type_json = load_yaml(type_file_path);
+                    auto start_time_validate = std::chrono::system_clock::now();
+                    json_validator validator(Config::loader, Config::format_checker);
+                    validator.set_root_schema(this->_schemas.type);
+                    validator.validate(type_json);
+                    auto end_time_validate = std::chrono::system_clock::now();
+                    EVLOG_info << "YAML validation of " << types_entry.path().string() << " took: "
+                               << std::chrono::duration_cast<std::chrono::milliseconds>(end_time_validate -
+                                                                                        start_time_validate)
+                                      .count()
+                               << "ms";
 
-                this->types[type_path] = type_json["types"];
-            } catch (const std::exception& e) {
-                EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse type file '{}', reason: {}",
-                                                               type_file_path.string(), e.what())));
+                    this->types[type_path] = type_json["types"];
+                } catch (const std::exception& e) {
+                    EVLOG_AND_THROW(EverestConfigError(fmt::format(
+                        "Failed to load and parse type file '{}', reason: {}", type_file_path.string(), e.what())));
+                }
             }
+            auto end_time = std::chrono::system_clock::now();
+            EVLOG_info << "Parsing of type " << types_entry.path().string() << " took: "
+                       << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
         }
     }
 
@@ -505,7 +512,7 @@ json Config::resolve_interface(const std::string& intf_name) {
 
 json Config::load_interface_file(const std::string& intf_name) {
     BOOST_LOG_FUNCTION();
-    fs::path intf_path = fs::path(this->interfaces_dir) / (intf_name + ".yaml");
+    fs::path intf_path = this->rs->interfaces_dir / (intf_name + ".yaml");
     try {
         EVLOG_debug << fmt::format("Loading interface file at: {}", fs::canonical(intf_path).string());
 
@@ -672,20 +679,20 @@ json Config::load_schema(const fs::path& path) {
     return schema;
 }
 
-schemas Config::load_schemas(std::string schemas_dir) {
+schemas Config::load_schemas(const fs::path& schemas_dir) {
     BOOST_LOG_FUNCTION();
     schemas schemas;
 
-    EVLOG_debug << fmt::format("Loading base schema files for config and manifests... from: {}", schemas_dir);
-    schemas.config = Config::load_schema(fs::path(schemas_dir) / "config.yaml");
-    schemas.manifest = Config::load_schema(fs::path(schemas_dir) / "manifest.yaml");
-    schemas.interface = Config::load_schema(fs::path(schemas_dir) / "interface.yaml");
-    schemas.type = Config::load_schema(fs::path(schemas_dir) / "type.yaml");
+    EVLOG_debug << fmt::format("Loading base schema files for config and manifests... from: {}", schemas_dir.string());
+    schemas.config = Config::load_schema(schemas_dir / "config.yaml");
+    schemas.manifest = Config::load_schema(schemas_dir / "manifest.yaml");
+    schemas.interface = Config::load_schema(schemas_dir / "interface.yaml");
+    schemas.type = Config::load_schema(schemas_dir / "type.yaml");
 
     return schemas;
 }
 
-json Config::load_all_manifests(std::string modules_dir, std::string schemas_dir) {
+json Config::load_all_manifests(const std::string& modules_dir, const std::string& schemas_dir) {
     BOOST_LOG_FUNCTION();
 
     json manifests = json({});
@@ -840,13 +847,13 @@ std::optional<TelemetryConfig> Config::get_telemetry_config(const std::string& m
 std::string Config::mqtt_prefix(const std::string& module_id, const std::string& impl_id) {
     BOOST_LOG_FUNCTION();
 
-    return fmt::format("{}{}/{}", this->mqtt_everest_prefix, module_id, impl_id);
+    return fmt::format("{}{}/{}", this->rs->mqtt_everest_prefix, module_id, impl_id);
 }
 
 std::string Config::mqtt_module_prefix(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
-    return fmt::format("{}{}", this->mqtt_everest_prefix, module_id);
+    return fmt::format("{}{}", this->rs->mqtt_everest_prefix, module_id);
 }
 
 json Config::extract_implementation_info(const std::string& module_id, const std::string& impl_id) {

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -416,8 +416,8 @@ Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), mana
     }
 
     // load type files
-    int total_time_validation_ms = 0, total_time_parsing_ms = 0;
     if (manager or rs->validate_schema) {
+        int total_time_validation_ms = 0, total_time_parsing_ms = 0;
         for (auto const& types_entry : fs::recursive_directory_iterator(this->rs->types_dir)) {
             auto start_time = std::chrono::system_clock::now();
             auto const& type_file_path = types_entry.path();

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -22,7 +22,7 @@ namespace Everest {
 const auto remote_cmd_res_timeout_seconds = 300;
 const std::array<std::string, 3> TELEMETRY_RESERVED_KEYS = {{"connector_id"}};
 
-Everest::Everest(std::string module_id_, Config config_, bool validate_data_with_schema,
+Everest::Everest(std::string module_id_, const Config& config_, bool validate_data_with_schema,
                  const std::string& mqtt_server_address, int mqtt_server_port, const std::string& mqtt_everest_prefix,
                  const std::string& mqtt_external_prefix, const std::string& telemetry_prefix, bool telemetry_enabled) :
     mqtt_abstraction(mqtt_server_address, std::to_string(mqtt_server_port), mqtt_everest_prefix, mqtt_external_prefix),

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -446,7 +446,7 @@ void Everest::telemetry_publish(const std::string& category, const std::string& 
 void Everest::signal_ready() {
     BOOST_LOG_FUNCTION();
 
-    EVLOG_info << "Module " << this->module_id << " initialized.";
+    // EVLOG_info << "Module " << this->module_id << " initialized.";
     const auto ready_topic = fmt::format("{}/ready", this->config.mqtt_module_prefix(this->module_id));
 
     this->mqtt_abstraction.publish(ready_topic, json(true));

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -69,10 +69,10 @@ static std::string get_prefixed_path_from_json(const nlohmann::json& value, cons
     return settings_configs_dir;
 }
 
-void populate_module_info_path_from_runtime_settings(ModuleInfo& mi, const RuntimeSettings& rs) {
-    mi.paths.etc = rs.etc_dir;
-    mi.paths.libexec = rs.modules_dir / mi.name;
-    mi.paths.share = rs.data_dir / defaults::MODULES_DIR / mi.name;
+void populate_module_info_path_from_runtime_settings(ModuleInfo& mi, std::shared_ptr<RuntimeSettings> rs) {
+    mi.paths.etc = rs->etc_dir;
+    mi.paths.libexec = rs->modules_dir / mi.name;
+    mi.paths.share = rs->data_dir / defaults::MODULES_DIR / mi.name;
 }
 
 RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& config_) {
@@ -317,7 +317,13 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
     } else {
         telemetry_enabled = defaults::TELEMETRY_ENABLED;
     }
-    validate_schema = false;
+
+    const auto settings_validate_schema_it = settings.find("validate_schema");
+    if (settings_validate_schema_it != settings.end()) {
+        validate_schema = settings_validate_schema_it->get<bool>();
+    } else {
+        validate_schema = defaults::VALIDATE_SCHEMA;
+    }
 }
 
 ModuleCallbacks::ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
@@ -335,18 +341,15 @@ ModuleLoader::ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks) :
 }
 
 int ModuleLoader::initialize() {
+    auto start_time = std::chrono::system_clock::now();
     if (!this->runtime_settings) {
         return 0;
     }
 
     auto& rs = this->runtime_settings;
-
     Logging::init(rs->logging_config_file.string(), this->module_id);
-
     try {
-        Config config = Config(rs->schemas_dir.string(), rs->config_file.string(), rs->modules_dir.string(),
-                               rs->interfaces_dir.string(), rs->types_dir.string(), rs->mqtt_everest_prefix,
-                               rs->mqtt_external_prefix);
+        Config config = Config(rs);
 
         if (!config.contains(this->module_id)) {
             EVLOG_error << fmt::format("Module id '{}' not found in config!", this->module_id);
@@ -416,7 +419,7 @@ int ModuleLoader::initialize() {
 
         auto module_configs = config.get_module_configs(this->module_id);
         auto module_info = config.get_module_info(this->module_id);
-        populate_module_info_path_from_runtime_settings(module_info, *rs);
+        populate_module_info_path_from_runtime_settings(module_info, rs);
         module_info.telemetry_enabled = everest.is_telemetry_enabled();
 
         this->callbacks.init(module_configs, module_info);
@@ -429,6 +432,11 @@ int ModuleLoader::initialize() {
 
         // the module should now be ready
         everest.signal_ready();
+
+        auto end_time = std::chrono::system_clock::now();
+        EVLOG_info << "Initialization of module " << module_id
+                   << " took: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count()
+                   << "ms";
 
         everest.wait_for_main_loop_end();
 

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -434,9 +434,8 @@ int ModuleLoader::initialize() {
         everest.signal_ready();
 
         auto end_time = std::chrono::system_clock::now();
-        EVLOG_info << "Initialization of module " << module_id
-                   << " took: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count()
-                   << "ms";
+        EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_id) << " initialized ["
+                   << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms]";
 
         everest.wait_for_main_loop_end();
 

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -59,6 +59,8 @@ properties:
         type: string
       telemetry_enabled:
         type: boolean
+      validate_schema:
+        type: boolean
     additionalProperties: false
   active_modules:
     type: object

--- a/src/controller/controller.cpp
+++ b/src/controller/controller.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
 
     Everest::Logging::init(config_params.at("logging_config_file"), "everest_ctrl");
 
-    EVLOG_info << "everest controller process started ...";
+    EVLOG_debug << "everest controller process started ...";
 
     CommandApi::Config config{
         config_params.at("module_dir"),

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -39,6 +39,7 @@ using namespace Everest;
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
 const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
+auto complete_start_time = std::chrono::system_clock::now();
 
 class SubprocessHandle {
 public:
@@ -179,10 +180,10 @@ static std::vector<char*> arguments_to_exec_argv(std::vector<std::string>& argum
     return argv_list;
 }
 
-static SubprocessHandle exec_cpp_module(const ModuleStartInfo& module_info, const RuntimeSettings& rs) {
+static SubprocessHandle exec_cpp_module(const ModuleStartInfo& module_info, std::shared_ptr<RuntimeSettings> rs) {
     const auto exec_binary = module_info.path.c_str();
-    std::vector<std::string> arguments = {module_info.printable_name, "--prefix", rs.prefix.string(), "--conf",
-                                          rs.config_file.string(),    "--module", module_info.name};
+    std::vector<std::string> arguments = {module_info.printable_name, "--prefix", rs->prefix.string(), "--conf",
+                                          rs->config_file.string(),   "--module", module_info.name};
 
     auto handle = create_subprocess();
     if (handle.is_child()) {
@@ -198,18 +199,23 @@ static SubprocessHandle exec_cpp_module(const ModuleStartInfo& module_info, cons
     return handle;
 }
 
-static SubprocessHandle exec_javascript_module(const ModuleStartInfo& module_info, const RuntimeSettings& rs) {
+static SubprocessHandle exec_javascript_module(const ModuleStartInfo& module_info,
+                                               std::shared_ptr<RuntimeSettings> rs) {
     // instead of using setenv, using execvpe might be a better way for a controlled environment!
 
     // FIXME (aw): everest directory layout
-    const auto node_modules_path = rs.prefix / defaults::LIB_DIR / defaults::NAMESPACE / "node_modules";
+    const auto node_modules_path = rs->prefix / defaults::LIB_DIR / defaults::NAMESPACE / "node_modules";
     setenv("NODE_PATH", node_modules_path.c_str(), 0);
 
     setenv("EV_MODULE", module_info.name.c_str(), 1);
-    setenv("EV_PREFIX", rs.prefix.c_str(), 0);
-    setenv("EV_CONF_FILE", rs.config_file.c_str(), 0);
+    setenv("EV_PREFIX", rs->prefix.c_str(), 0);
+    setenv("EV_CONF_FILE", rs->config_file.c_str(), 0);
 
-    if (!rs.validate_schema) {
+    if (rs->validate_schema) {
+        setenv("EV_VALIDATE_SCHEMA", "1", 1);
+    }
+
+    if (!rs->validate_schema) {
         setenv("EV_DONT_VALIDATE_SCHEMA", "", 0);
     }
 
@@ -234,17 +240,21 @@ static SubprocessHandle exec_javascript_module(const ModuleStartInfo& module_inf
     return handle;
 }
 
-static SubprocessHandle exec_python_module(const ModuleStartInfo& module_info, const RuntimeSettings& rs) {
+static SubprocessHandle exec_python_module(const ModuleStartInfo& module_info, std::shared_ptr<RuntimeSettings> rs) {
     // instead of using setenv, using execvpe might be a better way for a controlled environment!
 
-    const auto pythonpath = rs.prefix / defaults::LIB_DIR / defaults::NAMESPACE / "everestpy";
+    const auto pythonpath = rs->prefix / defaults::LIB_DIR / defaults::NAMESPACE / "everestpy";
 
     setenv("EV_MODULE", module_info.name.c_str(), 1);
-    setenv("EV_PREFIX", rs.prefix.c_str(), 0);
-    setenv("EV_CONF_FILE", rs.config_file.c_str(), 0);
+    setenv("EV_PREFIX", rs->prefix.c_str(), 0);
+    setenv("EV_CONF_FILE", rs->config_file.c_str(), 0);
     setenv("PYTHONPATH", pythonpath.c_str(), 0);
 
-    if (!rs.validate_schema) {
+    if (rs->validate_schema) {
+        setenv("EV_VALIDATE_SCHEMA", "1", 1);
+    }
+
+    if (!rs->validate_schema) {
         setenv("EV_DONT_VALIDATE_SCHEMA", "", 0);
     }
 
@@ -266,7 +276,7 @@ static SubprocessHandle exec_python_module(const ModuleStartInfo& module_info, c
 }
 
 static std::map<pid_t, std::string> spawn_modules(const std::vector<ModuleStartInfo>& modules,
-                                                  const RuntimeSettings& rs) {
+                                                  std::shared_ptr<RuntimeSettings> rs) {
     std::map<pid_t, std::string> started_modules;
 
     for (const auto& module : modules) {
@@ -308,7 +318,7 @@ std::mutex modules_ready_mutex;
 static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstraction& mqtt_abstraction,
                                                   const std::vector<std::string>& ignored_modules,
                                                   const std::vector<std::string>& standalone_modules,
-                                                  const RuntimeSettings& rs, StatusFifo& status_fifo) {
+                                                  std::shared_ptr<RuntimeSettings> rs, StatusFifo& status_fifo) {
 
     std::vector<ModuleStartInfo> modules_to_spawn;
 
@@ -327,7 +337,7 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
         auto module_it = modules_ready.emplace(module_name, ModuleReadyInfo{false, nullptr}).first;
 
         Handler module_ready_handler = [module_name, &mqtt_abstraction, standalone_modules,
-                                        mqtt_everest_prefix = rs.mqtt_everest_prefix,
+                                        mqtt_everest_prefix = rs->mqtt_everest_prefix,
                                         &status_fifo](nlohmann::json json) {
             EVLOG_debug << fmt::format("received module ready signal for module: {}({})", module_name, json.dump());
             std::unique_lock<std::mutex> lock(modules_ready_mutex);
@@ -351,6 +361,12 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
                 EVLOG_info << fmt::format(TERMINAL_STYLE_OK,
                                           ">>> All modules are initialized. EVerest up and running <<<");
                 status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
+                auto complete_end_time = std::chrono::system_clock::now();
+                EVLOG_info << "Complete startup time: "
+                           << std::chrono::duration_cast<std::chrono::milliseconds>(complete_end_time -
+                                                                                    complete_start_time)
+                                  .count()
+                           << "ms";
                 mqtt_abstraction.publish(fmt::format("{}ready", mqtt_everest_prefix), nlohmann::json(true));
             } else if (!standalone_modules.empty()) {
                 if (modules_spawned == modules_ready.size() - standalone_modules.size()) {
@@ -377,7 +393,7 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
         std::string binary_filename = fmt::format("{}", module_type);
         std::string javascript_library_filename = "index.js";
         std::string python_filename = "module.py";
-        auto module_path = rs.modules_dir / module_type;
+        auto module_path = rs->modules_dir / module_type;
         const auto printable_module_name = config.printable_identifier(module_name);
         auto binary_path = module_path / binary_filename;
         auto javascript_library_path = module_path / javascript_library_filename;
@@ -446,7 +462,7 @@ static void shutdown_modules(const std::map<pid_t, std::string>& modules, Config
     }
 }
 
-static ControllerHandle start_controller(const RuntimeSettings& rs) {
+static ControllerHandle start_controller(std::shared_ptr<RuntimeSettings> rs) {
     int socket_pair[2];
 
     // FIXME (aw): destroy this socketpair somewhere
@@ -480,13 +496,13 @@ static ControllerHandle start_controller(const RuntimeSettings& rs) {
                                                      {"method", "boot"},
                                                      {"params",
                                                       {
-                                                          {"module_dir", rs.modules_dir.string()},
-                                                          {"interface_dir", rs.interfaces_dir.string()},
-                                                          {"www_dir", rs.www_dir.string()},
-                                                          {"configs_dir", rs.configs_dir.string()},
-                                                          {"logging_config_file", rs.logging_config_file.string()},
-                                                          {"controller_port", rs.controller_port},
-                                                          {"controller_rpc_timeout_ms", rs.controller_rpc_timeout_ms},
+                                                          {"module_dir", rs->modules_dir.string()},
+                                                          {"interface_dir", rs->interfaces_dir.string()},
+                                                          {"www_dir", rs->www_dir.string()},
+                                                          {"configs_dir", rs->configs_dir.string()},
+                                                          {"logging_config_file", rs->logging_config_file.string()},
+                                                          {"controller_port", rs->controller_port},
+                                                          {"controller_rpc_timeout_ms", rs->controller_rpc_timeout_ms},
                                                       }},
                                                  });
 
@@ -499,25 +515,25 @@ int boot(const po::variables_map& vm) {
     const auto prefix_opt = parse_string_option(vm, "prefix");
     const auto config_opt = parse_string_option(vm, "config");
 
-    RuntimeSettings rs(prefix_opt, config_opt);
+    std::shared_ptr<RuntimeSettings> rs = std::make_shared<RuntimeSettings>(prefix_opt, config_opt);
 
-    Logging::init(rs.logging_config_file.string());
+    Logging::init(rs->logging_config_file.string());
 
     EVLOG_info << "8< 8< 8< ------------------------------------------------------------------------------ 8< 8< 8<";
-    EVLOG_info << "EVerest manager starting using " << rs.config_file.string();
-    EVLOG_info << "EVerest using MQTT broker " << rs.mqtt_broker_host << ":" << rs.mqtt_broker_port;
-    if (rs.telemetry_enabled) {
+    EVLOG_info << "EVerest manager starting using " << rs->config_file.string();
+    EVLOG_info << "EVerest using MQTT broker " << rs->mqtt_broker_host << ":" << rs->mqtt_broker_port;
+    if (rs->telemetry_enabled) {
         EVLOG_info << "EVerest telemetry enabled";
     }
 
-    EVLOG_verbose << fmt::format("EVerest prefix was set to {}", rs.prefix.string());
+    EVLOG_verbose << fmt::format("EVerest prefix was set to {}", rs->prefix.string());
 
     // dump all manifests if requested and terminate afterwards
     if (vm.count("dumpmanifests")) {
         auto dumpmanifests_path = fs::path(vm["dumpmanifests"].as<std::string>());
         EVLOG_debug << fmt::format("Dumping all known validated manifests into '{}'", dumpmanifests_path.string());
 
-        auto manifests = Config::load_all_manifests(rs.modules_dir.string(), rs.schemas_dir.string());
+        auto manifests = Config::load_all_manifests(rs->modules_dir.string(), rs->schemas_dir.string());
 
         for (const auto& module : manifests.items()) {
             std::string filename = module.key() + ".yaml";
@@ -532,12 +548,11 @@ int boot(const po::variables_map& vm) {
         return EXIT_SUCCESS;
     }
 
+    auto start_time = std::chrono::system_clock::now();
     std::unique_ptr<Config> config;
     try {
         // FIXME (aw): we should also use std::filesystem::path here as argument types
-        config = std::make_unique<Config>(rs.schemas_dir.string(), rs.config_file.string(), rs.modules_dir.string(),
-                                          rs.interfaces_dir.string(), rs.types_dir.string(), rs.mqtt_everest_prefix,
-                                          rs.mqtt_external_prefix);
+        config = std::make_unique<Config>(rs, true);
     } catch (EverestInternalError& e) {
         EVLOG_error << fmt::format("Failed to load and validate config!\n{}", boost::diagnostic_information(e, true));
         return EXIT_FAILURE;
@@ -550,6 +565,9 @@ int boot(const po::variables_map& vm) {
         EVLOG_critical << fmt::format("Caught top level std::exception:\n{}", boost::diagnostic_information(e, true));
         return EXIT_FAILURE;
     }
+    auto end_time = std::chrono::system_clock::now();
+    EVLOG_info << "Config parsing in manager took: "
+               << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
 
     // dump config if requested
     if (vm.count("dump")) {
@@ -592,11 +610,12 @@ int boot(const po::variables_map& vm) {
     // create StatusFifo object
     auto status_fifo = StatusFifo::create_from_path(vm["status-fifo"].as<std::string>());
 
-    auto mqtt_abstraction = MQTTAbstraction(rs.mqtt_broker_host, std::to_string(rs.mqtt_broker_port),
-                                            rs.mqtt_everest_prefix, rs.mqtt_external_prefix);
+    auto mqtt_abstraction = MQTTAbstraction(rs->mqtt_broker_host, std::to_string(rs->mqtt_broker_port),
+                                            rs->mqtt_everest_prefix, rs->mqtt_external_prefix);
 
     if (!mqtt_abstraction.connect()) {
-        EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", rs.mqtt_broker_host, rs.mqtt_broker_port);
+        EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", rs->mqtt_broker_host,
+                                   rs->mqtt_broker_port);
         return EXIT_FAILURE;
     }
 
@@ -661,9 +680,7 @@ int boot(const po::variables_map& vm) {
             const auto& payload = msg.json;
             if (payload.at("method") == "restart_modules") {
                 shutdown_modules(module_handles, *config, mqtt_abstraction);
-                config = std::make_unique<Config>(
-                    rs.schemas_dir.string(), rs.config_file.string(), rs.modules_dir.string(),
-                    rs.interfaces_dir.string(), rs.types_dir.string(), rs.mqtt_everest_prefix, rs.mqtt_external_prefix);
+                config = std::make_unique<Config>(rs, true);
                 modules_started = false;
                 restart_modules = true;
             } else if (payload.at("method") == "check_config") {
@@ -671,9 +688,7 @@ int boot(const po::variables_map& vm) {
 
                 try {
                     // check the config
-                    Config(rs.schemas_dir.string(), check_config_file_path, rs.modules_dir.string(),
-                           rs.interfaces_dir.string(), rs.types_dir.string(), rs.mqtt_everest_prefix,
-                           rs.mqtt_external_prefix);
+                    auto cfg = Config(rs, true);
                     controller_handle.send_message({{"id", payload.at("id")}});
                 } catch (const std::exception& e) {
                     controller_handle.send_message({{"result", e.what()}, {"id", payload.at("id")}});

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -358,15 +358,12 @@ static std::map<pid_t, std::string> start_modules(Config& config, MQTTAbstractio
             }
             if (std::all_of(modules_ready.begin(), modules_ready.end(),
                             [](const auto& element) { return element.second.ready; })) {
-                EVLOG_info << fmt::format(TERMINAL_STYLE_OK,
-                                          ">>> All modules are initialized. EVerest up and running <<<");
-                status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
                 auto complete_end_time = std::chrono::system_clock::now();
-                EVLOG_info << "Complete startup time: "
-                           << std::chrono::duration_cast<std::chrono::milliseconds>(complete_end_time -
-                                                                                    complete_start_time)
-                                  .count()
-                           << "ms";
+                status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
+                EVLOG_info << fmt::format(
+                    TERMINAL_STYLE_OK, "🚙🚙🚙 All modules are initialized. EVerest up and running [{}ms] 🚙🚙🚙",
+                    std::chrono::duration_cast<std::chrono::milliseconds>(complete_end_time - complete_start_time)
+                        .count());
                 mqtt_abstraction.publish(fmt::format("{}ready", mqtt_everest_prefix), nlohmann::json(true));
             } else if (!standalone_modules.empty()) {
                 if (modules_spawned == modules_ready.size() - standalone_modules.size()) {
@@ -519,11 +516,17 @@ int boot(const po::variables_map& vm) {
 
     Logging::init(rs->logging_config_file.string());
 
-    EVLOG_info << "8< 8< 8< ------------------------------------------------------------------------------ 8< 8< 8<";
-    EVLOG_info << "EVerest manager starting using " << rs->config_file.string();
-    EVLOG_info << "EVerest using MQTT broker " << rs->mqtt_broker_host << ":" << rs->mqtt_broker_port;
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, "  ________      __                _   ");
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " |  ____\\ \\    / /               | |  ");
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " | |__   \\ \\  / /__ _ __ ___  ___| |_ ");
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " |  __|   \\ \\/ / _ \\ '__/ _ \\/ __| __|");
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " | |____   \\  /  __/ | |  __/\\__ \\ |_ ");
+    EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " |______|   \\/ \\___|_|  \\___||___/\\__|");
+    EVLOG_info << "";
+
+    EVLOG_info << "Using MQTT broker " << rs->mqtt_broker_host << ":" << rs->mqtt_broker_port;
     if (rs->telemetry_enabled) {
-        EVLOG_info << "EVerest telemetry enabled";
+        EVLOG_info << "Telemetry enabled";
     }
 
     EVLOG_verbose << fmt::format("EVerest prefix was set to {}", rs->prefix.string());
@@ -566,7 +569,7 @@ int boot(const po::variables_map& vm) {
         return EXIT_FAILURE;
     }
     auto end_time = std::chrono::system_clock::now();
-    EVLOG_info << "Config parsing in manager took: "
+    EVLOG_info << "Config loading completed in "
                << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
 
     // dump config if requested


### PR DESCRIPTION


Validation of type files takes a substantial amount of time whil should not be repeated in every module

This commit also includes logging of the times it took to load a type yaml and validate it, as well as the total time module initialization and the complete startup process takes