### PR TITLE
Rust: Link against gcov

### DIFF
--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -14,3 +14,4 @@ thiserror = "1.0.48"
 
 [features]
 build_bazel = []
+link_gcov = []

--- a/everestrs/everestrs/build.rs
+++ b/everestrs/everestrs/build.rs
@@ -87,6 +87,11 @@ fn print_link_options(p: &Path) {
         p.parent().unwrap().to_string_lossy()
     );
     println!("cargo:rustc-link-lib={}", libname_from_path(p));
+    // If the c++ libraries are build with `-fprofile-arcs -ftest-coverage`
+    // compiler flags we've to link against the `gcov` lib as well.
+    if env::var("CARGO_FEATURE_LINK_GCOV").is_ok() {
+        println!("cargo:rustc-link-lib=gcov");
+    }
 }
 
 fn find_libs_in_everest_workspace() -> Option<Libraries> {


### PR DESCRIPTION
When we build with BUILD_TESTING, we're adding the flags for gcov and need to subsequently link against gcov. This commit fixes the behavior for rust