### PR TITLE
Bazel: update pybind11

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,6 +2,24 @@ workspace(name = "everest-framework")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+SHA="c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311"
+VERSION="0.31.0"
+
+http_archive(
+    name = "rules_python",
+    sha256 = SHA,
+    strip_prefix = "rules_python-{}".format(VERSION),
+    url = "https://github.com/bazelbuild/rules_python/releases/download/{}/rules_python-{}.tar.gz".format(VERSION,VERSION),
+)
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
+py_repositories()
+
+python_register_toolchains(
+    name = "python3_10",
+    python_version = "3.10",
+)
+
 http_archive(
     name = "rules_rust",
     sha256 = "36ab8f9facae745c9c9c1b33d225623d976e78f2cc3f729b7973d8c20934ab95",

--- a/third-party/bazel/defs.bzl
+++ b/third-party/bazel/defs.bzl
@@ -1,11 +1,9 @@
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 load("@cxx.rs//third-party/bazel:defs.bzl", cxx_crate_repositories = "crate_repositories")
-load("@pybind11_bazel//:python_configure.bzl", "python_configure")
 
 
 def everest_framework_deps(repo_mapping = {}):
     boost_deps()
     rules_foreign_cc_dependencies()
     cxx_crate_repositories()
-    python_configure(name = "local_config_python")

--- a/third-party/bazel/repos.bzl
+++ b/third-party/bazel/repos.bzl
@@ -192,10 +192,10 @@ make(
     )
 
     maybe(
-        http_archive,
+        git_repository,
         name = "pybind11_bazel",
-        strip_prefix = "pybind11_bazel-8889d39b2b925b2a47519ae09402a96f00ccf2b4",
-        urls = ["https://github.com/pybind/pybind11_bazel/archive/8889d39b2b925b2a47519ae09402a96f00ccf2b4.zip"],
+        tag = "v2.11.1.bzl.2",
+        remote = "https://github.com/pybind/pybind11_bazel",
     )
 
     maybe(


### PR DESCRIPTION
Updates the bazel dependencies for pybind11 - allowing hermetic python builds