### PR TITLE
Feature/add watchdog helper

### DIFF
--- a/include/framework/ModuleAdapter.hpp
+++ b/include/framework/ModuleAdapter.hpp
@@ -85,6 +85,7 @@ struct ModuleAdapter {
     using ExtMqttSubscribeFunc = std::function<void(const std::string&, StringHandler)>;
     using TelemetryPublishFunc =
         std::function<void(const std::string&, const std::string&, const std::string&, const TelemetryMap&)>;
+    using WatchdogFeedPublishFunc = std::function<void()>;
 
     CallFunc call;
     PublishFunc publish;
@@ -101,6 +102,7 @@ struct ModuleAdapter {
     ExtMqttSubscribeFunc ext_mqtt_subscribe;
     std::vector<cmd> registered_commands;
     TelemetryPublishFunc telemetry_publish;
+    WatchdogFeedPublishFunc watchdog_feed_publish;
 
     void check_complete() {
         // FIXME (aw): I should throw if some of my handlers are not set

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -140,6 +140,11 @@ public:
     bool is_telemetry_enabled();
 
     ///
+    /// \brief publishes a watchdog feed
+    ///
+    void watchdog_feed_publish();
+
+    ///
     /// \brief Chccks if all commands of a module that are listed in its manifest are available
     ///
     void check_code();
@@ -183,7 +188,6 @@ private:
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;
-    std::thread heartbeat_thread;
     std::string module_name;
     std::future<void> main_loop_end{};
     json module_manifest;
@@ -195,8 +199,6 @@ private:
     bool telemetry_enabled;
 
     void handle_ready(json data);
-
-    void heartbeat();
 
     void publish_metadata();
 

--- a/include/utils/watchdog.hpp
+++ b/include/utils/watchdog.hpp
@@ -39,7 +39,7 @@ public:
 
 private:
     void feed_manager_mqtt();
-    
+
     struct WatchdogData {
         WatchdogData(const std::string& _description, std::chrono::seconds _timeout) :
             description(_description), timeout(_timeout) {
@@ -58,7 +58,7 @@ private:
 
     constexpr static std::chrono::seconds check_interval{1};
     constexpr static std::chrono::seconds feed_manager_via_mqtt_interval{15};
-    constexpr static int feed_manager_via_mqtt_counts_max = feed_manager_via_mqtt_interval / check_interval;
+    std::chrono::steady_clock::time_point next_manager_feed_due;
 };
 
 } // namespace Everest

--- a/include/utils/watchdog.hpp
+++ b/include/utils/watchdog.hpp
@@ -21,12 +21,13 @@
 #include <thread>
 
 #include <everest/logging.hpp>
+#include <framework/ModuleAdapter.hpp>
 
 namespace Everest {
 
 class WatchdogSupervisor {
 public:
-    WatchdogSupervisor();
+    WatchdogSupervisor(ModuleAdapter& ev);
 
     ~WatchdogSupervisor();
 
@@ -38,8 +39,6 @@ public:
     }
 
 private:
-    void feed_manager_mqtt();
-
     struct WatchdogData {
         WatchdogData(const std::string& _description, std::chrono::seconds _timeout) :
             description(_description), timeout(_timeout) {
@@ -59,6 +58,8 @@ private:
     constexpr static std::chrono::seconds check_interval{1};
     constexpr static std::chrono::seconds feed_manager_via_mqtt_interval{15};
     std::chrono::steady_clock::time_point next_manager_feed_due;
+
+    ModuleAdapter& ev;
 };
 
 } // namespace Everest

--- a/include/utils/watchdog.hpp
+++ b/include/utils/watchdog.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Pionix GmbH and Contributors to EVerest
+
+/*
+ This is a helper class for modules to have an everest internal watchdog system.
+ A module can register watchdogs for several threads and feed them.
+ Requires external_mqtt enabled in the manifest.
+
+ A special watchdog module can check all watchdogs and itself feed e.g. a systemd watchdog.
+*/
+
+#ifndef EVEREST_UTILS_WATCHDOG_HPP
+#define EVEREST_UTILS_WATCHDOG_HPP
+
+#include <atomic>
+#include <chrono>
+#include <list>
+#include <mutex>
+#include <ratio>
+#include <string>
+#include <thread>
+
+#include <everest/logging.hpp>
+
+namespace Everest {
+
+class WatchdogSupervisor {
+public:
+    WatchdogSupervisor() {
+        // Thread that monitors all registered watchdogs
+        timeout_detection_thread = std::thread([this]() {
+            while (not should_stop) {
+                std::this_thread::sleep_for(check_interval);
+
+                // check if any watchdog timed out
+                for (const auto& dog : dogs) {
+                    std::chrono::steady_clock::time_point last_seen = dog.last_seen;
+                    if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - last_seen) >
+                        dog.timeout) {
+                        // Throw exception
+                        EVLOG_AND_THROW(EverestTimeoutError("Module internal watchdog timeout: " + dog.description));
+                    }
+                }
+
+                // check if we need to send an MQTT feed to manager
+                if (--feed_manager_via_mqtt_countdown == 0) {
+                    feed_manager_via_mqtt_countdown = feed_manager_via_mqtt_counts_max;
+                    // send MQTT feed to manager
+                }
+            }
+        });
+    }
+
+    ~WatchdogSupervisor() {
+        should_stop = true;
+        if (timeout_detection_thread.joinable()) {
+            timeout_detection_thread.join();
+        }
+    }
+
+    auto register_watchdog(const std::string& description, std::chrono::seconds timeout) {
+        std::scoped_lock lock(dogs_lock);
+        dogs.emplace_back(description, timeout);
+        auto& dog = dogs.back();
+        return [&dog]() { dog.last_seen = std::chrono::steady_clock::now(); };
+    }
+
+private:
+    struct WatchdogData {
+        WatchdogData(const std::string& _description, std::chrono::seconds _timeout) :
+            description(_description), timeout(_timeout) {
+            last_seen = std::chrono::steady_clock::now();
+        }
+        const std::string description;
+        const std::chrono::seconds timeout;
+        std::atomic<std::chrono::steady_clock::time_point> last_seen;
+    };
+
+    std::mutex dogs_lock;
+    std::list<WatchdogData> dogs;
+    std::atomic_bool should_stop{false};
+    std::thread timeout_detection_thread;
+    int feed_manager_via_mqtt_countdown{0};
+
+    constexpr static std::chrono::seconds check_interval{1};
+    constexpr static std::chrono::seconds feed_manager_via_mqtt_interval{15};
+    constexpr static int feed_manager_via_mqtt_counts_max = feed_manager_via_mqtt_interval / check_interval;
+};
+
+} // namespace Everest
+
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(framework
         date.cpp
         runtime.cpp
         yaml_loader.cpp
+        watchdog.cpp
 )
 
 # FIXME (aw): c++17 doesn't need necessarily to be public, but our

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -80,18 +80,12 @@ void Everest::wait_for_main_loop_end() {
     this->main_loop_end.get();
 }
 
-void Everest::heartbeat() {
+void Everest::watchdog_feed_publish() {
     BOOST_LOG_FUNCTION();
-    const auto heartbeat_topic = fmt::format("{}/heartbeat", this->config.mqtt_module_prefix(this->module_id));
+    // const auto heartbeat_topic = fmt::format("{}/heartbeat", this->config.mqtt_module_prefix(this->module_id));
+    const auto watchdog_topic = "everest/watchdogs";
 
-    using namespace date;
-
-    while (this->ready_received) {
-        std::ostringstream now;
-        now << date::utc_clock::now();
-        this->mqtt_abstraction.publish(heartbeat_topic, json(now.str()), QOS::QOS0);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
+    this->mqtt_abstraction.publish(watchdog_topic, this->module_id, QOS::QOS0);
 }
 
 void Everest::publish_metadata() {
@@ -793,9 +787,6 @@ void Everest::handle_ready(json data) {
         auto on_ready_handler = *on_ready;
         on_ready_handler();
     }
-
-    // TODO(kai): make heartbeat interval configurable, disable it completely until then
-    // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);
 }
 
 void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name, const JsonCommand handler) {

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -467,6 +467,8 @@ int ModuleLoader::initialize() {
             return everest.telemetry_publish(category, subcategory, type, telemetry);
         };
 
+        module_adapter.watchdog_feed_publish = [&everest]() { everest.watchdog_feed_publish(); };
+
         this->callbacks.register_module_adapter(module_adapter);
 
         // FIXME (aw): would be nice to move this config related thing toward the module_init function

--- a/lib/watchdog.cpp
+++ b/lib/watchdog.cpp
@@ -6,6 +6,9 @@
 namespace Everest {
 
 WatchdogSupervisor::WatchdogSupervisor() {
+
+    next_manager_feed_due = std::chrono::steady_clock::now();
+
     // Thread that monitors all registered watchdogs
     timeout_detection_thread = std::thread([this]() {
         while (not should_stop) {
@@ -22,8 +25,9 @@ WatchdogSupervisor::WatchdogSupervisor() {
             }
 
             // check if we need to send an MQTT feed to manager
-            if (--feed_manager_via_mqtt_countdown == 0) {
-                feed_manager_via_mqtt_countdown = feed_manager_via_mqtt_counts_max;
+            const auto now = std::chrono::steady_clock::now();
+            if (next_manager_feed_due < now) {
+                next_manager_feed_due = now + feed_manager_via_mqtt_interval;
                 // send MQTT feed to manager
                 feed_manager_mqtt();
             }

--- a/lib/watchdog.cpp
+++ b/lib/watchdog.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Pionix GmbH and Contributors to EVerest
+#include <everest/exceptions.hpp>
+#include <utils/watchdog.hpp>
+
+namespace Everest {
+
+WatchdogSupervisor::WatchdogSupervisor() {
+    // Thread that monitors all registered watchdogs
+    timeout_detection_thread = std::thread([this]() {
+        while (not should_stop) {
+            std::this_thread::sleep_for(check_interval);
+
+            // check if any watchdog timed out
+            for (const auto& dog : dogs) {
+                std::chrono::steady_clock::time_point last_seen = dog.last_seen;
+                if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - last_seen) >
+                    dog.timeout) {
+                    // Throw exception
+                    EVLOG_AND_THROW(EverestTimeoutError("Module internal watchdog timeout: " + dog.description));
+                }
+            }
+
+            // check if we need to send an MQTT feed to manager
+            if (--feed_manager_via_mqtt_countdown == 0) {
+                feed_manager_via_mqtt_countdown = feed_manager_via_mqtt_counts_max;
+                // send MQTT feed to manager
+                feed_manager_mqtt();
+            }
+        }
+    });
+}
+
+WatchdogSupervisor::~WatchdogSupervisor() {
+    should_stop = true;
+    if (timeout_detection_thread.joinable()) {
+        timeout_detection_thread.join();
+    }
+}
+
+void WatchdogSupervisor::feed_manager_mqtt() {
+}
+
+} // namespace Everest

--- a/lib/watchdog.cpp
+++ b/lib/watchdog.cpp
@@ -5,7 +5,7 @@
 
 namespace Everest {
 
-WatchdogSupervisor::WatchdogSupervisor() {
+WatchdogSupervisor::WatchdogSupervisor(ModuleAdapter& ev) : ev(ev) {
 
     next_manager_feed_due = std::chrono::steady_clock::now();
 
@@ -29,7 +29,7 @@ WatchdogSupervisor::WatchdogSupervisor() {
             if (next_manager_feed_due < now) {
                 next_manager_feed_due = now + feed_manager_via_mqtt_interval;
                 // send MQTT feed to manager
-                feed_manager_mqtt();
+                this->ev.watchdog_feed_publish();
             }
         }
     });
@@ -40,9 +40,6 @@ WatchdogSupervisor::~WatchdogSupervisor() {
     if (timeout_detection_thread.joinable()) {
         timeout_detection_thread.join();
     }
-}
-
-void WatchdogSupervisor::feed_manager_mqtt() {
 }
 
 } // namespace Everest


### PR DESCRIPTION
Adds watchdog functionality to the framework

Each module has a WatchdogSupervisor in its main module class that sends out watchdog feed heartbeats via MQTT.
This can be monitored by the manager (not yet implemented here). This at least ensures that the watchdog supervising thread in the module is still alive and MQTT communication works.

The module code can register multiple internal watchdogs, which is useful if it has looping threads.