### PR TITLE
Move some logging from debug to verbose level

### DIFF
--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -303,7 +303,7 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
             return;
         }
 
-        EVLOG_debug << fmt::format(
+        EVLOG_verbose << fmt::format(
             "Incoming res {} for {}->{}()", data_id,
             this->config.printable_identifier(connection["module_id"], connection["implementation_id"]), cmd_name);
 
@@ -338,7 +338,7 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
             "Timeout while waiting for result of {}->{}()",
             this->config.printable_identifier(connection["module_id"], connection["implementation_id"]), cmd_name)));
     } else if (res_future_status == std::future_status::ready) {
-        EVLOG_debug << "res future ready";
+        EVLOG_verbose << "res future ready";
         result = res_future.get();
     }
     this->mqtt_abstraction.unregister_handler(cmd_topic, res_token);
@@ -649,7 +649,7 @@ UnsubscribeToken Everest::provide_external_mqtt_handler(const std::string& topic
     std::string external_topic = fmt::format("{}{}", this->mqtt_external_prefix, topic);
 
     Handler external_handler = [this, handler, external_topic](json const& data) {
-        EVLOG_debug << fmt::format("Incoming external mqtt data for topic '{}'...", external_topic);
+        EVLOG_verbose << fmt::format("Incoming external mqtt data for topic '{}'...", external_topic);
         if (!data.is_string()) {
             EVLOG_AND_THROW(EverestInternalError("External mqtt result is not a string (that should never happen)"));
         }
@@ -765,9 +765,9 @@ void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name,
             arg_names = Config::keys(cmd_definition["arguments"]);
         }
 
-        EVLOG_debug << fmt::format("Incoming {}->{}({}) for <handler>",
-                                   this->config.printable_identifier(this->module_id, impl_id), cmd_name,
-                                   fmt::join(arg_names, ","));
+        EVLOG_verbose << fmt::format("Incoming {}->{}({}) for <handler>",
+                                     this->config.printable_identifier(this->module_id, impl_id), cmd_name,
+                                     fmt::join(arg_names, ","));
 
         // check data and ignore it if not matching (publishing it should have
         // been prohibited already)
@@ -820,7 +820,7 @@ void Everest::provide_cmd(const std::string impl_id, const std::string cmd_name,
             }
         }
 
-        EVLOG_debug << fmt::format("RETVAL: {}", res_data["retval"].dump());
+        EVLOG_verbose << fmt::format("RETVAL: {}", res_data["retval"].dump());
         res_data["origin"] = this->module_id;
 
         json res_publish_data = json::object({{"name", cmd_name}, {"type", "result"}, {"data", res_data}});

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -414,7 +414,7 @@ void Everest::subscribe_var(const Requirement& req, const std::string& var_name,
 
     Handler handler = [this, requirement_module_id, requirement_impl_id, requirement_manifest_vardef, var_name,
                        callback](json const& data) {
-        EVLOG_debug << fmt::format(
+        EVLOG_verbose << fmt::format(
             "Incoming {}->{}", this->config.printable_identifier(requirement_module_id, requirement_impl_id), var_name);
 
         if (this->validate_data_with_schema) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -160,7 +160,7 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
     }
     notify_write_data();
 
-    EVLOG_debug << fmt::format("publishing to {}", topic);
+    EVLOG_verbose << fmt::format("publishing to {}", topic);
 }
 
 void MQTTAbstractionImpl::subscribe(const std::string& topic) {
@@ -277,7 +277,7 @@ void MQTTAbstractionImpl::on_mqtt_message(std::shared_ptr<Message> message) {
         std::shared_ptr<json> data;
         bool is_everest_topic = false;
         if (topic.find(mqtt_everest_prefix) == 0) {
-            EVLOG_debug << fmt::format("topic {} starts with {}", topic, mqtt_everest_prefix);
+            EVLOG_verbose << fmt::format("topic {} starts with {}", topic, mqtt_everest_prefix);
             is_everest_topic = true;
             try {
                 data = std::make_shared<json>(json::parse(payload));

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -366,8 +366,8 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
                                    fmt::ptr(&handler->handler), handler->name, topic);
         break;
     case HandlerType::Result:
-        EVLOG_debug << fmt::format("Registering result handler {} for command {} on topic {}",
-                                   fmt::ptr(&handler->handler), handler->name, topic);
+        EVLOG_verbose << fmt::format("Registering result handler {} for command {} on topic {}",
+                                     fmt::ptr(&handler->handler), handler->name, topic);
         break;
     case HandlerType::SubscribeVar:
         EVLOG_debug << fmt::format("Registering subscribe handler {} for variable {} on topic {}",
@@ -400,16 +400,16 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
     // only subscribe for this topic if we aren't already and the mqtt client is connected
     // if we are not connected the on_mqtt_connect() callback will subscribe to the topic
     if (this->mqtt_is_connected && this->message_handlers[topic].count_handlers() == 1) {
-        EVLOG_debug << fmt::format("Subscribing to {}", topic);
+        EVLOG_verbose << fmt::format("Subscribing to {}", topic);
         this->subscribe(topic, qos);
     }
-    EVLOG_debug << fmt::format("#handler[{}] = {}", topic, this->message_handlers[topic].count_handlers());
+    EVLOG_verbose << fmt::format("#handler[{}] = {}", topic, this->message_handlers[topic].count_handlers());
 }
 
 void MQTTAbstractionImpl::unregister_handler(const std::string& topic, const Token& token) {
     BOOST_LOG_FUNCTION();
 
-    EVLOG_debug << fmt::format("Unregistering handler {} for {}", fmt::ptr(&token), topic);
+    EVLOG_verbose << fmt::format("Unregistering handler {} for {}", fmt::ptr(&token), topic);
 
     const std::lock_guard<std::mutex> lock(handlers_mutex);
     auto number_of_handlers = 0;
@@ -425,13 +425,13 @@ void MQTTAbstractionImpl::unregister_handler(const std::string& topic, const Tok
     if (number_of_handlers == 0) {
         // TODO(kai): should we throw/log an error if we are not connected?
         if (this->mqtt_is_connected) {
-            EVLOG_debug << fmt::format("Unsubscribing from {}", topic);
+            EVLOG_verbose << fmt::format("Unsubscribing from {}", topic);
             this->unsubscribe(topic);
         }
     }
 
     const std::string handler_count = (number_of_handlers == 0) ? "None" : std::to_string(number_of_handlers);
-    EVLOG_debug << fmt::format("#handler[{}] = {}", topic, handler_count);
+    EVLOG_verbose << fmt::format("#handler[{}] = {}", topic, handler_count);
 }
 
 bool MQTTAbstractionImpl::connectBroker(std::string& socket_path) {


### PR DESCRIPTION
If the logger is configured to show log messages above and including log level debug (DEBG) instead of info (INFO), a lot of somewhat useless information spams the logs. This distracts from the actual debug information the modules are trying to provide.

The spam includes all subscriptions and de-subscriptions to MQTT topics, incoming MQTT messages, and so on. All these are provided by the framework.

This change puts many of the spammy log messages into the verbose (VERB) level. Those used at the initial launch of the modules are still in level debug (DEBG), since they don't disturb the log during actual operation.

Co-authored-by: Mohannad Oraby <mohannad.oraby@chargebyte.com>