### PR TITLE
Rust: Add support for the config

### DIFF
--- a/everestrs/everestrs_sys/everestrs_sys.cpp
+++ b/everestrs/everestrs_sys/everestrs_sys.cpp
@@ -33,6 +33,41 @@ JsonBlob json2blob(const json& j) {
     return JsonBlob{vec};
 }
 
+// Below are overloads to be used with std::visit and our std::variant. We force
+// a compilation error if someone changes the underlying std::variant without
+// extending/adjusting the functions below.
+
+template <typename T, typename... VARIANT_T> struct VariantMemberImpl : public std::false_type {};
+
+template <typename T, typename... VARIANT_T>
+struct VariantMemberImpl<T, std::variant<VARIANT_T...>> : public std::disjunction<std::is_same<T, VARIANT_T>...> {};
+
+/// @brief Static checker if the type T can be converted to `ConfigEntry`.
+///
+/// We use this to detect `get_config_field` overloads which receive arguments
+/// which aren't part of our `ConfigEntry` variant.
+template <typename T> struct ConfigEntryMember : public VariantMemberImpl<T, ConfigEntry> {};
+
+inline ConfigField get_config_field(const std::string& _name, bool _value) {
+    static_assert(ConfigEntryMember<decltype(_value)>::value);
+    return {_name, ConfigType::Boolean, _value, {}, 0, 0};
+}
+
+inline ConfigField get_config_field(const std::string& _name, const std::string& _value) {
+    static_assert(ConfigEntryMember<std::remove_cv_t<std::remove_reference_t<decltype(_value)>>>::value);
+    return {_name, ConfigType::String, false, _value, 0, 0};
+}
+
+inline ConfigField get_config_field(const std::string& _name, double _value) {
+    static_assert(ConfigEntryMember<decltype(_value)>::value);
+    return {_name, ConfigType::Number, false, {}, _value, 0};
+}
+
+inline ConfigField get_config_field(const std::string& _name, int _value) {
+    static_assert(ConfigEntryMember<decltype(_value)>::value);
+    return {_name, ConfigType::Integer, false, {}, 0, _value};
+}
+
 } // namespace
 
 Module::Module(const std::string& module_id, const std::string& prefix, const std::string& config_file) :
@@ -91,45 +126,6 @@ void Module::publish_variable(rust::Str implementation_id, rust::Str name, JsonB
 std::unique_ptr<Module> create_module(rust::Str module_id, rust::Str prefix, rust::Str conf) {
     return std::make_unique<Module>(std::string(module_id), std::string(prefix), std::string(conf));
 }
-
-namespace {
-
-// Below are overloads to be used with std::visit and our std::variant. We force
-// a compilation error if someone changes the underlying std::variant without
-// extending/adjusting the functions below.
-
-template <typename T, typename... VARIANT_T> struct VariantMemberImpl : public std::false_type {};
-
-template <typename T, typename... VARIANT_T>
-struct VariantMemberImpl<T, std::variant<VARIANT_T...>> : public std::disjunction<std::is_same<T, VARIANT_T>...> {};
-
-/// @brief Static checker if the type T can be converted to `ConfigEntry`.
-///
-/// We use this to detect `get_config_field` overloads which receive arguments
-/// which aren't part of our `ConfigEntry` variant.
-template <typename T> struct ConfigEntryMember : public VariantMemberImpl<T, ConfigEntry> {};
-
-inline ConfigField get_config_field(const std::string& _name, bool _value) {
-    static_assert(ConfigEntryMember<decltype(_value)>::value);
-    return {_name, ConfigType::Boolean, _value, {}, 0, 0};
-}
-
-inline ConfigField get_config_field(const std::string& _name, const std::string& _value) {
-    static_assert(ConfigEntryMember<std::remove_cv_t<std::remove_reference_t<decltype(_value)>>>::value);
-    return {_name, ConfigType::String, false, _value, 0, 0};
-}
-
-inline ConfigField get_config_field(const std::string& _name, double _value) {
-    static_assert(ConfigEntryMember<decltype(_value)>::value);
-    return {_name, ConfigType::Number, false, {}, _value, 0};
-}
-
-inline ConfigField get_config_field(const std::string& _name, int _value) {
-    static_assert(ConfigEntryMember<decltype(_value)>::value);
-    return {_name, ConfigType::Integer, false, {}, 0, _value};
-}
-
-} // namespace
 
 rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_id, rust::Str prefix, rust::Str config_file) {
     const auto rs = std::make_shared<Everest::RuntimeSettings>(std::string(prefix), std::string(config_file));

--- a/everestrs/everestrs_sys/everestrs_sys.cpp
+++ b/everestrs/everestrs_sys/everestrs_sys.cpp
@@ -92,6 +92,10 @@ std::unique_ptr<Module> create_module(rust::Str module_id, rust::Str prefix, rus
 
 namespace {
 
+// Below are overloads to be used with std::visit and our std::variant. We force
+// a compilation error if someone changes the underlying std::variant without
+// extending/adjusting the functions below.
+
 inline ConfigField get_config_field(const std::string& _name, bool _value) {
     return {_name, ConfigType::Boolean, _value, {}, 0, 0};
 }

--- a/everestrs/everestrs_sys/everestrs_sys.hpp
+++ b/everestrs/everestrs_sys/everestrs_sys.hpp
@@ -4,11 +4,16 @@
 #include <framework/runtime.hpp>
 #include <memory>
 #include <string>
+#include <utils/types.hpp>
 
 #include "cxxbridge/rust.h"
+// #include "cxxbridge/lib.rs.h"
 
 struct JsonBlob;
 struct Runtime;
+struct RsModuleConfig;
+struct ConfigField;
+enum class ConfigTypes : uint8_t;
 
 class Module {
 public:
@@ -31,3 +36,7 @@ private:
 };
 
 std::unique_ptr<Module> create_module(rust::Str module_name, rust::Str prefix, rust::Str conf);
+
+
+
+rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name, rust::Str prefix, rust::Str conf);

--- a/everestrs/everestrs_sys/everestrs_sys.hpp
+++ b/everestrs/everestrs_sys/everestrs_sys.hpp
@@ -7,7 +7,6 @@
 #include <utils/types.hpp>
 
 #include "cxxbridge/rust.h"
-// #include "cxxbridge/lib.rs.h"
 
 struct JsonBlob;
 struct Runtime;
@@ -36,7 +35,5 @@ private:
 };
 
 std::unique_ptr<Module> create_module(rust::Str module_name, rust::Str prefix, rust::Str conf);
-
-
 
 rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name, rust::Str prefix, rust::Str conf);

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -127,7 +127,7 @@ public:
     ///
     /// \brief checks if the config contains the given \p module_id
     ///
-    bool contains(const std::string& module_id);
+    bool contains(const std::string& module_id) const;
 
     ///
     /// \returns a json object that contains the main config
@@ -136,7 +136,7 @@ public:
 
     ///
     /// \returns a map of module config options
-    ModuleConfigs get_module_configs(const std::string& module_id);
+    ModuleConfigs get_module_configs(const std::string& module_id) const;
 
     ///
     /// \returns a json object that contains the module config options

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -697,7 +697,7 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
-bool Config::contains(const std::string& module_id) {
+bool Config::contains(const std::string& module_id) const {
     BOOST_LOG_FUNCTION();
     return this->main.contains(module_id);
 }
@@ -713,7 +713,7 @@ json Config::get_module_json_config(const std::string& module_id) {
     return this->main[module_id]["config_maps"];
 }
 
-ModuleConfigs Config::get_module_configs(const std::string& module_id) {
+ModuleConfigs Config::get_module_configs(const std::string& module_id) const {
     BOOST_LOG_FUNCTION();
     ModuleConfigs module_configs;
 


### PR DESCRIPTION
The PR adds rust support for the configuration handling. 
The PR goes hand in hand with the pr into everest-core https://github.com/EVerest/everest-core/pull/418

