### PR TITLE
Make everest-framework compilable on macos

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -26,6 +26,11 @@ jobs:
           path: everest-dev-environment
           ref: v0.5.5
 
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{github.workspace}}/build
+
       - name: Install dependencies with homebrew
         run: brew install openssl@1.1 boost
 
@@ -43,5 +48,6 @@ jobs:
             -DCMAKE_PREFIX_PATH=$EVEREST_CMAKE_PATH \
             -DLWS_OPENSSL_LIBRARIES="/usr/local/opt/openssl@1.1/lib/libcrypto.dylib;/usr/local/opt/openssl@1.1/lib/libssl.dylib" \
             -DLWS_OPENSSL_INCLUDE_DIRS="/usr/local/opt/openssl@1.1/include" \
-            -DEVEREST_ENABLE_JS_SUPPORT=OFF
+            -DEVEREST_ENABLE_JS_SUPPORT=OFF \
+            -DEVEREST_ENABLE_RS_SUPPORT=ON
           make -j2

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -1,0 +1,47 @@
+name: MacOS Workflow
+on: [push]
+
+jobs:
+  build:
+    name: ensure that everest-framework builds on MacOS
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          path: everest-framework
+
+      - name: Checkout everest-cmake
+        uses: actions/checkout@v2
+        with:
+          repository: EVerest/everest-cmake
+          path: everest-cmake
+          ref: v0.1.0
+      
+      - name: Checkout dependency manager
+        uses: actions/checkout@v2
+        with:
+          repository: EVerest/everest-dev-environment
+          path: everest-dev-environment
+          ref: v0.5.5
+
+      - name: Install dependencies with homebrew
+        run: brew install openssl@1.1 boost
+
+      - name: Install dependency manager 
+        run: |
+          cd everest-dev-environment/dependency_manager
+          python3 -m pip install .
+
+      - name: build
+        run: |
+          EVEREST_CMAKE_PATH=$(pwd)/everest-cmake
+          mkdir build
+          pushd build
+          cmake .. \
+            -DCMAKE_PREFIX_PATH=$EVEREST_CMAKE_PATH \
+            -DLWS_OPENSSL_LIBRARIES="/usr/local/opt/openssl@1.1/lib/libcrypto.dylib;/usr/local/opt/openssl@1.1/lib/libssl.dylib" \
+            -DLWS_OPENSSL_INCLUDE_DIRS="/usr/local/opt/openssl@1.1/include" \
+            -DEVEREST_ENABLE_JS_SUPPORT=OFF
+          make -j2

--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -5,12 +5,9 @@
 
 #include <framework/everest.hpp>
 #include <framework/runtime.hpp>
+#include <utils/set_process_name.hpp>
 
 #include <napi.h>
-
-#ifndef __APPLE__
-#include <sys/prctl.h>
-#endif
 
 #include <chrono>
 #include <future>
@@ -318,14 +315,8 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         // initialize everest framework
         const auto& module_identifier = config->printable_identifier(module_id);
         EVLOG_debug << "Initializing framework for module " << module_identifier << "...";
-        EVLOG_debug << "Trying to set process name to: '" << module_identifier << "'...";
-#ifndef __APPLE__
-        if (prctl(PR_SET_NAME, module_identifier.c_str())) {
-            EVLOG_warning << "Could not set process name to '" << module_identifier << "'";
-        }
-#else
-        EVLOG_warning << "Could not set process name to '" << module_identifier << "' (not supported on macOS)";
-#endif
+
+        set_process_name(module_identifier);
 
         Everest::Logging::update_process_name(module_identifier);
 

--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -8,7 +8,9 @@
 
 #include <napi.h>
 
+#ifndef __APPLE__
 #include <sys/prctl.h>
+#endif
 
 #include <chrono>
 #include <future>
@@ -317,9 +319,13 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         const auto& module_identifier = config->printable_identifier(module_id);
         EVLOG_debug << "Initializing framework for module " << module_identifier << "...";
         EVLOG_debug << "Trying to set process name to: '" << module_identifier << "'...";
+#ifndef __APPLE__
         if (prctl(PR_SET_NAME, module_identifier.c_str())) {
             EVLOG_warning << "Could not set process name to '" << module_identifier << "'";
         }
+#else
+        EVLOG_warning << "Could not set process name to '" << module_identifier << "' (not supported on macOS)";
+#endif
 
         Everest::Logging::update_process_name(module_identifier);
 

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -10,9 +10,6 @@
 #include <fmt/color.h>
 #include <fmt/core.h>
 #include <framework/ModuleAdapter.hpp>
-#ifndef __APPLE__
-#include <sys/prctl.h>
-#endif
 
 #include <utils/yaml_loader.hpp>
 

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -10,7 +10,9 @@
 #include <fmt/color.h>
 #include <fmt/core.h>
 #include <framework/ModuleAdapter.hpp>
+#ifndef __APPLE__
 #include <sys/prctl.h>
+#endif
 
 #include <utils/yaml_loader.hpp>
 

--- a/include/utils/set_process_name.hpp
+++ b/include/utils/set_process_name.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+
+void set_process_name(const std::string& name);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,12 @@ add_library(everest::framework ALIAS framework)
 
 set_target_properties(framework PROPERTIES SOVERSION ${PROJECT_VERSION})
 
+if(APPLE)
+    set(OS_SPECIFIC_FILES "set_process_name.macos.cpp")
+else()
+    set(OS_SPECIFIC_FILES "set_process_name.linux.cpp")
+endif()
+
 target_sources(framework
     PRIVATE
         config.cpp
@@ -29,6 +35,7 @@ target_sources(framework
         date.cpp
         runtime.cpp
         yaml_loader.cpp
+        ${OS_SPECIFIC_FILES}
 )
 
 # FIXME (aw): c++17 doesn't need necessarily to be public, but our

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -4,6 +4,7 @@
 #include <framework/runtime.hpp>
 #include <utils/error.hpp>
 #include <utils/error_json.hpp>
+#include <utils/set_process_name.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -369,16 +370,9 @@ int ModuleLoader::initialize() {
 
         const std::string module_identifier = config.printable_identifier(this->module_id);
         EVLOG_debug << fmt::format("Initializing framework for module {}...", module_identifier);
-        EVLOG_verbose << fmt::format("Setting process name to: '{}'...", module_identifier);
-#ifndef __APPLE__
-        int prctl_return = prctl(PR_SET_NAME, module_identifier.c_str());
-        if (prctl_return == 1) {
-            EVLOG_warning << fmt::format("Could not set process name to '{}', it remains '{}'", module_identifier,
-                                         this->original_process_name);
-        }
-#else
-        EVLOG_warning << "Not Setting process names on macOS is not supported!";
-#endif
+
+        set_process_name(module_identifier);
+
         Logging::update_process_name(module_identifier);
 
         auto everest =

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -370,11 +370,15 @@ int ModuleLoader::initialize() {
         const std::string module_identifier = config.printable_identifier(this->module_id);
         EVLOG_debug << fmt::format("Initializing framework for module {}...", module_identifier);
         EVLOG_verbose << fmt::format("Setting process name to: '{}'...", module_identifier);
+#ifndef __APPLE__
         int prctl_return = prctl(PR_SET_NAME, module_identifier.c_str());
         if (prctl_return == 1) {
             EVLOG_warning << fmt::format("Could not set process name to '{}', it remains '{}'", module_identifier,
                                          this->original_process_name);
         }
+#else
+        EVLOG_warning << "Not Setting process names on macOS is not supported!";
+#endif
         Logging::update_process_name(module_identifier);
 
         auto everest =

--- a/lib/set_process_name.linux.cpp
+++ b/lib/set_process_name.linux.cpp
@@ -1,0 +1,17 @@
+#ifndef __linux__
+#error "This file is only meant to be compiled on Linux"
+#else
+
+#include "utils/set_process_name.hpp"
+#include <everest/logging.hpp>
+#include <fmt/core.h>
+#include <sys/prctl.h>
+
+void set_process_name(const std::string& name) {
+    EVLOG_verbose << fmt::format("Setting process name to: '{}'...", name);
+
+    if (prctl(PR_SET_NAME, name.c_str())) {
+        EVLOG_warning << fmt::format("Could not set process name to '{}'", name);
+    }
+}
+#endif // __linux__

--- a/lib/set_process_name.macos.cpp
+++ b/lib/set_process_name.macos.cpp
@@ -1,0 +1,15 @@
+#ifndef __APPLE__
+#error "This file is only meant to be compiled on macOS"
+#else
+
+#include "utils/set_process_name.hpp"
+#include <everest/logging.hpp>
+#include <fmt/core.h>
+
+void set_process_name(const std::string& name) {
+    EVLOG_verbose << fmt::format("Setting process name to: '{}'...", name);
+
+    EVLOG_warning << fmt::format("Could not set process name to '{}'. Not supported on macos", name);
+}
+
+#endif // __APPLE__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,13 @@
-add_executable(manager manager.cpp)
+if (APPLE)
+    set(OS_SPECIFIC_FILES "create_pipe.macos.cpp")
+else ()
+    set(OS_SPECIFIC_FILES "create_pipe.linux.cpp")
+endif ()
+
+add_executable(manager 
+    manager.cpp
+    create_pipe.hpp
+    ${OS_SPECIFIC_FILES})
 
 target_link_libraries(manager
     PRIVATE

--- a/src/create_pipe.hpp
+++ b/src/create_pipe.hpp
@@ -1,0 +1,5 @@
+// Creates pipe in a cross-platform way.
+// params:
+//     pipefd: pointer to an array of two integers, where file descriptors for
+//             the pipe will be stored.
+void create_pipe(int* pipefd);

--- a/src/create_pipe.linux.cpp
+++ b/src/create_pipe.linux.cpp
@@ -1,0 +1,16 @@
+#ifndef __linux__
+#error "This file is only meant to be compiled on Linux"
+#else
+
+#include "create_pipe.hpp"
+#include <fcntl.h>
+#include <fmt/format.h>
+#include <stdexcept>
+#include <unistd.h>
+
+void create_pipe(int* pipefd) {
+    if (pipe2(pipefd, O_CLOEXEC | O_DIRECT)) {
+        throw std::runtime_error(fmt::format("Syscall pipe2() failed ({}), exiting", strerror(errno)));
+    }
+}
+#endif // __linux__

--- a/src/create_pipe.macos.cpp
+++ b/src/create_pipe.macos.cpp
@@ -1,0 +1,23 @@
+#ifndef __APPLE__
+#error "This file is only meant to be compiled on macOS"
+#else
+
+#include <fmt/core.h>
+#include <stdexcept>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+void create_pipe(int* pipefd) {
+    if (pipe(pipefd)) {
+        throw std::runtime_error(fmt::format("Syscall pipe() failed ({}), exiting", strerror(errno)));
+    }
+    if (fcntl(pipefd[0], F_NOCACHE, 1)) {
+        throw std::runtime_error(fmt::format("Syscall fcntl() failed ({}), exiting", strerror(errno)));
+    }
+
+    if (fcntl(pipefd[0], F_SETFD, O_CLOEXEC)) {
+        throw std::runtime_error(fmt::format("Syscall fcntl() failed ({}), exiting", strerror(errno)));
+    }
+}
+#endif // __APPLE__

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -35,6 +35,7 @@
 #include <utils/status_fifo.hpp>
 
 #include "controller/ipc.hpp"
+#include "create_pipe.hpp"
 
 namespace po = boost::program_options;
 namespace fs = std::filesystem;
@@ -128,27 +129,6 @@ struct ControllerHandle {
 };
 
 #endif
-
-// Wrapper for pipe2()/pipe() syscall to support different platforms
-void create_pipe(int* pipefd) {
-
-#ifndef __APPLE__
-    if (pipe2(pipefd, O_CLOEXEC | O_DIRECT)) {
-        throw std::runtime_error(fmt::format("Syscall pipe2() failed ({}), exiting", strerror(errno)));
-    }
-#else
-    if (pipe(pipefd)) {
-        throw std::runtime_error(fmt::format("Syscall pipe() failed ({}), exiting", strerror(errno)));
-    }
-    if (fcntl(pipefd[0], F_NOCACHE, 1)) {
-        throw std::runtime_error(fmt::format("Syscall fcntl() failed ({}), exiting", strerror(errno)));
-    }
-
-    if (fcntl(pipefd[0], F_SETFD, O_CLOEXEC)) {
-        throw std::runtime_error(fmt::format("Syscall fcntl() failed ({}), exiting", strerror(errno)));
-    }
-#endif
-}
 
 SubprocessHandle create_subprocess(bool set_pdeathsig = true) {
     int pipefd[2];


### PR DESCRIPTION
## Objective
To develop modules on macos it is nice to have the sources that at least compile, so that different tools (IDEs) can use  them.
Compilable code enables the future work on making macos-based development of EVerest and modules. But it needs to be tested and may require some further work. So specific use-cases are not guaranteed to be working in this PR.

## Details

There were a couple of system calls, that are unavailable on macOS.

`prctl` - used only for the setting of the process name and some cleanup. Process name setting is just disabled, the cleanup maybe won't work. Needs review.
`pipe2` - on macos opening pipe, and setting flags are different calls, so it is now refactored a bit.

`libwebsockets` doesn't compile with openssl3 (AFAIK), so version 1.1 needs to be installed, and the paths should be set in CMake.

There is a workflow for macos build added, to ensure, that it still compiles on macos.