### PR TITLE
MQTT event loop optimization and added support for Unix Domain Sockets for MQTT communication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.10
+    VERSION 0.10.1
     DESCRIPTION "The open operating system for e-mobility charging stations"
 	LANGUAGES CXX C
 )

--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -746,9 +746,10 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         module_this.DefineProperty(Napi::PropertyDescriptor::Value("info", module_info_prop, napi_enumerable));
 
         // connect to mqtt server and start mqtt mainloop thread
-        auto everest_handle = std::make_unique<Everest::Everest>(
-            module_id, *config, validate_schema, rs->mqtt_broker_host, rs->mqtt_broker_port, rs->mqtt_everest_prefix,
-            rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
+        auto everest_handle =
+            std::make_unique<Everest::Everest>(module_id, *config, validate_schema, rs->mqtt_broker_socket_path,
+                                               rs->mqtt_broker_host, rs->mqtt_broker_port, rs->mqtt_everest_prefix,
+                                               rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
 
         ctx = new EvModCtx(std::move(everest_handle), module_manifest, env);
 

--- a/everestpy/src/everest/module.cpp
+++ b/everestpy/src/everest/module.cpp
@@ -8,8 +8,9 @@ std::unique_ptr<Everest::Everest> Module::create_everest_instance(const std::str
                                                                   const RuntimeSession& session) {
     const auto& rs = session.get_runtime_settings();
     return std::make_unique<Everest::Everest>(module_id, session.get_config(), rs->validate_schema,
-                                              rs->mqtt_broker_host, rs->mqtt_broker_port, rs->mqtt_everest_prefix,
-                                              rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
+                                              rs->mqtt_broker_socket_path, rs->mqtt_broker_host, rs->mqtt_broker_port,
+                                              rs->mqtt_everest_prefix, rs->mqtt_external_prefix, rs->telemetry_prefix,
+                                              rs->telemetry_enabled);
 }
 
 static std::string get_ev_module_from_env() {

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -13,9 +13,9 @@ namespace {
 std::unique_ptr<Everest::Everest> create_everest_instance(const std::string& module_id,
                                                           std::shared_ptr<Everest::RuntimeSettings> rs,
                                                           const Everest::Config& config) {
-    return std::make_unique<Everest::Everest>(module_id, config, rs->validate_schema, rs->mqtt_broker_host,
-                                              rs->mqtt_broker_port, rs->mqtt_everest_prefix, rs->mqtt_external_prefix,
-                                              rs->telemetry_prefix, rs->telemetry_enabled);
+    return std::make_unique<Everest::Everest>(module_id, config, rs->validate_schema, rs->mqtt_broker_socket_path,
+                                              rs->mqtt_broker_host, rs->mqtt_broker_port, rs->mqtt_everest_prefix,
+                                              rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
 }
 
 std::unique_ptr<Everest::Config> create_config_instance(std::shared_ptr<Everest::RuntimeSettings> rs) {

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -40,8 +40,9 @@ using UnsubscribeToken = std::function<void()>;
 class Everest {
 public:
     Everest(std::string module_id, const Config& config, bool validate_data_with_schema,
-            const std::string& mqtt_server_address, int mqtt_server_port, const std::string& mqtt_everest_prefix,
-            const std::string& mqtt_external_prefix, const std::string& telemetry_prefix, bool telemetry_enabled);
+            const std::string& mqtt_server_socket_path, const std::string& mqtt_server_address, int mqtt_server_port,
+            const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix,
+            const std::string& telemetry_prefix, bool telemetry_enabled);
 
     // forbid copy assignment and copy construction
     // NOTE (aw): move assignment and construction are also not supported because we're creating explicit references to

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -74,7 +74,7 @@ inline constexpr auto WWW_DIR = "www";
 
 inline constexpr auto CONTROLLER_PORT = 8849;
 inline constexpr auto CONTROLLER_RPC_TIMEOUT_MS = 2000;
-inline constexpr auto MQTT_BROKER_SOCKET_PATH = "/tmp/mqtt_brocker.sock";
+inline constexpr auto MQTT_BROKER_SOCKET_PATH = "/tmp/mqtt_broker.sock";
 inline constexpr auto MQTT_BROKER_HOST = "localhost";
 inline constexpr auto MQTT_BROKER_PORT = 1883;
 inline constexpr auto MQTT_EVEREST_PREFIX = "everest";

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -74,6 +74,7 @@ inline constexpr auto WWW_DIR = "www";
 
 inline constexpr auto CONTROLLER_PORT = 8849;
 inline constexpr auto CONTROLLER_RPC_TIMEOUT_MS = 2000;
+inline constexpr auto MQTT_BROKER_SOCKET_PATH = "/tmp/mqtt_brocker.sock";
 inline constexpr auto MQTT_BROKER_HOST = "localhost";
 inline constexpr auto MQTT_BROKER_PORT = 1883;
 inline constexpr auto MQTT_EVEREST_PREFIX = "everest";
@@ -109,6 +110,7 @@ struct RuntimeSettings {
     fs::path www_dir;
     int controller_port;
     int controller_rpc_timeout_ms;
+    std::string mqtt_broker_socket_path;
     std::string mqtt_broker_host;
     int mqtt_broker_port;
     std::string mqtt_everest_prefix;

--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -20,8 +20,9 @@ class MQTTAbstractionImpl;
 ///
 class MQTTAbstraction {
 public:
-    MQTTAbstraction(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
-                    const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix);
+    MQTTAbstraction(const std::string& mqtt_server_socket_path, const std::string& mqtt_server_address,
+                    const std::string& mqtt_server_port, const std::string& mqtt_everest_prefix,
+                    const std::string& mqtt_external_prefix);
 
     // forbid copy assignment and copy construction
     MQTTAbstraction(MQTTAbstraction const&) = delete;

--- a/include/utils/mqtt_abstraction_impl.hpp
+++ b/include/utils/mqtt_abstraction_impl.hpp
@@ -38,6 +38,9 @@ class MQTTAbstractionImpl {
 public:
     MQTTAbstractionImpl(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
                         const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix);
+    MQTTAbstractionImpl(const std::string& mqtt_server_socket_path, const std::string& mqtt_everest_prefix,
+                        const std::string& mqtt_external_prefix);
+
     ~MQTTAbstractionImpl();
 
     MQTTAbstractionImpl(MQTTAbstractionImpl const&) = delete;
@@ -104,7 +107,7 @@ public:
     static void publish_callback(void** unused, struct mqtt_response_publish* published);
 
 private:
-    static constexpr int mqtt_poll_timeout_ms{100};
+    static constexpr int mqtt_poll_timeout_ms{300000};
     bool mqtt_is_connected;
     std::map<std::string, MessageHandler> message_handlers;
     std::mutex handlers_mutex;
@@ -114,6 +117,7 @@ private:
 
     Thread mqtt_mainloop_thread;
 
+    std::string mqtt_server_socket_path;
     std::string mqtt_server_address;
     std::string mqtt_server_port;
     std::string mqtt_everest_prefix;
@@ -123,6 +127,7 @@ private:
     uint8_t recvbuf[MQTT_BUF_SIZE];
 
     static int open_nb_socket(const char* addr, const char* port);
+    bool connectBroker(std::string& socket_path);
     bool connectBroker(const char* host, const char* port);
     void on_mqtt_message(std::shared_ptr<Message> message);
     void on_mqtt_connect();

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -27,9 +27,11 @@ const auto remote_cmd_res_timeout_seconds = 300;
 const std::array<std::string, 3> TELEMETRY_RESERVED_KEYS = {{"connector_id"}};
 
 Everest::Everest(std::string module_id_, const Config& config_, bool validate_data_with_schema,
-                 const std::string& mqtt_server_address, int mqtt_server_port, const std::string& mqtt_everest_prefix,
-                 const std::string& mqtt_external_prefix, const std::string& telemetry_prefix, bool telemetry_enabled) :
-    mqtt_abstraction(mqtt_server_address, std::to_string(mqtt_server_port), mqtt_everest_prefix, mqtt_external_prefix),
+                 const std::string& mqtt_server_socket_path, const std::string& mqtt_server_address,
+                 int mqtt_server_port, const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix,
+                 const std::string& telemetry_prefix, bool telemetry_enabled) :
+    mqtt_abstraction(mqtt_server_socket_path, mqtt_server_address, std::to_string(mqtt_server_port),
+                     mqtt_everest_prefix, mqtt_external_prefix),
     config(std::move(config_)),
     module_id(std::move(module_id_)),
     remote_cmd_res_timeout(remote_cmd_res_timeout_seconds),

--- a/lib/mqtt_abstraction.cpp
+++ b/lib/mqtt_abstraction.cpp
@@ -6,11 +6,17 @@
 #include <utils/mqtt_abstraction_impl.hpp>
 
 namespace Everest {
-MQTTAbstraction::MQTTAbstraction(const std::string& mqtt_server_address, const std::string& mqtt_server_port,
-                                 const std::string& mqtt_everest_prefix, const std::string& mqtt_external_prefix) :
-    mqtt_abstraction(std::make_unique<MQTTAbstractionImpl>(mqtt_server_address, mqtt_server_port, mqtt_everest_prefix,
-                                                           mqtt_external_prefix)) {
+MQTTAbstraction::MQTTAbstraction(const std::string& mqtt_server_socket_path, const std::string& mqtt_server_address,
+                                 const std::string& mqtt_server_port, const std::string& mqtt_everest_prefix,
+                                 const std::string& mqtt_external_prefix) {
     EVLOG_debug << "initialized mqtt_abstraction";
+    if (mqtt_server_socket_path.empty()) {
+        mqtt_abstraction = std::make_unique<MQTTAbstractionImpl>(mqtt_server_address, mqtt_server_port,
+                                                                 mqtt_everest_prefix, mqtt_external_prefix);
+    } else {
+        mqtt_abstraction =
+            std::make_unique<MQTTAbstractionImpl>(mqtt_server_socket_path, mqtt_everest_prefix, mqtt_external_prefix);
+    }
 }
 
 MQTTAbstraction::~MQTTAbstraction() = default;

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -49,6 +49,8 @@ properties:
         type: integer
       controller_rpc_timeout_ms:
         type: integer
+      mqtt_broker_socket_path:
+        type: string
       mqtt_broker_host:
         type: string
       mqtt_broker_port:

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -492,7 +492,11 @@ int boot(const po::variables_map& vm) {
     EVLOG_info << fmt::format(TERMINAL_STYLE_BLUE, " |______|   \\/ \\___|_|  \\___||___/\\__|");
     EVLOG_info << "";
 
-    EVLOG_info << "Using MQTT broker " << rs->mqtt_broker_host << ":" << rs->mqtt_broker_port;
+    if (rs->mqtt_broker_socket_path.empty()) {
+        EVLOG_info << "Using MQTT broker " << rs->mqtt_broker_host << ":" << rs->mqtt_broker_port;
+    } else {
+        EVLOG_info << "Using MQTT broker unix domain sockets:" << rs->mqtt_broker_socket_path;
+    }
     if (rs->telemetry_enabled) {
         EVLOG_info << "Telemetry enabled";
     }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -588,12 +588,17 @@ int boot(const po::variables_map& vm) {
     // create StatusFifo object
     auto status_fifo = StatusFifo::create_from_path(vm["status-fifo"].as<std::string>());
 
-    auto mqtt_abstraction = MQTTAbstraction(rs->mqtt_broker_host, std::to_string(rs->mqtt_broker_port),
-                                            rs->mqtt_everest_prefix, rs->mqtt_external_prefix);
+    auto mqtt_abstraction =
+        MQTTAbstraction(rs->mqtt_broker_socket_path, rs->mqtt_broker_host, std::to_string(rs->mqtt_broker_port),
+                        rs->mqtt_everest_prefix, rs->mqtt_external_prefix);
 
     if (!mqtt_abstraction.connect()) {
-        EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", rs->mqtt_broker_host,
-                                   rs->mqtt_broker_port);
+        if (rs->mqtt_broker_socket_path.empty()) {
+            EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", rs->mqtt_broker_host,
+                                       rs->mqtt_broker_port);
+        } else {
+            EVLOG_error << fmt::format("Cannot connect to MQTT broker socket at {}", rs->mqtt_broker_socket_path);
+        }
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
* Added support for Unix Domain Sockets for MQTT communication
   - Created a new config option 'mqtt_broker_socket_path' where one can provide the socket path
   - The config option mutual exclusive to the normal TCP socket and will raise an exception if both are provided in the config file (or as env variable)
   - There is no default value for the UDS path, it must be provided in the config file
   - We keep the backward compatibility, thus if nothing is provided in the config file, the default MQTT values are used (localhost:1883)
   - Beside functionality added, this provides an optimization over the TCP connection (observed on slow systems around 5%)
   - Updated the config schema to for the new option
* Optimization made in the MQTT event loop (we moved from executing the event loop from 100ms to 300s)
   - Normally the keep alive message is send by the MQTT lib, in certain cases however this might not work unless you call mqtt_sync often and on regular basis (few ms)
   - We decreased the event loop execution frequency drastically (on slow systems we can see a decrease of CPU usage around 10%)