### PR TITLE
Expose mappings of requirements, provides and modules to modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.17.2
+    VERSION 0.18.0
     DESCRIPTION "The open operating system for e-mobility charging stations"
     LANGUAGES CXX C
 )

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <framework/runtime.hpp>
+#include <utils/types.hpp>
 
 class RuntimeSession {
 public:
@@ -26,12 +27,6 @@ private:
     std::unique_ptr<Everest::Config> config;
 
     static std::unique_ptr<Everest::Config> create_config_instance(std::shared_ptr<Everest::RuntimeSettings> rs);
-};
-
-struct Fulfillment {
-    std::string module_id;
-    std::string implementation_id;
-    Requirement requirement;
 };
 
 struct Interface {

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -108,14 +108,14 @@ void Module::provide_command(const Runtime& rt, rust::String implementation_id, 
 
 void Module::subscribe_variable(const Runtime& rt, rust::String implementation_id, size_t index,
                                 rust::String name) const {
-    const Requirement req(std::string(implementation_id), index);
+    const auto req = Requirement{std::string(implementation_id), index};
     handle_->subscribe_var(req, std::string(name), [&rt, implementation_id, index, name](json args) {
         rt.handle_variable(implementation_id, index, name, json2blob(args));
     });
 }
 
 JsonBlob Module::call_command(rust::Str implementation_id, size_t index, rust::Str name, JsonBlob blob) const {
-    const Requirement req(std::string(implementation_id), index);
+    const auto req = Requirement{std::string(implementation_id), index};
     json return_value = handle_->call_cmd(req, std::string(name), json::parse(blob.data.begin(), blob.data.end()));
 
     return json2blob(return_value);

--- a/include/framework/ModuleAdapter.hpp
+++ b/include/framework/ModuleAdapter.hpp
@@ -93,7 +93,6 @@ struct ModuleAdapter {
     using TelemetryPublishFunc =
         std::function<void(const std::string&, const std::string&, const std::string&, const TelemetryMap&)>;
     using GetMappingFunc = std::function<std::optional<ModuleTierMappings>()>;
-    using GetImplMappingFunc = std::function<std::optional<Mapping>(const std::string&)>;
 
     CallFunc call;
     PublishFunc publish;
@@ -110,7 +109,6 @@ struct ModuleAdapter {
     std::vector<cmd> registered_commands;
     TelemetryPublishFunc telemetry_publish;
     GetMappingFunc get_mapping;
-    GetImplMappingFunc get_impl_mapping;
 
     void check_complete() {
         // FIXME (aw): I should throw if some of my handlers are not set

--- a/include/framework/ModuleAdapter.hpp
+++ b/include/framework/ModuleAdapter.hpp
@@ -92,6 +92,8 @@ struct ModuleAdapter {
     using ExtMqttSubscribeFunc = std::function<UnsubscribeToken(const std::string&, StringHandler)>;
     using TelemetryPublishFunc =
         std::function<void(const std::string&, const std::string&, const std::string&, const TelemetryMap&)>;
+    using GetMappingFunc = std::function<std::optional<ModuleTierMappings>()>;
+    using GetImplMappingFunc = std::function<std::optional<Mapping>(const std::string&)>;
 
     CallFunc call;
     PublishFunc publish;
@@ -107,6 +109,8 @@ struct ModuleAdapter {
     ExtMqttSubscribeFunc ext_mqtt_subscribe;
     std::vector<cmd> registered_commands;
     TelemetryPublishFunc telemetry_publish;
+    GetMappingFunc get_mapping;
+    GetImplMappingFunc get_impl_mapping;
 
     void check_complete() {
         // FIXME (aw): I should throw if some of my handlers are not set

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -148,11 +148,6 @@ public:
     std::optional<ModuleTierMappings> get_3_tier_model_mapping();
 
     ///
-    /// \returns the 3 tier model mapping for the given \p impl_id
-    ///
-    std::optional<Mapping> get_3_tier_model_mapping(const std::string& impl_id);
-
-    ///
     /// \brief Chccks if all commands of a module that are listed in its manifest are available
     ///
     void check_code();
@@ -249,6 +244,13 @@ private:
     ///
     void subscribe_global_all_errors(const error::ErrorCallback& callback, const error::ErrorCallback& clear_callback);
 };
+
+///
+/// \returns the 3 tier model mapping from a \p module_tier_mapping for the given \p impl_id
+///
+std::optional<Mapping> get_impl_mapping(std::optional<ModuleTierMappings> module_tier_mappings,
+                                        const std::string& impl_id);
+
 } // namespace Everest
 
 #endif // FRAMEWORK_EVEREST_HPP

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -143,6 +143,16 @@ public:
     bool is_telemetry_enabled();
 
     ///
+    /// \returns the 3 tier model mappings for this module
+    ///
+    std::optional<ModuleTierMappings> get_3_tier_model_mapping();
+
+    ///
+    /// \returns the 3 tier model mapping for the given \p impl_id
+    ///
+    std::optional<Mapping> get_3_tier_model_mapping(const std::string& impl_id);
+
+    ///
     /// \brief Chccks if all commands of a module that are listed in its manifest are available
     ///
     void check_code();

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -134,8 +134,7 @@ void populate_module_info_path_from_runtime_settings(ModuleInfo&, std::shared_pt
 
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;
-    std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>
-        everest_register;
+    std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)> everest_register;
     std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)> init;
     std::function<void()> ready;
 
@@ -143,8 +142,7 @@ struct ModuleCallbacks {
 
     ModuleCallbacks(
         const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-        const std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
-            everest_register,
+        const std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)>& everest_register,
         const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
         const std::function<void()>& ready);
 };

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -135,7 +135,7 @@ void populate_module_info_path_from_runtime_settings(ModuleInfo&, std::shared_pt
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;
     std::function<std::vector<cmd>(
-        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>
+        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>
         everest_register;
     std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)> init;
     std::function<void()> ready;
@@ -144,7 +144,7 @@ struct ModuleCallbacks {
 
     ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
                     const std::function<std::vector<cmd>(
-                        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>&
+                        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
                         everest_register,
                     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
                     const std::function<void()>& ready);

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -143,7 +143,9 @@ struct ModuleCallbacks {
     ModuleCallbacks() = default;
 
     ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-                    const std::function<std::vector<cmd>(const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>& everest_register,
+                    const std::function<std::vector<cmd>(
+                        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>&
+                        everest_register,
                     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
                     const std::function<void()>& ready);
 };
@@ -166,7 +168,7 @@ private:
 
 public:
     explicit ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks) :
-        ModuleLoader(argc, argv, callbacks, {"undefined project", "undefined version", "undefined git version"}) {};
+        ModuleLoader(argc, argv, callbacks, {"undefined project", "undefined version", "undefined git version"}){};
     explicit ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks,
                           const VersionInformation version_information);
 

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -134,14 +134,16 @@ void populate_module_info_path_from_runtime_settings(ModuleInfo&, std::shared_pt
 
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;
-    std::function<std::vector<cmd>(const json& connections)> everest_register;
+    std::function<std::vector<cmd>(
+        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>
+        everest_register;
     std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)> init;
     std::function<void()> ready;
 
     ModuleCallbacks() = default;
 
     ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-                    const std::function<std::vector<cmd>(const json& connections)>& everest_register,
+                    const std::function<std::vector<cmd>(const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>& everest_register,
                     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
                     const std::function<void()>& ready);
 };
@@ -164,7 +166,7 @@ private:
 
 public:
     explicit ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks) :
-        ModuleLoader(argc, argv, callbacks, {"undefined project", "undefined version", "undefined git version"}){};
+        ModuleLoader(argc, argv, callbacks, {"undefined project", "undefined version", "undefined git version"}) {};
     explicit ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks,
                           const VersionInformation version_information);
 

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -134,20 +134,19 @@ void populate_module_info_path_from_runtime_settings(ModuleInfo&, std::shared_pt
 
 struct ModuleCallbacks {
     std::function<void(ModuleAdapter module_adapter)> register_module_adapter;
-    std::function<std::vector<cmd>(
-        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>
+    std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>
         everest_register;
     std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)> init;
     std::function<void()> ready;
 
     ModuleCallbacks() = default;
 
-    ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-                    const std::function<std::vector<cmd>(
-                        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
-                        everest_register,
-                    const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
-                    const std::function<void()>& ready);
+    ModuleCallbacks(
+        const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
+        const std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
+            everest_register,
+        const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
+        const std::function<void()>& ready);
 };
 
 struct VersionInformation {

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -147,8 +147,14 @@ public:
     json resolve_requirement(const std::string& module_id, const std::string& requirement_id) const;
 
     ///
-    /// \returns a map of Fulfillments for \p module_id
+    /// \returns a list of Requirements for \p module_id
     ///
+    std::list<Requirement> get_requirements(const std::string& module_id) const;
+
+    ///
+    /// \brief A Fulfillment is a combination of a Requirement and the module and implementation ids where this is
+    /// implemented
+    /// \returns a map of Fulfillments for \p module_id
     std::map<std::string, std::vector<Fulfillment>> get_fulfillments(const std::string& module_id);
 
     ///

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -105,12 +105,17 @@ private:
 
     ///
     /// \brief Parses the 3 tier model mappings in the config
+    /// A "mapping" can be specified in the following way:
     /// You can set a EVSE id called "evse" and Connector id called "connector" for the whole module.
-    /// Additionally a "mapping" can be specified in the following way:
+    /// Alternatively you can set individual mappings for implementations.
     /// mapping:
-    ///   implementation_id:
+    ///   module:
     ///     evse: 1
     ///     connector: 1
+    ///   implementations:
+    ///     implementation_id:
+    ///       evse: 1
+    ///       connector: 1
     /// If no mappings are found it will be assumed that the module is mapped to the charging station.
     /// If only a module mapping is defined alle implementations are mapped to this module mapping.
     /// Implementations can have overwritten mappings.

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -147,9 +147,9 @@ public:
     json resolve_requirement(const std::string& module_id, const std::string& requirement_id) const;
 
     ///
-    /// \returns a map of RequirementConnections for \p module_id
+    /// \returns a map of Fulfillments for \p module_id
     ///
-    std::map<std::string, std::vector<RequirementConnection>> get_requirement_connections(const std::string& module_id);
+    std::map<std::string, std::vector<Fulfillment>> get_fulfillments(const std::string& module_id);
 
     ///
     /// \brief checks if the config contains the given \p module_id

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -204,7 +204,7 @@ public:
 
     //
     /// \returns the 3 tier model mappings for the given \p module_id
-    std::optional<ModuleTierMappings> get_3_tier_model_mappings(const std::string& module_id);
+    std::optional<ModuleTierMappings> get_module_3_tier_model_mappings(const std::string& module_id);
 
     //
     /// \returns the 3 tier model mapping for the given \p module_id and \p impl_id

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -147,6 +147,13 @@ public:
     json resolve_requirement(const std::string& module_id, const std::string& requirement_id) const;
 
     ///
+    /// \brief resolves all Requirements of the given \p module_id to their Fulfillments
+    ///
+    /// \returns a map indexed by Requirements
+    std::map<Requirement, Fulfillment> resolve_requirements(const std::string& module_id) const;
+
+
+    ///
     /// \returns a list of Requirements for \p module_id
     ///
     std::list<Requirement> get_requirements(const std::string& module_id) const;

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -152,7 +152,6 @@ public:
     /// \returns a map indexed by Requirements
     std::map<Requirement, Fulfillment> resolve_requirements(const std::string& module_id) const;
 
-
     ///
     /// \returns a list of Requirements for \p module_id
     ///
@@ -163,6 +162,12 @@ public:
     /// implemented
     /// \returns a map of Fulfillments for \p module_id
     std::map<std::string, std::vector<Fulfillment>> get_fulfillments(const std::string& module_id) const;
+
+    ///
+    /// \brief A RequirementInitialization contains everything needed to initialize a requirement in user code. This
+    /// includes the Requirement, its Fulfillment and an optional Mapping
+    /// \returns a RequirementInitialization
+    RequirementInitialization get_requirement_initialization(const std::string& module_id) const;
 
     ///
     /// \brief checks if the config contains the given \p module_id

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -147,9 +147,9 @@ public:
     json resolve_requirement(const std::string& module_id, const std::string& requirement_id) const;
 
     ///
-    /// \returns a list of Requirements for \p module_id
+    /// \returns a map of RequirementConnections for \p module_id
     ///
-    std::list<Requirement> get_requirements(const std::string& module_id) const;
+    std::map<std::string, std::vector<RequirementConnection>> get_requirement_connections(const std::string& module_id);
 
     ///
     /// \brief checks if the config contains the given \p module_id

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -155,7 +155,7 @@ public:
     /// \brief A Fulfillment is a combination of a Requirement and the module and implementation ids where this is
     /// implemented
     /// \returns a map of Fulfillments for \p module_id
-    std::map<std::string, std::vector<Fulfillment>> get_fulfillments(const std::string& module_id);
+    std::map<std::string, std::vector<Fulfillment>> get_fulfillments(const std::string& module_id) const;
 
     ///
     /// \brief checks if the config contains the given \p module_id
@@ -204,11 +204,11 @@ public:
 
     //
     /// \returns the 3 tier model mappings for the given \p module_id
-    std::optional<ModuleTierMappings> get_module_3_tier_model_mappings(const std::string& module_id);
+    std::optional<ModuleTierMappings> get_module_3_tier_model_mappings(const std::string& module_id) const;
 
     //
     /// \returns the 3 tier model mapping for the given \p module_id and \p impl_id
-    std::optional<Mapping> get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id);
+    std::optional<Mapping> get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id) const;
 
     ///
     /// \brief turns then given \p module_id into a printable identifier

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -138,13 +138,22 @@ struct Requirement {
 };
 
 /// \brief A Fulfillment relates a Requirement to its connected implementation, identified via its module and
-/// implementation id. It additionally provides access to the Mapping associated with the Requirement.
+/// implementation id.
 struct Fulfillment {
     std::string module_id;
     std::string implementation_id;
     Requirement requirement;
     std::optional<Mapping> mapping;
 };
+
+/// \brief Contains everything that's needed to initialize a requirement in user code
+struct RequirementInitializer {
+    Requirement requirement;
+    Fulfillment fulfillment;
+    std::optional<Mapping> mapping;
+};
+
+using RequirementInitialization = std::map<std::string, std::vector<RequirementInitializer>>;
 
 struct ImplementationIdentifier {
     ImplementationIdentifier(const std::string& module_id_, const std::string& implementation_id_,

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -130,8 +130,6 @@ struct TelemetryConfig {
 };
 
 struct Requirement {
-    Requirement() = default;
-    Requirement(const std::string& requirement_id_, size_t index_);
     std::string id;
     size_t index = 0;
 };

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -105,10 +105,17 @@ struct ModuleTierMappings {
 };
 
 struct Requirement {
-    Requirement(const std::string& requirement_id_, size_t index_);
+    Requirement() = default;
+    Requirement(const std::string& requirement_id_, size_t index_, std::optional<Mapping> mapping = std::nullopt);
     bool operator<(const Requirement& rhs) const;
     std::string id;
-    size_t index;
+    size_t index = 0;
+    std::optional<Mapping> mapping;
+};
+
+struct RequirementConnection {
+    Requirement requirement;
+    std::string requirement_module_id;
 };
 
 struct ImplementationIdentifier {

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -64,26 +64,6 @@ enum class QOS {
     QOS2  ///< Exactly once delivery
 };
 
-struct ModuleInfo {
-    struct Paths {
-        std::filesystem::path etc;
-        std::filesystem::path libexec;
-        std::filesystem::path share;
-    };
-
-    std::string name;
-    std::vector<std::string> authors;
-    std::string license;
-    std::string id;
-    Paths paths;
-    bool telemetry_enabled;
-    bool global_errors_enabled;
-};
-
-struct TelemetryConfig {
-    int id;
-};
-
 /// \brief A Mapping that can be used to map a module or implementation to a specific EVSE or optionally to a Connector
 struct Mapping {
     int evse;                     ///< The EVSE id
@@ -126,6 +106,27 @@ struct ModuleTierMappings {
                                    ///< absent the module is assumed to be mapped to the whole charging station
     std::unordered_map<std::string, std::optional<Mapping>>
         implementations; ///< Mappings for the individual implementations of the module
+};
+
+struct ModuleInfo {
+    struct Paths {
+        std::filesystem::path etc;
+        std::filesystem::path libexec;
+        std::filesystem::path share;
+    };
+
+    std::string name;
+    std::vector<std::string> authors;
+    std::string license;
+    std::string id;
+    Paths paths;
+    bool telemetry_enabled;
+    bool global_errors_enabled;
+    std::optional<Mapping> mapping;
+};
+
+struct TelemetryConfig {
+    int id;
 };
 
 struct Requirement {

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -131,11 +131,10 @@ struct TelemetryConfig {
 
 struct Requirement {
     Requirement() = default;
-    Requirement(const std::string& requirement_id_, size_t index_, std::optional<Mapping> mapping = std::nullopt);
+    Requirement(const std::string& requirement_id_, size_t index_);
     bool operator<(const Requirement& rhs) const;
     std::string id;
     size_t index = 0;
-    std::optional<Mapping> mapping;
 };
 
 /// \brief Describes a how a requirement is fulfilled by a connection to another module and its implementation
@@ -143,6 +142,7 @@ struct Fulfillment {
     std::string module_id;
     std::string implementation_id;
     Requirement requirement;
+    std::optional<Mapping> mapping;
 };
 
 struct ImplementationIdentifier {

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -137,7 +137,8 @@ struct Requirement {
     size_t index = 0;
 };
 
-/// \brief Describes a how a requirement is fulfilled by a connection to another module and its implementation
+/// \brief A Fulfillment relates a Requirement to its connected implementation, identified via its module and
+/// implementation id. It additionally provides access to the Mapping associated with the Requirement.
 struct Fulfillment {
     std::string module_id;
     std::string implementation_id;

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -138,9 +138,11 @@ struct Requirement {
     std::optional<Mapping> mapping;
 };
 
-struct RequirementConnection {
+/// \brief Describes a how a requirement is fulfilled by a connection to another module and its implementation
+struct Fulfillment {
+    std::string module_id;
+    std::string implementation_id;
     Requirement requirement;
-    std::string requirement_module_id;
 };
 
 struct ImplementationIdentifier {

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -132,10 +132,11 @@ struct TelemetryConfig {
 struct Requirement {
     Requirement() = default;
     Requirement(const std::string& requirement_id_, size_t index_);
-    bool operator<(const Requirement& rhs) const;
     std::string id;
     size_t index = 0;
 };
+
+bool operator<(const Requirement& lhs, const Requirement& rhs);
 
 /// \brief A Fulfillment relates a Requirement to its connected implementation, identified via its module and
 /// implementation id.

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -96,6 +96,30 @@ struct Mapping {
     }
 };
 
+/// \brief Writes the string representation of the given Mapping \p mapping to the given output stream \p os
+/// \returns an output stream with the Mapping written to
+inline std::ostream& operator<<(std::ostream& os, const Mapping& mapping) {
+    os << "Mapping(evse: " << mapping.evse;
+    if (mapping.connector.has_value()) {
+        os << ", connector: " << mapping.connector.value();
+    }
+    os << ")";
+
+    return os;
+}
+
+/// \brief Writes the string representation of the given Mapping \p mapping to the given output stream \p os
+/// \returns an output stream with the Mapping written to
+inline std::ostream& operator<<(std::ostream& os, const std::optional<Mapping>& mapping) {
+    if (mapping.has_value()) {
+        os << mapping.value();
+    } else {
+        os << "Mapping(charging station)";
+    }
+
+    return os;
+}
+
 /// \brief A 3 tier mapping for a module and its individual implementations
 struct ModuleTierMappings {
     std::optional<Mapping> module; ///< Mapping of the whole module to an EVSE id and optional Connector id. If this is

--- a/include/utils/types.hpp
+++ b/include/utils/types.hpp
@@ -143,7 +143,6 @@ struct Fulfillment {
     std::string module_id;
     std::string implementation_id;
     Requirement requirement;
-    std::optional<Mapping> mapping;
 };
 
 /// \brief Contains everything that's needed to initialize a requirement in user code

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -756,6 +756,19 @@ std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const s
     return res;
 }
 
+RequirementInitialization Config::get_requirement_initialization(const std::string& module_id) const {
+    BOOST_LOG_FUNCTION();
+
+    RequirementInitialization res;
+
+    for (const auto& [requirement, fulfillment] : this->resolve_requirements(module_id)) {
+        const auto& mapping = this->get_3_tier_model_mapping(fulfillment.module_id, fulfillment.implementation_id);
+        res[requirement.id].push_back({requirement, fulfillment, mapping});
+    }
+
+    return res;
+}
+
 bool Config::contains(const std::string& module_id) const {
     BOOST_LOG_FUNCTION();
     return this->main.contains(module_id);

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -714,16 +714,14 @@ std::map<Requirement, Fulfillment> Config::resolve_requirements(const std::strin
         if (!resolved_req.is_array()) {
             const auto resolved_module_id = resolved_req.at("module_id");
             const auto resolved_impl_id = resolved_req.at("implementation_id");
-            const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
             Requirement req(req_id, 0);
-            requirements[req] = {resolved_module_id, resolved_impl_id, req, mapping};
+            requirements[req] = {resolved_module_id, resolved_impl_id, req};
         } else {
             for (int i = 0; i < resolved_req.size(); i++) {
                 const auto resolved_module_id = resolved_req.at(i).at("module_id");
                 const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
-                const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
                 Requirement req(req_id, i);
-                requirements[req] = {resolved_module_id, resolved_impl_id, req, mapping};
+                requirements[req] = {resolved_module_id, resolved_impl_id, req};
             }
         }
     }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -710,9 +710,9 @@ std::list<Requirement> Config::get_requirements(const std::string& module_id) co
 
     std::list<Requirement> res;
 
-    std::string module_name = get_module_name(module_id);
+    const std::string module_name = get_module_name(module_id);
     for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
-        json resolved_req = this->resolve_requirement(module_id, req_id);
+        const json resolved_req = this->resolve_requirement(module_id, req_id);
         if (!resolved_req.is_array()) {
             Requirement req(req_id, 0);
             res.push_back(req);
@@ -727,25 +727,25 @@ std::list<Requirement> Config::get_requirements(const std::string& module_id) co
     return res;
 }
 
-std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const std::string& module_id) {
+std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const std::string& module_id) const {
     BOOST_LOG_FUNCTION();
 
     std::map<std::string, std::vector<Fulfillment>> res;
 
-    std::string module_name = get_module_name(module_id);
+    const std::string module_name = get_module_name(module_id);
     for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
         std::vector<Fulfillment> fulfillments;
-        json resolved_req = this->resolve_requirement(module_id, req_id);
+        const json resolved_req = this->resolve_requirement(module_id, req_id);
         if (!resolved_req.is_array()) {
-            auto resolved_module_id = resolved_req.at("module_id");
-            auto resolved_impl_id = resolved_req.at("implementation_id");
+            const auto resolved_module_id = resolved_req.at("module_id");
+            const auto resolved_impl_id = resolved_req.at("implementation_id");
             const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
             Requirement req(req_id, 0);
             fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
         } else {
             for (int i = 0; i < resolved_req.size(); i++) {
-                auto resolved_module_id = resolved_req.at(i).at("module_id");
-                auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
+                const auto resolved_module_id = resolved_req.at(i).at("module_id");
+                const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
                 const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
                 Requirement req(req_id, i);
                 fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
@@ -839,19 +839,19 @@ std::unordered_map<std::string, ModuleTierMappings> Config::get_3_tier_model_map
     return this->tier_mappings;
 }
 
-std::optional<ModuleTierMappings> Config::get_module_3_tier_model_mappings(const std::string& module_id) {
+std::optional<ModuleTierMappings> Config::get_module_3_tier_model_mappings(const std::string& module_id) const {
     if (this->tier_mappings.find(module_id) == this->tier_mappings.end()) {
         return std::nullopt;
     }
     return this->tier_mappings.at(module_id);
 }
 
-std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id) {
-    auto module_tier_mappings = this->get_module_3_tier_model_mappings(module_id);
+std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id) const {
+    const auto module_tier_mappings = this->get_module_3_tier_model_mappings(module_id);
     if (not module_tier_mappings.has_value()) {
         return std::nullopt;
     }
-    auto& mapping = module_tier_mappings.value();
+    const auto& mapping = module_tier_mappings.value();
     if (mapping.implementations.find(impl_id) == mapping.implementations.end()) {
         // if no specific implementation mapping is given, use the module mapping
         return mapping.module;
@@ -1203,11 +1203,11 @@ void Config::resolve_all_requirements() {
 void Config::parse_3_tier_model_mapping() {
     for (auto& element : this->main.items()) {
         const auto& module_id = element.key();
-        auto impl_info = this->extract_implementation_info(module_id);
-        auto provides = this->manifests.at(impl_info.at("module_name")).at("provides");
+        const auto impl_info = this->extract_implementation_info(module_id);
+        const auto provides = this->manifests.at(impl_info.at("module_name")).at("provides");
 
         ModuleTierMappings module_tier_mappings;
-        auto& module_config = element.value();
+        const auto& module_config = element.value();
         if (module_config.contains("evse")) {
             auto mapping = Mapping(module_config.at("evse").get<int>());
             if (module_config.contains("connector")) {
@@ -1215,12 +1215,12 @@ void Config::parse_3_tier_model_mapping() {
             }
             module_tier_mappings.module = mapping;
         }
-        auto& mapping = module_config.at("mapping");
+        const auto& mapping = module_config.at("mapping");
         // an empty mapping means it is mapped to the charging station and gets no specific mapping attached
         if (not mapping.empty()) {
             for (auto& tier_mapping : mapping.items()) {
-                auto impl_id = tier_mapping.key();
-                auto tier_mapping_value = tier_mapping.value();
+                const auto impl_id = tier_mapping.key();
+                const auto tier_mapping_value = tier_mapping.value();
                 if (provides.contains(impl_id)) {
                     if (tier_mapping_value.contains("connector")) {
                         module_tier_mappings.implementations[impl_id] = Mapping(

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -737,7 +737,6 @@ std::list<Requirement> Config::get_requirements(const std::string& module_id) co
 
     for (const auto& [requirement, fulfillment] : this->resolve_requirements(module_id)) {
         res.push_back(requirement);
-        (void)fulfillment; // fulfillment is not used here
     }
 
     return res;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,23 +705,40 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
+std::map<Requirement, Fulfillment> Config::resolve_requirements(const std::string& module_id) const {
+    std::map<Requirement, Fulfillment> requirements;
+
+    const auto module_name = get_module_name(module_id);
+    for (const auto& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
+        const json resolved_req = this->resolve_requirement(module_id, req_id);
+        if (!resolved_req.is_array()) {
+            const auto resolved_module_id = resolved_req.at("module_id");
+            const auto resolved_impl_id = resolved_req.at("implementation_id");
+            const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
+            Requirement req(req_id, 0);
+            requirements[req] = {resolved_module_id, resolved_impl_id, req, mapping};
+        } else {
+            for (int i = 0; i < resolved_req.size(); i++) {
+                const auto resolved_module_id = resolved_req.at(i).at("module_id");
+                const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
+                const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
+                Requirement req(req_id, i);
+                requirements[req] = {resolved_module_id, resolved_impl_id, req, mapping};
+            }
+        }
+    }
+
+    return requirements;
+}
+
 std::list<Requirement> Config::get_requirements(const std::string& module_id) const {
     BOOST_LOG_FUNCTION();
 
     std::list<Requirement> res;
 
-    const std::string module_name = get_module_name(module_id);
-    for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
-        const json resolved_req = this->resolve_requirement(module_id, req_id);
-        if (!resolved_req.is_array()) {
-            Requirement req(req_id, 0);
-            res.push_back(req);
-        } else {
-            for (int i = 0; i < resolved_req.size(); i++) {
-                Requirement req(req_id, i);
-                res.push_back(req);
-            }
-        }
+    for (const auto& [requirement, fulfillment] : this->resolve_requirements(module_id)) {
+        res.push_back(requirement);
+        (void)fulfillment; // fulfillment is not used here
     }
 
     return res;
@@ -732,26 +749,9 @@ std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const s
 
     std::map<std::string, std::vector<Fulfillment>> res;
 
-    const std::string module_name = get_module_name(module_id);
-    for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
-        std::vector<Fulfillment> fulfillments;
-        const json resolved_req = this->resolve_requirement(module_id, req_id);
-        if (!resolved_req.is_array()) {
-            const auto resolved_module_id = resolved_req.at("module_id");
-            const auto resolved_impl_id = resolved_req.at("implementation_id");
-            const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
-            Requirement req(req_id, 0);
-            fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
-        } else {
-            for (int i = 0; i < resolved_req.size(); i++) {
-                const auto resolved_module_id = resolved_req.at(i).at("module_id");
-                const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
-                const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
-                Requirement req(req_id, i);
-                fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
-            }
-        }
-        res[req_id] = fulfillments;
+    const auto& resolved_requirements = this->resolve_requirements(module_id);
+    for (const auto& [requirement, fulfillment] : this->resolve_requirements(module_id)) {
+        res[requirement.id].push_back(fulfillment);
     }
 
     return res;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,23 +705,31 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
-std::list<Requirement> Config::get_requirements(const std::string& module_id) const {
+std::map<std::string, std::vector<RequirementConnection>> Config::get_requirement_connections(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
-    std::list<Requirement> res;
+    std::map<std::string, std::vector<RequirementConnection>> res;
 
     std::string module_name = get_module_name(module_id);
     for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
+        std::vector<RequirementConnection> requirement_connections;
         json resolved_req = this->resolve_requirement(module_id, req_id);
         if (!resolved_req.is_array()) {
-            Requirement req(req_id, 0);
-            res.push_back(req);
+            auto resolved_module_id = resolved_req.at("module_id");
+            auto resolved_impl_id = resolved_req.at("implementation_id");
+            const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
+            Requirement req(req_id, 0, mapping);
+            requirement_connections.push_back({req, resolved_module_id});
         } else {
             for (int i = 0; i < resolved_req.size(); i++) {
-                Requirement req(req_id, i);
-                res.push_back(req);
+                auto resolved_module_id = resolved_req.at(i).at("module_id");
+                auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
+                const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
+                Requirement req(req_id, i, mapping);
+                requirement_connections.push_back({req, resolved_module_id});
             }
         }
+        res[req_id] = requirement_connections;
     }
 
     return res;
@@ -823,7 +831,8 @@ std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& modul
     }
     auto& mapping = module_tier_mappings.value();
     if (mapping.implementations.find(impl_id) == mapping.implementations.end()) {
-        return std::nullopt;
+        // if no specific implementation mapping is given, use the module mapping
+        return mapping.module;
     }
     return mapping.implementations.at(impl_id);
 }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -709,19 +709,19 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
 std::map<Requirement, Fulfillment> Config::resolve_requirements(const std::string& module_id) const {
     std::map<Requirement, Fulfillment> requirements;
 
-    const auto module_name = get_module_name(module_id);
+    const auto& module_name = get_module_name(module_id);
     for (const auto& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
-        const json resolved_req = this->resolve_requirement(module_id, req_id);
+        const auto& resolved_req = this->resolve_requirement(module_id, req_id);
         if (!resolved_req.is_array()) {
-            const auto resolved_module_id = resolved_req.at("module_id");
-            const auto resolved_impl_id = resolved_req.at("implementation_id");
-            auto req = Requirement{req_id, 0};
+            const auto& resolved_module_id = resolved_req.at("module_id");
+            const auto& resolved_impl_id = resolved_req.at("implementation_id");
+            const auto req = Requirement{req_id, 0};
             requirements[req] = {resolved_module_id, resolved_impl_id, req};
         } else {
             for (std::size_t i = 0; i < resolved_req.size(); i++) {
-                const auto resolved_module_id = resolved_req.at(i).at("module_id");
-                const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
-                auto req = Requirement{req_id, i};
+                const auto& resolved_module_id = resolved_req.at(i).at("module_id");
+                const auto& resolved_impl_id = resolved_req.at(i).at("implementation_id");
+                const auto req = Requirement{req_id, i};
                 requirements[req] = {resolved_module_id, resolved_impl_id, req};
             }
         }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -839,7 +839,7 @@ std::unordered_map<std::string, ModuleTierMappings> Config::get_3_tier_model_map
     return this->tier_mappings;
 }
 
-std::optional<ModuleTierMappings> Config::get_3_tier_model_mappings(const std::string& module_id) {
+std::optional<ModuleTierMappings> Config::get_module_3_tier_model_mappings(const std::string& module_id) {
     if (this->tier_mappings.find(module_id) == this->tier_mappings.end()) {
         return std::nullopt;
     }
@@ -847,7 +847,7 @@ std::optional<ModuleTierMappings> Config::get_3_tier_model_mappings(const std::s
 }
 
 std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id) {
-    auto module_tier_mappings = this->get_3_tier_model_mappings(module_id);
+    auto module_tier_mappings = this->get_module_3_tier_model_mappings(module_id);
     if (not module_tier_mappings.has_value()) {
         return std::nullopt;
     }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,32 +705,32 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
-std::map<std::string, std::vector<RequirementConnection>>
-Config::get_requirement_connections(const std::string& module_id) {
+std::map<std::string, std::vector<Fulfillment>>
+Config::get_fulfillments(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
-    std::map<std::string, std::vector<RequirementConnection>> res;
+    std::map<std::string, std::vector<Fulfillment>> res;
 
     std::string module_name = get_module_name(module_id);
     for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
-        std::vector<RequirementConnection> requirement_connections;
+        std::vector<Fulfillment> fulfillments;
         json resolved_req = this->resolve_requirement(module_id, req_id);
         if (!resolved_req.is_array()) {
             auto resolved_module_id = resolved_req.at("module_id");
             auto resolved_impl_id = resolved_req.at("implementation_id");
             const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
             Requirement req(req_id, 0, mapping);
-            requirement_connections.push_back({req, resolved_module_id});
+            fulfillments.push_back({resolved_module_id, resolved_impl_id, req});
         } else {
             for (int i = 0; i < resolved_req.size(); i++) {
                 auto resolved_module_id = resolved_req.at(i).at("module_id");
                 auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
                 const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
                 Requirement req(req_id, i, mapping);
-                requirement_connections.push_back({req, resolved_module_id});
+                fulfillments.push_back({resolved_module_id, resolved_impl_id, req});
             }
         }
-        res[req_id] = requirement_connections;
+        res[req_id] = fulfillments;
     }
 
     return res;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,7 +705,8 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
-std::map<std::string, std::vector<RequirementConnection>> Config::get_requirement_connections(const std::string& module_id) {
+std::map<std::string, std::vector<RequirementConnection>>
+Config::get_requirement_connections(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
     std::map<std::string, std::vector<RequirementConnection>> res;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,6 +705,28 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
+std::list<Requirement> Config::get_requirements(const std::string& module_id) const {
+    BOOST_LOG_FUNCTION();
+
+    std::list<Requirement> res;
+
+    std::string module_name = get_module_name(module_id);
+    for (const std::string& req_id : Config::keys(this->manifests.at(module_name).at("requires"))) {
+        json resolved_req = this->resolve_requirement(module_id, req_id);
+        if (!resolved_req.is_array()) {
+            Requirement req(req_id, 0);
+            res.push_back(req);
+        } else {
+            for (int i = 0; i < resolved_req.size(); i++) {
+                Requirement req(req_id, i);
+                res.push_back(req);
+            }
+        }
+    }
+
+    return res;
+}
+
 std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
@@ -718,15 +740,15 @@ std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const s
             auto resolved_module_id = resolved_req.at("module_id");
             auto resolved_impl_id = resolved_req.at("implementation_id");
             const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
-            Requirement req(req_id, 0, mapping);
-            fulfillments.push_back({resolved_module_id, resolved_impl_id, req});
+            Requirement req(req_id, 0);
+            fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
         } else {
             for (int i = 0; i < resolved_req.size(); i++) {
                 auto resolved_module_id = resolved_req.at(i).at("module_id");
                 auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
                 const auto mapping = this->get_3_tier_model_mapping(resolved_module_id, resolved_impl_id);
-                Requirement req(req_id, i, mapping);
-                fulfillments.push_back({resolved_module_id, resolved_impl_id, req});
+                Requirement req(req_id, i);
+                fulfillments.push_back({resolved_module_id, resolved_impl_id, req, mapping});
             }
         }
         res[req_id] = fulfillments;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <list>
 #include <set>
@@ -714,13 +715,13 @@ std::map<Requirement, Fulfillment> Config::resolve_requirements(const std::strin
         if (!resolved_req.is_array()) {
             const auto resolved_module_id = resolved_req.at("module_id");
             const auto resolved_impl_id = resolved_req.at("implementation_id");
-            Requirement req(req_id, 0);
+            auto req = Requirement{req_id, 0};
             requirements[req] = {resolved_module_id, resolved_impl_id, req};
         } else {
-            for (int i = 0; i < resolved_req.size(); i++) {
+            for (std::size_t i = 0; i < resolved_req.size(); i++) {
                 const auto resolved_module_id = resolved_req.at(i).at("module_id");
                 const auto resolved_impl_id = resolved_req.at(i).at("implementation_id");
-                Requirement req(req_id, i);
+                auto req = Requirement{req_id, i};
                 requirements[req] = {resolved_module_id, resolved_impl_id, req};
             }
         }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -705,8 +705,7 @@ json Config::resolve_requirement(const std::string& module_id, const std::string
     return module_config["connections"][requirement_id];
 }
 
-std::map<std::string, std::vector<Fulfillment>>
-Config::get_fulfillments(const std::string& module_id) {
+std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 
     std::map<std::string, std::vector<Fulfillment>> res;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -846,7 +846,8 @@ std::optional<ModuleTierMappings> Config::get_module_3_tier_model_mappings(const
     return this->tier_mappings.at(module_id);
 }
 
-std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& module_id, const std::string& impl_id) const {
+std::optional<Mapping> Config::get_3_tier_model_mapping(const std::string& module_id,
+                                                        const std::string& impl_id) const {
     const auto module_tier_mappings = this->get_module_3_tier_model_mappings(module_id);
     if (not module_tier_mappings.has_value()) {
         return std::nullopt;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -749,7 +749,6 @@ std::map<std::string, std::vector<Fulfillment>> Config::get_fulfillments(const s
 
     std::map<std::string, std::vector<Fulfillment>> res;
 
-    const auto& resolved_requirements = this->resolve_requirements(module_id);
     for (const auto& [requirement, fulfillment] : this->resolve_requirements(module_id)) {
         res[requirement.id].push_back(fulfillment);
     }

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -112,14 +112,14 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
 
         std::optional<Mapping> mapping;
         if (this->module_tier_mappings.has_value()) {
-            auto& module_tier_mapping = this->module_tier_mappings.value();
+            const auto& module_tier_mapping = this->module_tier_mappings.value();
             // start with the module mapping and overwrite it (partially) with the implementation mapping
             mapping = module_tier_mapping.module;
-            auto impl_mapping = config.get_3_tier_model_mapping(this->module_id, impl);
+            const auto impl_mapping = config.get_3_tier_model_mapping(this->module_id, impl);
             if (impl_mapping.has_value()) {
                 if (mapping.has_value()) {
                     auto& mapping_value = mapping.value();
-                    auto& impl_mapping_value = impl_mapping.value();
+                    const auto& impl_mapping_value = impl_mapping.value();
                     if (mapping_value.evse != impl_mapping_value.evse) {
                         EVLOG_warning << fmt::format("Mapping value mismatch. {} ({}) evse ({}) != {} mapping evse "
                                                      "({}). Setting evse={}, please fix this in the config.",
@@ -132,8 +132,8 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
                         mapping_value.connector = impl_mapping_value.connector;
                     }
                     if (mapping_value.connector.has_value() and impl_mapping_value.connector.has_value()) {
-                        auto& mapping_value_connector_value = mapping_value.connector.value();
-                        auto& impl_mapping_value_connector_value = impl_mapping_value.connector.value();
+                        const auto& mapping_value_connector_value = mapping_value.connector.value();
+                        const auto& impl_mapping_value_connector_value = impl_mapping_value.connector.value();
                         if (mapping_value_connector_value != impl_mapping_value_connector_value) {
                             EVLOG_warning
                                 << fmt::format("Mapping value mismatch. {} ({}) connector ({}) != {} mapping connector "

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -158,33 +158,30 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     }
 
     // setup error_databases, error_managers and error_state_monitors for all requirements
-    for (const auto& fulfillments : config.get_fulfillments(module_id)) {
-        for (const Fulfillment& fulfillment : fulfillments.second) {
-            auto& req = fulfillment.requirement;
-            // setup shared database
-            std::shared_ptr<error::ErrorDatabaseMap> error_database = std::make_shared<error::ErrorDatabaseMap>();
+    for (const Requirement& req : config.get_requirements(module_id)) {
+        // setup shared database
+        std::shared_ptr<error::ErrorDatabaseMap> error_database = std::make_shared<error::ErrorDatabaseMap>();
 
-            // setup error manager
-            std::string interface_name = this->module_manifest.at("requires").at(req.id).at("interface");
-            json interface_def = this->config.get_interface_definition(interface_name);
-            std::list<std::string> allowed_error_types;
-            for (const auto& error_namespace_it : interface_def["errors"].items()) {
-                for (const auto& error_name_it : error_namespace_it.value().items()) {
-                    allowed_error_types.push_back(error_namespace_it.key() + "/" + error_name_it.key());
-                }
+        // setup error manager
+        std::string interface_name = this->module_manifest.at("requires").at(req.id).at("interface");
+        json interface_def = this->config.get_interface_definition(interface_name);
+        std::list<std::string> allowed_error_types;
+        for (const auto& error_namespace_it : interface_def["errors"].items()) {
+            for (const auto& error_name_it : error_namespace_it.value().items()) {
+                allowed_error_types.push_back(error_namespace_it.key() + "/" + error_name_it.key());
             }
-            error::ErrorManagerReq::SubscribeErrorFunc subscribe_error_func =
-                [this, req](const error::ErrorType& type, const error::ErrorCallback& callback,
-                            const error::ErrorCallback& clear_callback) {
-                    this->subscribe_error(req, type, callback, clear_callback);
-                };
-            this->req_error_managers[req] = std::make_shared<error::ErrorManagerReq>(
-                std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database,
-                allowed_error_types, subscribe_error_func);
-
-            // setup error state monitor
-            this->req_error_state_monitors[req] = std::make_shared<error::ErrorStateMonitor>(error_database);
         }
+        error::ErrorManagerReq::SubscribeErrorFunc subscribe_error_func =
+            [this, req](const error::ErrorType& type, const error::ErrorCallback& callback,
+                        const error::ErrorCallback& clear_callback) {
+                this->subscribe_error(req, type, callback, clear_callback);
+            };
+        this->req_error_managers[req] = std::make_shared<error::ErrorManagerReq>(
+            std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database, allowed_error_types,
+            subscribe_error_func);
+
+        // setup error state monitor
+        this->req_error_state_monitors[req] = std::make_shared<error::ErrorStateMonitor>(error_database);
     }
 
     // register handler for global ready signal

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -158,9 +158,9 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     }
 
     // setup error_databases, error_managers and error_state_monitors for all requirements
-    for (const auto& requirement_connections : config.get_requirement_connections(module_id)) {
-        for (const RequirementConnection& req_con : requirement_connections.second) {
-            auto& req = req_con.requirement;
+    for (const auto& fulfillments : config.get_fulfillments(module_id)) {
+        for (const Fulfillment& fulfillment : fulfillments.second) {
+            auto& req = fulfillment.requirement;
             // setup shared database
             std::shared_ptr<error::ErrorDatabaseMap> error_database = std::make_shared<error::ErrorDatabaseMap>();
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -179,8 +179,8 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
                     this->subscribe_error(req, type, callback, clear_callback);
                 };
             this->req_error_managers[req] = std::make_shared<error::ErrorManagerReq>(
-                std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database, allowed_error_types,
-                subscribe_error_func);
+                std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database,
+                allowed_error_types, subscribe_error_func);
 
             // setup error state monitor
             this->req_error_state_monitors[req] = std::make_shared<error::ErrorStateMonitor>(error_database);

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -81,7 +81,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         this->global_error_state_monitor = nullptr;
     }
 
-    this->module_tier_mappings = config.get_3_tier_model_mappings(this->module_id);
+    this->module_tier_mappings = config.get_module_3_tier_model_mappings(this->module_id);
 
     // setup error_managers, error_state_monitors, error_factories and error_databases for all implementations
     for (const std::string& impl : Config::keys(this->module_manifest.at("provides"))) {

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -259,18 +259,6 @@ std::optional<ModuleTierMappings> Everest::get_3_tier_model_mapping() {
     return this->module_tier_mappings;
 }
 
-std::optional<Mapping> Everest::get_3_tier_model_mapping(const std::string& impl_id) {
-    if (not this->module_tier_mappings.has_value()) {
-        return std::nullopt;
-    }
-    auto& mapping = this->module_tier_mappings.value();
-    if (mapping.implementations.find(impl_id) == mapping.implementations.end()) {
-        // if no specific implementation mapping is given, use the module mapping
-        return mapping.module;
-    }
-    return mapping.implementations.at(impl_id);
-}
-
 void Everest::check_code() {
     BOOST_LOG_FUNCTION();
 
@@ -1094,5 +1082,18 @@ bool Everest::check_arg(ArgumentType arg_types, json manifest_arg) {
         }
     }
     return true;
+}
+
+std::optional<Mapping> get_impl_mapping(std::optional<ModuleTierMappings> module_tier_mappings,
+                                        const std::string& impl_id) {
+    if (not module_tier_mappings.has_value()) {
+        return std::nullopt;
+    }
+    auto& mapping = module_tier_mappings.value();
+    if (mapping.implementations.find(impl_id) == mapping.implementations.end()) {
+        // if no specific implementation mapping is given, use the module mapping
+        return mapping.module;
+    }
+    return mapping.implementations.at(impl_id);
 }
 } // namespace Everest

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -497,9 +497,7 @@ int ModuleLoader::initialize() {
             return everest.telemetry_publish(category, subcategory, type, telemetry);
         };
 
-        module_adapter.get_mapping = [&everest]() {
-            return everest.get_3_tier_model_mapping();
-        };
+        module_adapter.get_mapping = [&everest]() { return everest.get_3_tier_model_mapping(); };
 
         module_adapter.get_impl_mapping = [&everest](const std::string& impl_id) {
             return everest.get_3_tier_model_mapping(impl_id);

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -385,8 +385,8 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
 
 ModuleCallbacks::ModuleCallbacks(
     const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-    const std::function<std::vector<cmd>(
-        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>& everest_register,
+    const std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
+        everest_register,
     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
     const std::function<void()>& ready) :
     register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -385,8 +385,7 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
 
 ModuleCallbacks::ModuleCallbacks(
     const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-    const std::function<std::vector<cmd>(const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>&
-        everest_register,
+    const std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)>& everest_register,
     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
     const std::function<void()>& ready) :
     register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {
@@ -502,7 +501,8 @@ int ModuleLoader::initialize() {
         this->callbacks.register_module_adapter(module_adapter);
 
         // FIXME (aw): would be nice to move this config related thing toward the module_init function
-        std::vector<cmd> cmds = this->callbacks.everest_register(config.get_fulfillments(this->module_id));
+        std::vector<cmd> cmds =
+            this->callbacks.everest_register(config.get_requirement_initialization(this->module_id));
 
         for (auto const& command : cmds) {
             everest.provide_cmd(command);

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -383,10 +383,12 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
     }
 }
 
-ModuleCallbacks::ModuleCallbacks(const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
-                                 const std::function<std::vector<cmd>(const json& connections)>& everest_register,
-                                 const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
-                                 const std::function<void()>& ready) :
+ModuleCallbacks::ModuleCallbacks(
+    const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
+    const std::function<std::vector<cmd>(
+        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>& everest_register,
+    const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
+    const std::function<void()>& ready) :
     register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {
 }
 
@@ -495,11 +497,18 @@ int ModuleLoader::initialize() {
             return everest.telemetry_publish(category, subcategory, type, telemetry);
         };
 
+        module_adapter.get_mapping = [&everest]() {
+            return everest.get_3_tier_model_mapping();
+        };
+
+        module_adapter.get_impl_mapping = [&everest](const std::string& impl_id) {
+            return everest.get_3_tier_model_mapping(impl_id);
+        };
+
         this->callbacks.register_module_adapter(module_adapter);
 
         // FIXME (aw): would be nice to move this config related thing toward the module_init function
-        std::vector<cmd> cmds =
-            this->callbacks.everest_register(config.get_main_config()[this->module_id]["connections"]);
+        std::vector<cmd> cmds = this->callbacks.everest_register(config.get_requirement_connections(this->module_id));
 
         for (auto const& command : cmds) {
             everest.provide_cmd(command);

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -386,7 +386,7 @@ RuntimeSettings::RuntimeSettings(const std::string& prefix_, const std::string& 
 ModuleCallbacks::ModuleCallbacks(
     const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
     const std::function<std::vector<cmd>(
-        const std::map<std::string, std::vector<RequirementConnection>>& requirement_connections)>& everest_register,
+        const std::map<std::string, std::vector<Fulfillment>>& fulfillments)>& everest_register,
     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
     const std::function<void()>& ready) :
     register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {
@@ -506,7 +506,7 @@ int ModuleLoader::initialize() {
         this->callbacks.register_module_adapter(module_adapter);
 
         // FIXME (aw): would be nice to move this config related thing toward the module_init function
-        std::vector<cmd> cmds = this->callbacks.everest_register(config.get_requirement_connections(this->module_id));
+        std::vector<cmd> cmds = this->callbacks.everest_register(config.get_fulfillments(this->module_id));
 
         for (auto const& command : cmds) {
             everest.provide_cmd(command);

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -499,10 +499,6 @@ int ModuleLoader::initialize() {
 
         module_adapter.get_mapping = [&everest]() { return everest.get_3_tier_model_mapping(); };
 
-        module_adapter.get_impl_mapping = [&everest](const std::string& impl_id) {
-            return everest.get_3_tier_model_mapping(impl_id);
-        };
-
         this->callbacks.register_module_adapter(module_adapter);
 
         // FIXME (aw): would be nice to move this config related thing toward the module_init function

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -518,6 +518,10 @@ int ModuleLoader::initialize() {
         auto module_info = config.get_module_info(this->module_id);
         populate_module_info_path_from_runtime_settings(module_info, rs);
         module_info.telemetry_enabled = everest.is_telemetry_enabled();
+        auto module_mappings = everest.get_3_tier_model_mapping();
+        if (module_mappings.has_value()) {
+            module_info.mapping = module_mappings.value().module;
+        }
 
         this->callbacks.init(module_configs, module_info);
 

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -13,8 +13,7 @@ TypedHandler::TypedHandler(HandlerType type_, std::shared_ptr<Handler> handler_)
     TypedHandler("", "", type_, handler_) {
 }
 
-Requirement::Requirement(const std::string& requirement_id_, size_t index_) :
-    id(requirement_id_), index(index_) {
+Requirement::Requirement(const std::string& requirement_id_, size_t index_) : id(requirement_id_), index(index_) {
 }
 
 bool Requirement::operator<(const Requirement& rhs) const {

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -13,8 +13,8 @@ TypedHandler::TypedHandler(HandlerType type_, std::shared_ptr<Handler> handler_)
     TypedHandler("", "", type_, handler_) {
 }
 
-Requirement::Requirement(const std::string& requirement_id_, size_t index_, std::optional<Mapping> mapping) :
-    id(requirement_id_), index(index_), mapping(mapping) {
+Requirement::Requirement(const std::string& requirement_id_, size_t index_) :
+    id(requirement_id_), index(index_) {
 }
 
 bool Requirement::operator<(const Requirement& rhs) const {

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -16,11 +16,11 @@ TypedHandler::TypedHandler(HandlerType type_, std::shared_ptr<Handler> handler_)
 Requirement::Requirement(const std::string& requirement_id_, size_t index_) : id(requirement_id_), index(index_) {
 }
 
-bool Requirement::operator<(const Requirement& rhs) const {
-    if (id < rhs.id) {
+bool operator<(const Requirement& lhs, const Requirement& rhs) {
+    if (lhs.id < rhs.id) {
         return true;
-    } else if (id == rhs.id) {
-        return (index < rhs.index);
+    } else if (lhs.id == rhs.id) {
+        return (lhs.index < rhs.index);
     } else {
         return false;
     }

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -13,9 +13,6 @@ TypedHandler::TypedHandler(HandlerType type_, std::shared_ptr<Handler> handler_)
     TypedHandler("", "", type_, handler_) {
 }
 
-Requirement::Requirement(const std::string& requirement_id_, size_t index_) : id(requirement_id_), index(index_) {
-}
-
 bool operator<(const Requirement& lhs, const Requirement& rhs) {
     if (lhs.id < rhs.id) {
         return true;

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -13,7 +13,8 @@ TypedHandler::TypedHandler(HandlerType type_, std::shared_ptr<Handler> handler_)
     TypedHandler("", "", type_, handler_) {
 }
 
-Requirement::Requirement(const std::string& requirement_id_, size_t index_) : id(requirement_id_), index(index_) {
+Requirement::Requirement(const std::string& requirement_id_, size_t index_, std::optional<Mapping> mapping) :
+    id(requirement_id_), index(index_), mapping(mapping) {
 }
 
 bool Requirement::operator<(const Requirement& rhs) const {

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -147,32 +147,40 @@ properties:
             default: {}
             # don't allow arbitrary additional properties
             additionalProperties: false
-          evse:
-            description: evse this module id maps to
-            type: integer
-          connector:
-            description: connector this module id maps to
-            type: integer
           mapping:
             description: >-
-              this configures a list of implementations this module provides and their mapping to the 3-tier-model of charging station, evse and connector
+              this configures a module mapping and a list of implementations this module provides and their mapping to the 3-tier-model of charging station, evse and connector
               if no mapping is provided by default this implementation is associated with the charging station
             type: object
-            patternProperties:
-              # implementation id
-              ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
+            properties:
+              module:
                 type: object
-                required:
-                  - evse
                 properties:
                   evse:
-                    description: evse this implementation id maps to
+                    description: evse this module id maps to
                     type: integer
                   connector:
-                    description: connector this implementation id maps to
+                    description: connector this module id maps to
                     type: integer
-                  # don't allow arbitrary additional properties
-                  additionalProperties: false
+                # allow arbitrary additional properties for future extensions (not used at the moment)
+              additionalProperties: true
+              implementations:
+                type: object
+                patternProperties:
+                  # implementation id
+                  ^[a-zA-Z_][a-zA-Z0-9_.-]*$:
+                    type: object
+                    required:
+                      - evse
+                    properties:
+                      evse:
+                        description: evse this implementation id maps to
+                        type: integer
+                      connector:
+                        description: connector this implementation id maps to
+                        type: integer
+                      # allow arbitrary additional properties for future extensions (not used at the moment)
+                      additionalProperties: true
             # add empty config if not already present
             default: {}
             # don't allow arbitrary additional properties


### PR DESCRIPTION
EVerest modules and even individual interface implementations can have mappings
assigned to them. These mappings are inspired by the OCPP 3-tier model.

Modules can access the mapping information in the following ways depending on which specific information is required, all of these return an optional `Mapping` struct
If the mapping of a requirement is of interest it can be accessed via a get_mapping() function of a requirments:
`r_name_of_the_requirement->get_mapping()`

If the mapping of an interface implementation is of interest it can also be accessed via a get_mapping() function: `p_name_of_an_implementation->get_mapping()`

If the mapping of the current module is of interest it can be accessed via the module info:
`this->info.mapping`

Mapping information is also available in error reporting via "error.origin.mapping":
```
const auto error_handler = [this](const Everest::error::Error& error) {
    const auto evse_id = error.origin.mapping.has_value() ? error.origin.mapping.value().evse : 0;
};
```