### PR TITLE
Date: adjust flags to not use remote

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,14 @@ cc_library(
         "@com_github_nlohmann_json//:json",
         "@com_github_pboettch_json-schema-validator//:json-schema-validator",
     ],
+    # See https://github.com/HowardHinnant/date/issues/324
+    local_defines = [
+        "BUILD_TZ_LIB=ON",
+        "USE_SYSTEM_TZ_DB=ON",
+        "USE_OS_TZDB=1",
+        "USE_AUTOLOAD=0",
+        "HAS_REMOTE_API=0",
+    ],
 )
 
 cc_library(

--- a/third-party/bazel/BUILD.date.bazel
+++ b/third-party/bazel/BUILD.date.bazel
@@ -11,8 +11,10 @@ cmake(
     cache_entries = {
         "BUILD_TZ_LIB": "ON",
         "USE_SYSTEM_TZ_DB": "ON",
-        "MANUAL_TZ_DB": "ON",
+        "HAS_REMOTE_API": "0",
+        "USE_AUTOLOAD": "0",
     },
+    copts = ["-std=c++17"],
     lib_source = ":all_srcs",
     out_static_libs = ["libdate-tz.a"],
     visibility = [


### PR DESCRIPTION
Fixes the compilation flags for the date library 
The flags were not the same as for the cmake/yocto toolchains