### PR TITLE
fix: Add node21 as potential include path

### DIFF
--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -65,6 +65,7 @@ find_path(NODEJS_INCLUDE_DIR "node_api.h"
         "node18"
         "node19"
         "node20"
+        "node21"
         "nodejs/src"
     HINTS
         "$ENV{HOME}/.nvm/versions/node/${NODE_VERSION}/include"


### PR DESCRIPTION
Adds `node21` to the candidates for `NODEJS_INCLUDE_DIR`, so that cmake is able to find the node headers on OpenSUSE-Tumbleweed