### PR TITLE
Update nlohmann_json_schema_validator dependency to 2.3.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,7 +32,7 @@ nlohmann_json:
   options: ["JSON_BuildTests OFF", "JSON_MultipleHeaders ON"]
 nlohmann_json_schema_validator:
   git: https://github.com/pboettch/json-schema-validator
-  git_tag: f4194d7e24e2e2365660ff35b57a7c4e088b27fa
+  git_tag: 2.3.0
   options:
     [
       "JSON_VALIDATOR_INSTALL OFF",


### PR DESCRIPTION
- only contains minor changes compared to the git rev used before
- is a proper versioned tag