### PR TITLE
Allow disabling the admin panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
 option(EVEREST_ENABLE_JS_SUPPORT "Enable everestjs for JavaScript modules" ON)
 option(EVEREST_ENABLE_PY_SUPPORT "Enable everestpy for Python modules" ON)
 option(EVEREST_ENABLE_RS_SUPPORT "Enable everestrs for Rust modules" OFF)
+option(EVEREST_ENABLE_ADMIN_PANEL_BACKEND "Enable everest admin panel backend" ON)
+option(EVEREST_INSTALL_ADMIN_PANEL "Download and install everest admin panel" ON)
 
 # make own cmake modules available
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,21 @@
-add_subdirectory(controller)
-
 add_executable(manager manager.cpp)
 
 target_link_libraries(manager
     PRIVATE
         everest::framework
-        controller-ipc
         Boost::program_options
 )
+
+if (EVEREST_ENABLE_ADMIN_PANEL_BACKEND)
+    target_link_libraries(manager
+        PRIVATE
+            controller-ipc
+    )
+
+    target_compile_definitions(manager PRIVATE ENABLE_ADMIN_PANEL)
+
+    add_subdirectory(controller)
+endif ()
 
 target_compile_options(manager PRIVATE ${COMPILER_WARNING_OPTIONS})
 
@@ -16,4 +24,10 @@ target_compile_features(manager PRIVATE cxx_std_17)
 install(
     TARGETS manager
     RUNTIME
+)
+
+# FIXME (aw): the www folder currently always needs to exist, so that the manager does not complain
+install(
+    DIRECTORY # intentionally left blank
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/everest/www"
 )

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -40,7 +40,9 @@ target_link_libraries(controller
 
 target_compile_features(controller PRIVATE cxx_std_17)
 
-if (NOT NO_FETCH_CONTENT)
+install(TARGETS controller RUNTIME)
+
+if (EVEREST_INSTALL_ADMIN_PANEL)
     include(FetchContent)
     message(STATUS "Fetching everest-admin-panel")
     FetchContent_Declare(admin-panel
@@ -53,5 +55,3 @@ if (NOT NO_FETCH_CONTENT)
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/everest/www"
     )
 endif ()
-
-install(TARGETS controller RUNTIME)


### PR DESCRIPTION
- the option EVEREST_ENABLE_ADMIN_PANEL_BACKEND enables or disables the backend for the admin panel completely
- in case it is disabled, the admin panel will also not get fetched
- in case it is enabled, the option EVEREST_INSTALL_ADMIN_PANEL will enable or disable fetching and installing of the admin panel