### PR TITLE
Update fmtlib dependency to v10.1.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -51,7 +51,7 @@ liblog:
   options: ["BUILD_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libfmt:
   git: https://github.com/fmtlib/fmt.git
-  git_tag: 9.1.0
+  git_tag: 10.1.0
   options:
     ["FMT_TEST OFF", "FMT_DOC OFF", "BUILD_SHARED_LIBS ON", "FMT_INSTALL ON"]
 date:


### PR DESCRIPTION
I stumpled over the version mismatch when trying to run a binary which was created with a standalone cmake cross-build for our Charge Control C platform.

The cross-build binary required fmtlib in version 9 on the target which was not available.

Reason is, that in meta-everest there is a recipe for v10.1.0 and it is used when building EVerest in Yocto environments.

Since we are testing our Yocto EVerest builds extensively and did not encounter any problems so far, I assume that the update does not cause issues.