### PR TITLE
Fix: MQTTAbstractionImpl: flush/sync MQTT Connect message immediately

### DIFF
--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -484,19 +484,18 @@ bool MQTTAbstractionImpl::connectBroker(std::string& socket_path) {
     uint8_t connect_flags = MQTT_CONNECT_CLEAN_SESSION;
     /* Send connection request to the broker. */
     if (mqtt_connect(&this->mqtt_client, nullptr, nullptr, nullptr, 0, nullptr, nullptr, connect_flags,
-                     mqtt_keep_alive) == MQTT_OK) {
-        // TODO(kai): async?
-        MQTTErrors error = mqtt_sync(&this->mqtt_client);
-        if (error != MQTT_OK) {
-            EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
-            return false;
-        }
-
-        on_mqtt_connect();
-        return true;
+                     mqtt_keep_alive) != MQTT_OK) {
+        return false;
+    }
+    // TODO(kai): async?
+    const auto error = mqtt_sync(&this->mqtt_client);
+    if (error != MQTT_OK) {
+        EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
+        return false;
     }
 
-    return false;
+    on_mqtt_connect();
+    return true;
 }
 
 bool MQTTAbstractionImpl::connectBroker(const char* host, const char* port) {
@@ -527,19 +526,18 @@ bool MQTTAbstractionImpl::connectBroker(const char* host, const char* port) {
     uint8_t connect_flags = MQTT_CONNECT_CLEAN_SESSION;
     /* Send connection request to the broker. */
     if (mqtt_connect(&this->mqtt_client, nullptr, nullptr, nullptr, 0, nullptr, nullptr, connect_flags,
-                     mqtt_keep_alive) == MQTT_OK) {
-        // TODO(kai): async?
-        MQTTErrors error = mqtt_sync(&this->mqtt_client);
-        if (error != MQTT_OK) {
-            EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
-            return false;
-        }
-
-        on_mqtt_connect();
-        return true;
+                     mqtt_keep_alive) != MQTT_OK) {
+        return false;
+    }
+    // TODO(kai): async?
+    const auto error = mqtt_sync(&this->mqtt_client);
+    if (error != MQTT_OK) {
+        EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
+        return false;
     }
 
-    return false;
+    on_mqtt_connect();
+    return true;
 }
 
 int MQTTAbstractionImpl::open_nb_socket(const char* addr, const char* port) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -486,6 +486,15 @@ bool MQTTAbstractionImpl::connectBroker(std::string& socket_path) {
     if (mqtt_connect(&this->mqtt_client, nullptr, nullptr, nullptr, 0, nullptr, nullptr, connect_flags,
                      mqtt_keep_alive) == MQTT_OK) {
         // TODO(kai): async?
+        MQTTErrors error = mqtt_sync(&this->mqtt_client);
+        if (error != MQTT_OK) {
+            EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
+
+            on_mqtt_disconnect();
+
+            return false;
+        }
+
         on_mqtt_connect();
         return true;
     }
@@ -523,6 +532,15 @@ bool MQTTAbstractionImpl::connectBroker(const char* host, const char* port) {
     if (mqtt_connect(&this->mqtt_client, nullptr, nullptr, nullptr, 0, nullptr, nullptr, connect_flags,
                      mqtt_keep_alive) == MQTT_OK) {
         // TODO(kai): async?
+        MQTTErrors error = mqtt_sync(&this->mqtt_client);
+        if (error != MQTT_OK) {
+            EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
+
+            on_mqtt_disconnect();
+
+            return false;
+        }
+
         on_mqtt_connect();
         return true;
     }

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -489,9 +489,6 @@ bool MQTTAbstractionImpl::connectBroker(std::string& socket_path) {
         MQTTErrors error = mqtt_sync(&this->mqtt_client);
         if (error != MQTT_OK) {
             EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
-
-            on_mqtt_disconnect();
-
             return false;
         }
 
@@ -535,9 +532,6 @@ bool MQTTAbstractionImpl::connectBroker(const char* host, const char* port) {
         MQTTErrors error = mqtt_sync(&this->mqtt_client);
         if (error != MQTT_OK) {
             EVLOG_error << fmt::format("Error during MQTT sync: {}", mqtt_error_str(error));
-
-            on_mqtt_disconnect();
-
             return false;
         }
 


### PR DESCRIPTION
Previously, a socket was opened, but the MQTT Connect command message was not flushed to the broker until init() was finished. This could be critical if a module's init() phase waits for some reason, as the MQTT broker's default socket timeout might disconnect the client.

This behavior was observed with the mosquitto broker, where unregistered sockets were consistently disconnected after 94 seconds.

Insert an additional mqtt_sync() directly after mqtt_connect(), while the mqtt_sync() thread is not yet started.

Co-authored-by: Fabian Hartung <fabian.hartung@chargebyte.com>