### PR TITLE
Fix node-addon-api detection on older versions of npm

### DIFF
--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -25,7 +25,7 @@ find_program(
 # FIXME (aw): we want this as an requirement, not implicitely install it by ourself
 execute_process(
     COMMAND
-        ${NPM} list -p node-addon-api
+        ${NPM} list -p node-addon-api --loglevel=error | grep node-addon-api
     WORKING_DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR}
     OUTPUT_VARIABLE


### PR DESCRIPTION
On certain unsupported combinations of nodejs and npm (for example nodejs v10.24.0 and npm 5.8.0 on debian buster) the node-addon-api detection wasn't working properly