### PR TITLE
Rust: init logging only once

### DIFF
--- a/everestrs/everestrs-build/jinja/module.jinja2
+++ b/everestrs/everestrs-build/jinja/module.jinja2
@@ -105,7 +105,7 @@ impl Module {
 {% endfor %}
     ) -> ::std::sync::Arc<Self> {
         let runtime = ::everestrs::Runtime::new();
-        let connections = ::everestrs::get_module_connections();        
+        let connections = runtime.get_module_connections();
         let this = ::std::sync::Arc::new(Self {
             on_ready,
 {% for provide in provides %}

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -155,11 +155,8 @@ rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_id, rust::Str pref
     return out;
 }
 
-rust::Vec<RsModuleConnections> get_module_connections(rust::Str module_id, rust::Str prefix, rust::Str config_file) {
-    const auto rs = std::make_shared<Everest::RuntimeSettings>(std::string(prefix), std::string(config_file));
-    Everest::Config config{rs};
-
-    const auto connections = config.get_main_config().at(std::string(module_id))["connections"];
+rust::Vec<RsModuleConnections> Module::get_module_connections() const {
+    const auto connections = config_->get_main_config().at(std::string(module_id_))["connections"];
 
     // Iterate over the connections block.
     rust::Vec<RsModuleConnections> out;
@@ -173,7 +170,6 @@ rust::Vec<RsModuleConnections> get_module_connections(rust::Str module_id, rust:
 int init_logging(rust::Str module_id, rust::Str prefix, rust::Str config_file) {
     using namespace boost::log;
     using namespace Everest::Logging;
-
 
     const std::string module_id_cpp{module_id};
     const std::string prefix_cpp{prefix};

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -28,12 +28,6 @@ std::unique_ptr<Everest::Everest> create_everest_instance(const std::string& mod
                                               rs->mqtt_external_prefix, rs->telemetry_prefix, rs->telemetry_enabled);
 }
 
-std::unique_ptr<Everest::Config> create_config_instance(std::shared_ptr<Everest::RuntimeSettings> rs) {
-    // FIXME (aw): where to initialize the logger?
-    Everest::Logging::init(rs->logging_config_file);
-    return std::make_unique<Everest::Config>(rs);
-}
-
 JsonBlob json2blob(const json& j) {
     // I did not find a way to not copy the data at least once here.
     const std::string dumped = j.dump();
@@ -83,7 +77,7 @@ inline ConfigField get_config_field(const std::string& _name, int _value) {
 Module::Module(const std::string& module_id, const std::string& prefix, const std::string& config_file) :
     module_id_(module_id),
     rs_(std::make_shared<Everest::RuntimeSettings>(prefix, config_file)),
-    config_(create_config_instance(rs_)),
+    config_(std::make_unique<Everest::Config>(rs_)),
     handle_(create_everest_instance(module_id, rs_, *config_)) {
 }
 
@@ -176,18 +170,26 @@ rust::Vec<RsModuleConnections> get_module_connections(rust::Str module_id, rust:
     return out;
 }
 
-int Module::get_log_level() const {
+int init_logging(rust::Str module_id, rust::Str prefix, rust::Str config_file) {
+    using namespace boost::log;
+    using namespace Everest::Logging;
+
+
+    const std::string module_id_cpp{module_id};
+    const std::string prefix_cpp{prefix};
+    const std::string config_file_cpp{config_file};
+
+    // Init the CPP logger.
+    Everest::RuntimeSettings rs{prefix_cpp, config_file_cpp};
+    init(rs.logging_config_file, module_id_cpp);
+
     // Below is something really ugly. Boost's log filter rules may actually be
     // quite "complex" but the library does not expose any way to check the
     // already installed filters. We therefore reopen the config and construct
     // or own filter - and feed it with dummy values to determine its filtering
     // behaviour (the lowest severity which is accepted by the filter)
-    std::filesystem::path logging_path{rs_->logging_config_file};
+    std::filesystem::path logging_path{rs.logging_config_file};
     std::ifstream logging_config(logging_path.c_str());
-
-    using namespace boost::log;
-    using namespace Everest::Logging;
-
     if (!logging_config.is_open()) {
         return info;
     }

--- a/everestrs/everestrs/src/everestrs_sys.hpp
+++ b/everestrs/everestrs/src/everestrs_sys.hpp
@@ -27,7 +27,6 @@ public:
     JsonBlob call_command(rust::Str implementation_id, size_t index, rust::Str name, JsonBlob args) const;
     void subscribe_variable(const Runtime& rt, rust::String implementation_id, size_t index, rust::String name) const;
     void publish_variable(rust::Str implementation_id, rust::Str name, JsonBlob blob) const;
-    int get_log_level() const;
 
 private:
     const std::string module_id_;
@@ -40,4 +39,6 @@ std::unique_ptr<Module> create_module(rust::Str module_name, rust::Str prefix, r
 
 rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name, rust::Str prefix, rust::Str conf);
 rust::Vec<RsModuleConnections> get_module_connections(rust::Str module_name, rust::Str prefix, rust::Str conf);
+
+int init_logging(rust::Str module_name, rust::Str prefix, rust::Str conf);
 void log2cxx(int level, int line, rust::Str file, rust::Str message);

--- a/everestrs/everestrs/src/everestrs_sys.hpp
+++ b/everestrs/everestrs/src/everestrs_sys.hpp
@@ -27,6 +27,7 @@ public:
     JsonBlob call_command(rust::Str implementation_id, size_t index, rust::Str name, JsonBlob args) const;
     void subscribe_variable(const Runtime& rt, rust::String implementation_id, size_t index, rust::String name) const;
     void publish_variable(rust::Str implementation_id, rust::Str name, JsonBlob blob) const;
+    rust::Vec<RsModuleConnections> get_module_connections() const;
 
 private:
     const std::string module_id_;
@@ -38,7 +39,6 @@ private:
 std::unique_ptr<Module> create_module(rust::Str module_name, rust::Str prefix, rust::Str conf);
 
 rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name, rust::Str prefix, rust::Str conf);
-rust::Vec<RsModuleConnections> get_module_connections(rust::Str module_name, rust::Str prefix, rust::Str conf);
 
 int init_logging(rust::Str module_name, rust::Str prefix, rust::Str conf);
 void log2cxx(int level, int line, rust::Str file, rust::Str message);

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -8,9 +8,13 @@ use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::Once;
 use std::sync::RwLock;
 use std::sync::Weak;
 use thiserror::Error;
+
+/// Prevent calling the init of loggers more than once.
+static INIT_LOGGER_ONCE: Once = Once::new();
 
 // Reexport everything so the clients can use it.
 pub use serde;
@@ -158,9 +162,6 @@ mod ffi {
         /// Publishes the given `blob` under the `implementation_id` and `name`.
         fn publish_variable(self: &Module, implementation_id: &str, name: &str, blob: JsonBlob);
 
-        /// Returns the severity for the cxx logger.
-        fn get_log_level(self: &Module) -> i32;
-
         /// Returns the module config from cpp.
         fn get_module_configs(module_id: &str, prefix: &str, conf: &str) -> Vec<RsModuleConfig>;
 
@@ -171,6 +172,9 @@ mod ffi {
             prefix: &str,
             conf: &str,
         ) -> Vec<RsModuleConnections>;
+
+        /// Call this once.
+        fn init_logging(module_id: &str, prefix: &str, conf: &str) -> i32;
 
         /// Logging sink for the EVerest module.
         fn log2cxx(level: i32, line: i32, file: &str, message: &str);
@@ -195,6 +199,7 @@ impl ffi::JsonBlob {
 /// Very simple logger to use by the Rust modules.
 mod logger {
     use super::ffi;
+    use crate::INIT_LOGGER_ONCE;
 
     pub(crate) struct Logger {
         level: log::Level,
@@ -237,19 +242,21 @@ mod logger {
         /// Init the logger for everest.
         ///
         /// Don't do this on your own as we must also control some cxx code.
-        pub(crate) fn init_logger(module: &ffi::Module) {
-            let level = match module.get_log_level() {
-                0 => log::Level::Trace,
-                1 => log::Level::Debug,
-                2 => log::Level::Info,
-                3 => log::Level::Warn,
-                4 => log::Level::Error,
-                _ => log::Level::Info,
-            };
+        pub(crate) fn init_logger(module_name: &str, prefix: &str, conf: &str) {
+            INIT_LOGGER_ONCE.call_once(|| {
+                let level = match ffi::init_logging(module_name, prefix, conf) {
+                    0 => log::Level::Trace,
+                    1 => log::Level::Debug,
+                    2 => log::Level::Info,
+                    3 => log::Level::Warn,
+                    4 => log::Level::Error,
+                    _ => log::Level::Info,
+                };
 
-            let logger = Self { level };
-            log::set_boxed_logger(Box::new(logger)).unwrap();
-            log::set_max_level(level.to_level_filter());
+                let logger = Self { level };
+                log::set_boxed_logger(Box::new(logger)).unwrap();
+                log::set_max_level(level.to_level_filter());
+            });
         }
     }
 }
@@ -395,13 +402,17 @@ impl Runtime {
     // TODO(hrapp): This function could use some error handling.
     pub fn new() -> Pin<Arc<Self>> {
         let args: Args = argh::from_env();
-        let cpp_module = ffi::create_module(
+        logger::Logger::init_logger(
             &args.module,
             &args.prefix.to_string_lossy(),
             &args.conf.to_string_lossy(),
         );
 
-        logger::Logger::init_logger(&cpp_module);
+        let cpp_module = ffi::create_module(
+            &args.module,
+            &args.prefix.to_string_lossy(),
+            &args.conf.to_string_lossy(),
+        );
 
         Arc::pin(Self {
             cpp_module,
@@ -505,8 +516,16 @@ impl TryFrom<&Config> for i64 {
 }
 
 /// Interface for fetching the configurations through the C++ runtime.
+///
+/// This is separetated from the module since the user might need the config
+/// to create the [Runtime].
 pub fn get_module_configs() -> HashMap<String, HashMap<String, Config>> {
     let args: Args = argh::from_env();
+    logger::Logger::init_logger(
+        &args.module,
+        &args.prefix.to_string_lossy(),
+        &args.conf.to_string_lossy(),
+    );
     let raw_config = ffi::get_module_configs(
         &args.module,
         &args.prefix.to_string_lossy(),


### PR DESCRIPTION
Fixes the use of the logger before calling initialize