### PR TITLE
Fix missing Exception throw on loading config

### DIFF
--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -135,8 +135,8 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
     if (config == nullptr) {
         EVLOG_info << "Config file is null, treating it as empty";
         config = json::object();
-    } else if (!config->is_object()) {
-        throw BootException(fmt::format("Config file '{}' is not an object", config_file));
+    } else if (!config.is_object()) {
+        throw BootException(fmt::format("Config file '{}' is not an object", config_file.string()));
     }
 
     const auto settings = config.value("settings", json::object());

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -132,6 +132,9 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
     }
 
     config = load_yaml(config_file);
+    if (config == nullptr) {
+        EVLOG_AND_THROW(EverestConfigError("Config file is nullptr!"));
+    }
 
     const auto settings = config.value("settings", json::object());
 

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -133,7 +133,10 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
 
     config = load_yaml(config_file);
     if (config == nullptr) {
-        EVLOG_AND_THROW(EverestConfigError("Config file is nullptr!"));
+        EVLOG_info << "Config file is null, treating it as empty";
+        config = json::object();
+    } else if (!config->is_object()) {
+        throw BootException(fmt::format("Config file '{}' is not an object", config_file));
     }
 
     const auto settings = config.value("settings", json::object());

--- a/lib/yaml_loader.cpp
+++ b/lib/yaml_loader.cpp
@@ -40,7 +40,7 @@ struct RymlCallbackInitializer {
 
 static nlohmann::ordered_json ryml_to_nlohmann_json(const c4::yml::NodeRef& ryml_node) {
     if (ryml_node.empty()) {
-        return nullptr;
+        return nlohmann::ordered_json::object();
     } else if (ryml_node.is_map()) {
         // handle object
         auto object = nlohmann::ordered_json::object();

--- a/lib/yaml_loader.cpp
+++ b/lib/yaml_loader.cpp
@@ -39,9 +39,7 @@ struct RymlCallbackInitializer {
 };
 
 static nlohmann::ordered_json ryml_to_nlohmann_json(const c4::yml::NodeRef& ryml_node) {
-    if (ryml_node.empty()) {
-        return nlohmann::ordered_json::object();
-    } else if (ryml_node.is_map()) {
+    if (ryml_node.is_map()) {
         // handle object
         auto object = nlohmann::ordered_json::object();
         for (const auto& child : ryml_node) {
@@ -55,7 +53,7 @@ static nlohmann::ordered_json ryml_to_nlohmann_json(const c4::yml::NodeRef& ryml
             array.emplace_back(ryml_to_nlohmann_json(child));
         }
         return array;
-    } else if (ryml_node.val_is_null()) {
+    } else if (ryml_node.empty() or ryml_node.val_is_null()) {
         return nullptr;
     } else {
         // check type of data


### PR DESCRIPTION
In case of loading a broken config.yaml the function load_yaml returns a nullptr. This fix avoid accessing non-existing elements on a nullptr.