### PR TITLE
Rust: Add default and clone for mocked ModulePublisher

### DIFF
--- a/everestrs/everestrs-build/jinja/module.jinja2
+++ b/everestrs/everestrs-build/jinja/module.jinja2
@@ -33,8 +33,8 @@ pub(crate) trait OnReadySubscriber: Sync + Send {
 {% include "client" %}
 {% endfor %}
 
-#[cfg_attr(any(not(test), not(feature = "mockall")), derive(Clone))]
-#[cfg_attr(all(test, feature = "mockall"), derive(Default))]
+#[derive(Clone)]
+#[cfg_attr(all(test, feature="mockall"), derive(Default))]
 pub(crate) struct ModulePublisher {
 {% for provide in provides %}
    pub(crate) {{ provide.implementation_id | identifier }}: {{provide.interface | title}}ServicePublisher,


### PR DESCRIPTION
Extends the codegen to support default and clone for the mocked ModulePublisher