### PR TITLE
add virtual destructor to prevent potential memory leak

### DIFF
--- a/include/framework/ModuleAdapter.hpp
+++ b/include/framework/ModuleAdapter.hpp
@@ -55,6 +55,7 @@ private:
 class ModuleBase {
 public:
     ModuleBase(const ModuleInfo& info) : info(info){};
+    virtual ~ModuleBase() = default;
 
     const ModuleInfo& info;
 


### PR DESCRIPTION
When looking through the EVerest code, I found that ModuleBase did not have a virtual destructor, though all modules do inherit from it.
For now this is not much of an issue, because the modules are not heap allocated and destroyed by base, but looking at the TODO in the ld_ev.cpp this may come up (by saving the modules by the ModuleBase)

I tried to make a snippet in Godbolt to prove the issue, but in a single compilation unit this apparently doesn't come forward, but it's a [common known issue](https://softwareengineering.stackexchange.com/questions/328530/what-are-the-consequences-of-no-virtual-destructor-for-this-base-class) with missing virtual destructors.