### PR TITLE
everestjs: Fix node-addon-api error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 project(everest-framework
     VERSION 0.16.0
     DESCRIPTION "The open operating system for e-mobility charging stations"
-	LANGUAGES CXX C
+    LANGUAGES CXX C
 )
 
 find_package(everest-cmake 0.4 REQUIRED

--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -46,7 +46,7 @@ if (NOT NODE_ADDON_API_PACKAGE_DIR)
     )
 
     if (NPM_INSTALL_NODE_ADDON_API_FAILED)
-        message(FATAL "Installation of node-addon-api failed")
+        message(FATAL_ERROR "Installation of node-addon-api failed")
     endif ()
 endif ()
 


### PR DESCRIPTION
Let CMake fail if node-addon-api can't be installed.