### PR TITLE
fix(fmt): backward compatibility with libfmt

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -50,7 +50,7 @@ liblog:
   options: ["BUILD_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libfmt:
   git: https://github.com/fmtlib/fmt.git
-  git_tag: 10.1.0
+  git_tag: 9.1.0
   options:
     ["FMT_TEST OFF", "FMT_DOC OFF", "BUILD_SHARED_LIBS ON", "FMT_INSTALL ON"]
 date:

--- a/include/utils/formatter.hpp
+++ b/include/utils/formatter.hpp
@@ -16,7 +16,7 @@ namespace everest::formatting {
 // NOTE (aw): this is only for backward compatibility, once finally
 // switching to version 10, this function could be removed again
 void throw_format_error(const char* message);
-}
+} // namespace everest::formatting
 
 template <> struct fmt::formatter<nlohmann::json> {
     constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator {

--- a/include/utils/formatter.hpp
+++ b/include/utils/formatter.hpp
@@ -8,12 +8,22 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
+namespace everest::formatting {
+// NOTE (aw): this function is only here to hide the implementation of
+// fmt::format_error in <fmt/format.h>
+// in fmt version < 10, the function throw_format_error is not exposed
+// in the public api
+// NOTE (aw): this is only for backward compatibility, once finally
+// switching to version 10, this function could be removed again
+void throw_format_error(const char* message);
+}
+
 template <> struct fmt::formatter<nlohmann::json> {
     constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator {
         auto it = ctx.begin(), end = ctx.end();
 
         if (it != end && *it != '}') {
-            fmt::throw_format_error("Invalid format");
+            everest::formatting::throw_format_error("Invalid format");
         }
 
         return it;
@@ -29,7 +39,7 @@ template <> struct fmt::formatter<std::atomic_bool> {
         auto it = ctx.begin(), end = ctx.end();
 
         if (it != end && *it != '}') {
-            fmt::throw_format_error("Invalid format");
+            everest::formatting::throw_format_error("Invalid format");
         }
 
         return it;
@@ -48,7 +58,7 @@ template <typename T> struct fmt::formatter<std::atomic<T>> {
         auto it = ctx.begin(), end = ctx.end();
 
         if (it != end && *it != '}') {
-            fmt::throw_format_error("Invalid format");
+            everest::formatting::throw_format_error("Invalid format");
         }
 
         return it;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(framework
         error_database.cpp
         error_manager.cpp
         everest.cpp
+        formatter.cpp
         message_queue.cpp
         mqtt_abstraction.cpp
         mqtt_abstraction_impl.cpp

--- a/lib/formatter.cpp
+++ b/lib/formatter.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+#include <utils/formatter.hpp>
+
+#include <fmt/format.h>
+
+namespace everest::formatting {
+void throw_format_error(const char* message) {
+    throw fmt::format_error(message);
+}
+} // namespace everest::formatting

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -9,12 +9,14 @@ target_compile_options(controller-ipc PRIVATE ${COMPILER_WARNING_OPTIONS})
 
 find_package(Threads REQUIRED)
 
-# FIXME (aw): refactor the yaml_loader into on lib, so it can be shared somehow, similar to the controller-ipc
+# FIXME (aw): refactor the yaml_loader and formatter into a lib
+# so it can be shared somehow, similar to the controller-ipc
 add_executable(controller 
     controller.cpp
     command_api.cpp
     rpc.cpp
     server.cpp
+    ${PROJECT_SOURCE_DIR}/lib/formatter.cpp
     ${PROJECT_SOURCE_DIR}/lib/yaml_loader.cpp
 )
 


### PR DESCRIPTION
Added a helper function which exposes the throw_format_error() functionality of libfmt, which is only publicly accessible from libfmt version 10 onwards.