### PR TITLE
Use shared error type map

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <list>
+#include <memory>
 #include <optional>
 #include <regex>
 #include <set>
@@ -122,7 +123,7 @@ private:
 
     void load_and_validate_manifest(const std::string& module_id, const json& module_config);
 
-    error::ErrorTypeMap error_map;
+    error::ErrorTypeMapPtr error_map;
 
     ///
     /// \brief loads and validates the given file \p file_path with the schema \p schema
@@ -131,7 +132,7 @@ private:
     std::tuple<json, int> load_and_validate_with_schema(const fs::path& file_path, const json& schema);
 
 public:
-    error::ErrorTypeMap get_error_map() const;
+    error::ErrorTypeMapPtr get_error_map() const;
     std::string get_module_name(const std::string& module_id) const;
     bool module_provides(const std::string& module_name, const std::string& impl_id);
     json get_module_cmds(const std::string& module_name, const std::string& impl_id);

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -123,7 +123,7 @@ private:
 
     void load_and_validate_manifest(const std::string& module_id, const json& module_config);
 
-    error::ErrorTypeMapPtr error_map;
+    error::ErrorTypeMap::ConstPtr error_map;
 
     ///
     /// \brief loads and validates the given file \p file_path with the schema \p schema
@@ -132,7 +132,7 @@ private:
     std::tuple<json, int> load_and_validate_with_schema(const fs::path& file_path, const json& schema);
 
 public:
-    error::ErrorTypeMapPtr get_error_map() const;
+    error::ErrorTypeMap::ConstPtr get_error_map() const;
     std::string get_module_name(const std::string& module_id) const;
     bool module_provides(const std::string& module_name, const std::string& impl_id);
     json get_module_cmds(const std::string& module_name, const std::string& impl_id);

--- a/include/utils/error/error_factory.hpp
+++ b/include/utils/error/error_factory.hpp
@@ -16,10 +16,11 @@ namespace error {
 
 class ErrorFactory {
 public:
-    explicit ErrorFactory(ErrorTypeMapPtr error_type_map);
-    ErrorFactory(ErrorTypeMapPtr error_type_map, ImplementationIdentifier default_origin);
-    ErrorFactory(ErrorTypeMapPtr error_type_map, ImplementationIdentifier default_origin, Severity default_severity);
-    ErrorFactory(ErrorTypeMapPtr error_type_map, std::optional<ImplementationIdentifier> default_origin,
+    explicit ErrorFactory(ErrorTypeMap::ConstPtr error_type_map);
+    ErrorFactory(ErrorTypeMap::ConstPtr error_type_map, ImplementationIdentifier default_origin);
+    ErrorFactory(ErrorTypeMap::ConstPtr error_type_map, ImplementationIdentifier default_origin,
+                 Severity default_severity);
+    ErrorFactory(ErrorTypeMap::ConstPtr error_type_map, std::optional<ImplementationIdentifier> default_origin,
                  std::optional<Severity> default_severity, std::optional<State> default_state,
                  std::optional<ErrorType> default_type, std::optional<ErrorSubType> default_sub_type,
                  std::optional<std::string> default_message, std::optional<std::string> default_vendor_id);
@@ -50,7 +51,7 @@ private:
     std::optional<std::string> default_message;
     std::optional<std::string> default_vendor_id;
 
-    ErrorTypeMapPtr error_type_map;
+    ErrorTypeMap::ConstPtr error_type_map;
 
     void set_description(Error& error) const;
 };

--- a/include/utils/error/error_factory.hpp
+++ b/include/utils/error/error_factory.hpp
@@ -9,19 +9,17 @@
 #include <string>
 
 #include <utils/error.hpp>
+#include <utils/error/error_type_map.hpp>
 
 namespace Everest {
 namespace error {
 
-struct ErrorTypeMap;
-
 class ErrorFactory {
 public:
-    explicit ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map);
-    ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map, ImplementationIdentifier default_origin);
-    ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map, ImplementationIdentifier default_origin,
-                 Severity default_severity);
-    ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map, std::optional<ImplementationIdentifier> default_origin,
+    explicit ErrorFactory(ErrorTypeMapPtr error_type_map);
+    ErrorFactory(ErrorTypeMapPtr error_type_map, ImplementationIdentifier default_origin);
+    ErrorFactory(ErrorTypeMapPtr error_type_map, ImplementationIdentifier default_origin, Severity default_severity);
+    ErrorFactory(ErrorTypeMapPtr error_type_map, std::optional<ImplementationIdentifier> default_origin,
                  std::optional<Severity> default_severity, std::optional<State> default_state,
                  std::optional<ErrorType> default_type, std::optional<ErrorSubType> default_sub_type,
                  std::optional<std::string> default_message, std::optional<std::string> default_vendor_id);
@@ -52,7 +50,7 @@ private:
     std::optional<std::string> default_message;
     std::optional<std::string> default_vendor_id;
 
-    const std::shared_ptr<ErrorTypeMap> error_type_map;
+    ErrorTypeMapPtr error_type_map;
 
     void set_description(Error& error) const;
 };

--- a/include/utils/error/error_manager_impl.hpp
+++ b/include/utils/error/error_manager_impl.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <utils/error.hpp>
+#include <utils/error/error_type_map.hpp>
 
 namespace Everest {
 namespace error {
@@ -19,7 +20,7 @@ class ErrorManagerImpl {
 public:
     using PublishErrorFunc = std::function<void(const error::Error&)>;
 
-    ErrorManagerImpl(std::shared_ptr<ErrorTypeMap> error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerImpl(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                      std::list<ErrorType> allowed_error_types, PublishErrorFunc publish_raised_error,
                      PublishErrorFunc publish_cleared_error, const bool validate_error_types = true);
 
@@ -61,7 +62,7 @@ private:
     PublishErrorFunc publish_cleared_error;
 
     std::shared_ptr<ErrorDatabase> database;
-    std::shared_ptr<ErrorTypeMap> error_type_map;
+    ErrorTypeMapPtr error_type_map;
     std::list<ErrorType> allowed_error_types;
 
     const bool validate_error_types;

--- a/include/utils/error/error_manager_impl.hpp
+++ b/include/utils/error/error_manager_impl.hpp
@@ -20,7 +20,7 @@ class ErrorManagerImpl {
 public:
     using PublishErrorFunc = std::function<void(const error::Error&)>;
 
-    ErrorManagerImpl(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerImpl(ErrorTypeMap::ConstPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                      std::list<ErrorType> allowed_error_types, PublishErrorFunc publish_raised_error,
                      PublishErrorFunc publish_cleared_error, const bool validate_error_types = true);
 
@@ -62,7 +62,7 @@ private:
     PublishErrorFunc publish_cleared_error;
 
     std::shared_ptr<ErrorDatabase> database;
-    ErrorTypeMapPtr error_type_map;
+    ErrorTypeMap::ConstPtr error_type_map;
     std::list<ErrorType> allowed_error_types;
 
     const bool validate_error_types;

--- a/include/utils/error/error_manager_req.hpp
+++ b/include/utils/error/error_manager_req.hpp
@@ -20,7 +20,7 @@ class ErrorManagerReq {
 public:
     using SubscribeErrorFunc = std::function<void(const ErrorType&, const ErrorCallback&, const ErrorCallback&)>;
 
-    ErrorManagerReq(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerReq(ErrorTypeMap::ConstPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                     std::list<ErrorType> allowed_error_types, SubscribeErrorFunc subscribe_error_func);
 
     void subscribe_error(const ErrorType& type, const ErrorCallback& callback, const ErrorCallback& clear_callback);
@@ -42,7 +42,7 @@ private:
 
     SubscribeErrorFunc subscribe_error_func;
 
-    ErrorTypeMapPtr error_type_map;
+    ErrorTypeMap::ConstPtr error_type_map;
     std::shared_ptr<ErrorDatabase> database;
     std::list<ErrorType> allowed_error_types;
 };

--- a/include/utils/error/error_manager_req.hpp
+++ b/include/utils/error/error_manager_req.hpp
@@ -5,6 +5,7 @@
 #define UTILS_ERROR_MANAGER_REQ_HPP
 
 #include <utils/error.hpp>
+#include <utils/error/error_type_map.hpp>
 
 #include <list>
 #include <map>
@@ -14,13 +15,12 @@ namespace Everest {
 namespace error {
 
 struct ErrorDatabase;
-struct ErrorTypeMap;
 
 class ErrorManagerReq {
 public:
     using SubscribeErrorFunc = std::function<void(const ErrorType&, const ErrorCallback&, const ErrorCallback&)>;
 
-    ErrorManagerReq(std::shared_ptr<ErrorTypeMap> error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerReq(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                     std::list<ErrorType> allowed_error_types, SubscribeErrorFunc subscribe_error_func);
 
     void subscribe_error(const ErrorType& type, const ErrorCallback& callback, const ErrorCallback& clear_callback);
@@ -42,7 +42,7 @@ private:
 
     SubscribeErrorFunc subscribe_error_func;
 
-    std::shared_ptr<ErrorTypeMap> error_type_map;
+    ErrorTypeMapPtr error_type_map;
     std::shared_ptr<ErrorDatabase> database;
     std::list<ErrorType> allowed_error_types;
 };

--- a/include/utils/error/error_manager_req_global.hpp
+++ b/include/utils/error/error_manager_req_global.hpp
@@ -20,7 +20,7 @@ class ErrorManagerReqGlobal {
 public:
     using SubscribeGlobalAllErrorsFunc = std::function<void(const ErrorCallback&, const ErrorCallback&)>;
 
-    ErrorManagerReqGlobal(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerReqGlobal(ErrorTypeMap::ConstPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                           SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func);
 
     void subscribe_global_all_errors(const ErrorCallback& callback, const ErrorCallback& clear_callback);
@@ -39,7 +39,7 @@ private:
 
     SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func;
 
-    ErrorTypeMapPtr error_type_map;
+    ErrorTypeMap::ConstPtr error_type_map;
     std::shared_ptr<ErrorDatabase> database;
 };
 

--- a/include/utils/error/error_manager_req_global.hpp
+++ b/include/utils/error/error_manager_req_global.hpp
@@ -5,6 +5,7 @@
 #define UTILS_ERROR_MANAGER_REQ_GLOBAL_HPP
 
 #include <utils/error.hpp>
+#include <utils/error/error_type_map.hpp>
 
 #include <list>
 #include <map>
@@ -14,13 +15,12 @@ namespace Everest {
 namespace error {
 
 struct ErrorDatabase;
-struct ErrorTypeMap;
 
 class ErrorManagerReqGlobal {
 public:
     using SubscribeGlobalAllErrorsFunc = std::function<void(const ErrorCallback&, const ErrorCallback&)>;
 
-    ErrorManagerReqGlobal(std::shared_ptr<ErrorTypeMap> error_type_map, std::shared_ptr<ErrorDatabase> error_database,
+    ErrorManagerReqGlobal(ErrorTypeMapPtr error_type_map, std::shared_ptr<ErrorDatabase> error_database,
                           SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func);
 
     void subscribe_global_all_errors(const ErrorCallback& callback, const ErrorCallback& clear_callback);
@@ -39,7 +39,7 @@ private:
 
     SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func;
 
-    std::shared_ptr<ErrorTypeMap> error_type_map;
+    ErrorTypeMapPtr error_type_map;
     std::shared_ptr<ErrorDatabase> database;
 };
 

--- a/include/utils/error/error_type_map.hpp
+++ b/include/utils/error/error_type_map.hpp
@@ -53,13 +53,13 @@ public:
     ///
     bool has(const ErrorType& error_type) const;
 
+    /// Const pointer to a ErrorTypeMap. This is the default how we share the
+    /// error type map between different classes.
+    using ConstPtr = std::shared_ptr<const ErrorTypeMap>;
+
 private:
     std::map<ErrorType, std::string> error_types;
 };
-
-/// Const pointer to a ErrorTypeMap. This is the default how we share the error
-/// map between different types.
-using ErrorTypeMapPtr = std::shared_ptr<const ErrorTypeMap>;
 
 } // namespace error
 } // namespace Everest

--- a/include/utils/error/error_type_map.hpp
+++ b/include/utils/error/error_type_map.hpp
@@ -5,6 +5,9 @@
 #define UTILS_ERROR_TYPE_MAP_HPP
 
 #include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
 
 #include <utils/error.hpp>
 
@@ -53,6 +56,10 @@ public:
 private:
     std::map<ErrorType, std::string> error_types;
 };
+
+/// Const pointer to a ErrorTypeMap. This is the default how we share the error
+/// map between different types.
+using ErrorTypeMapPtr = std::shared_ptr<const ErrorTypeMap>;
 
 } // namespace error
 } // namespace Everest

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -551,7 +551,7 @@ Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), mana
     parse_3_tier_model_mapping();
 }
 
-error::ErrorTypeMapPtr Config::get_error_map() const {
+error::ErrorTypeMap::ConstPtr Config::get_error_map() const {
     return this->error_map;
 }
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -397,7 +397,7 @@ std::tuple<json, int> Config::load_and_validate_with_schema(const fs::path& file
 Config::Config(std::shared_ptr<RuntimeSettings> rs) : Config(rs, false) {
 }
 
-Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), manager(manager) {
+Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), manager(manager), error_map{nullptr} {
     BOOST_LOG_FUNCTION();
 
     this->manifests = json({});
@@ -406,7 +406,7 @@ Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), mana
     this->types = json({});
     this->errors = json({});
     this->_schemas = Config::load_schemas(this->rs->schemas_dir);
-    this->error_map = error::ErrorTypeMap(this->rs->errors_dir);
+    this->error_map = std::make_shared<error::ErrorTypeMap>(error::ErrorTypeMap(this->rs->errors_dir));
 
     // load and process config file
     fs::path config_path = rs->config_file;
@@ -551,7 +551,7 @@ Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), mana
     parse_3_tier_model_mapping();
 }
 
-error::ErrorTypeMap Config::get_error_map() const {
+error::ErrorTypeMapPtr Config::get_error_map() const {
     return this->error_map;
 }
 

--- a/lib/error/error_factory.cpp
+++ b/lib/error/error_factory.cpp
@@ -8,24 +8,23 @@
 namespace Everest {
 namespace error {
 
-ErrorFactory::ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map_) :
+ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_) :
     ErrorFactory(error_type_map_, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map_, ImplementationIdentifier default_origin_) :
+ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, ImplementationIdentifier default_origin_) :
     ErrorFactory(error_type_map_, default_origin_, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map_, ImplementationIdentifier default_origin_,
+ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, ImplementationIdentifier default_origin_,
                            Severity default_severity_) :
     ErrorFactory(error_type_map_, default_origin_, default_severity_, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt, std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(std::shared_ptr<ErrorTypeMap> error_type_map_,
-                           std::optional<ImplementationIdentifier> default_origin_,
+ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, std::optional<ImplementationIdentifier> default_origin_,
                            std::optional<Severity> default_severity_, std::optional<State> default_state_,
                            std::optional<ErrorType> default_type_, std::optional<ErrorSubType> default_sub_type_,
                            std::optional<std::string> default_message_, std::optional<std::string> default_vendor_id_) :

--- a/lib/error/error_factory.cpp
+++ b/lib/error/error_factory.cpp
@@ -8,23 +8,24 @@
 namespace Everest {
 namespace error {
 
-ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_) :
+ErrorFactory::ErrorFactory(ErrorTypeMap::ConstPtr error_type_map_) :
     ErrorFactory(error_type_map_, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, ImplementationIdentifier default_origin_) :
+ErrorFactory::ErrorFactory(ErrorTypeMap::ConstPtr error_type_map_, ImplementationIdentifier default_origin_) :
     ErrorFactory(error_type_map_, default_origin_, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, ImplementationIdentifier default_origin_,
+ErrorFactory::ErrorFactory(ErrorTypeMap::ConstPtr error_type_map_, ImplementationIdentifier default_origin_,
                            Severity default_severity_) :
     ErrorFactory(error_type_map_, default_origin_, default_severity_, std::nullopt, std::nullopt, std::nullopt,
                  std::nullopt, std::nullopt) {
 }
 
-ErrorFactory::ErrorFactory(ErrorTypeMapPtr error_type_map_, std::optional<ImplementationIdentifier> default_origin_,
+ErrorFactory::ErrorFactory(ErrorTypeMap::ConstPtr error_type_map_,
+                           std::optional<ImplementationIdentifier> default_origin_,
                            std::optional<Severity> default_severity_, std::optional<State> default_state_,
                            std::optional<ErrorType> default_type_, std::optional<ErrorSubType> default_sub_type_,
                            std::optional<std::string> default_message_, std::optional<std::string> default_vendor_id_) :

--- a/lib/error/error_manager_impl.cpp
+++ b/lib/error/error_manager_impl.cpp
@@ -5,7 +5,6 @@
 
 #include <utils/error.hpp>
 #include <utils/error/error_database.hpp>
-#include <utils/error/error_type_map.hpp>
 
 #include <everest/logging.hpp>
 
@@ -15,8 +14,7 @@
 namespace Everest {
 namespace error {
 
-ErrorManagerImpl::ErrorManagerImpl(std::shared_ptr<ErrorTypeMap> error_type_map_,
-                                   std::shared_ptr<ErrorDatabase> error_database_,
+ErrorManagerImpl::ErrorManagerImpl(ErrorTypeMapPtr error_type_map_, std::shared_ptr<ErrorDatabase> error_database_,
                                    std::list<ErrorType> allowed_error_types_,
                                    ErrorManagerImpl::PublishErrorFunc publish_raised_error_,
                                    ErrorManagerImpl::PublishErrorFunc publish_cleared_error_,

--- a/lib/error/error_manager_impl.cpp
+++ b/lib/error/error_manager_impl.cpp
@@ -14,7 +14,8 @@
 namespace Everest {
 namespace error {
 
-ErrorManagerImpl::ErrorManagerImpl(ErrorTypeMapPtr error_type_map_, std::shared_ptr<ErrorDatabase> error_database_,
+ErrorManagerImpl::ErrorManagerImpl(ErrorTypeMap::ConstPtr error_type_map_,
+                                   std::shared_ptr<ErrorDatabase> error_database_,
                                    std::list<ErrorType> allowed_error_types_,
                                    ErrorManagerImpl::PublishErrorFunc publish_raised_error_,
                                    ErrorManagerImpl::PublishErrorFunc publish_cleared_error_,

--- a/lib/error/error_manager_req.cpp
+++ b/lib/error/error_manager_req.cpp
@@ -6,15 +6,13 @@
 #include <utils/error.hpp>
 #include <utils/error/error_database.hpp>
 #include <utils/error/error_filter.hpp>
-#include <utils/error/error_type_map.hpp>
 
 #include <everest/logging.hpp>
 
 namespace Everest {
 namespace error {
 
-ErrorManagerReq::ErrorManagerReq(std::shared_ptr<ErrorTypeMap> error_type_map_,
-                                 std::shared_ptr<ErrorDatabase> error_database_,
+ErrorManagerReq::ErrorManagerReq(ErrorTypeMapPtr error_type_map_, std::shared_ptr<ErrorDatabase> error_database_,
                                  std::list<ErrorType> allowed_error_types_, SubscribeErrorFunc subscribe_error_func_) :
     error_type_map(error_type_map_),
     database(error_database_),

--- a/lib/error/error_manager_req.cpp
+++ b/lib/error/error_manager_req.cpp
@@ -12,7 +12,7 @@
 namespace Everest {
 namespace error {
 
-ErrorManagerReq::ErrorManagerReq(ErrorTypeMapPtr error_type_map_, std::shared_ptr<ErrorDatabase> error_database_,
+ErrorManagerReq::ErrorManagerReq(ErrorTypeMap::ConstPtr error_type_map_, std::shared_ptr<ErrorDatabase> error_database_,
                                  std::list<ErrorType> allowed_error_types_, SubscribeErrorFunc subscribe_error_func_) :
     error_type_map(error_type_map_),
     database(error_database_),

--- a/lib/error/error_manager_req_global.cpp
+++ b/lib/error/error_manager_req_global.cpp
@@ -9,7 +9,7 @@
 namespace Everest {
 namespace error {
 
-ErrorManagerReqGlobal::ErrorManagerReqGlobal(ErrorTypeMapPtr error_type_map_,
+ErrorManagerReqGlobal::ErrorManagerReqGlobal(ErrorTypeMap::ConstPtr error_type_map_,
                                              std::shared_ptr<ErrorDatabase> error_database_,
                                              SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func_) :
     error_type_map(error_type_map_),

--- a/lib/error/error_manager_req_global.cpp
+++ b/lib/error/error_manager_req_global.cpp
@@ -5,12 +5,11 @@
 
 #include <everest/logging.hpp>
 #include <utils/error/error_database.hpp>
-#include <utils/error/error_type_map.hpp>
 
 namespace Everest {
 namespace error {
 
-ErrorManagerReqGlobal::ErrorManagerReqGlobal(std::shared_ptr<ErrorTypeMap> error_type_map_,
+ErrorManagerReqGlobal::ErrorManagerReqGlobal(ErrorTypeMapPtr error_type_map_,
                                              std::shared_ptr<ErrorDatabase> error_database_,
                                              SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func_) :
     error_type_map(error_type_map_),

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -73,8 +73,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
                 this->subscribe_global_all_errors(callback, clear_callback);
             };
         this->global_error_manager = std::make_shared<error::ErrorManagerReqGlobal>(
-            std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), global_error_database,
-            subscribe_global_all_errors_func);
+            this->config.get_error_map(), global_error_database, subscribe_global_all_errors_func);
         this->global_error_state_monitor = std::make_shared<error::ErrorStateMonitor>(global_error_database);
     } else {
         this->global_error_manager = nullptr;
@@ -103,9 +102,9 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         error::ErrorManagerImpl::PublishErrorFunc publish_cleared_error = [this, impl](const error::Error& error) {
             this->publish_cleared_error(impl, error);
         };
-        this->impl_error_managers[impl] = std::make_shared<error::ErrorManagerImpl>(
-            std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database, allowed_error_types,
-            publish_raised_error, publish_cleared_error);
+        this->impl_error_managers[impl] =
+            std::make_shared<error::ErrorManagerImpl>(this->config.get_error_map(), error_database, allowed_error_types,
+                                                      publish_raised_error, publish_cleared_error);
 
         // setup error state monitor
         this->impl_error_state_monitors[impl] = std::make_shared<error::ErrorStateMonitor>(error_database);
@@ -153,8 +152,8 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
 
         // setup error factory
         ImplementationIdentifier default_origin(this->module_id, impl, mapping);
-        this->error_factories[impl] = std::make_shared<error::ErrorFactory>(
-            std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), default_origin);
+        this->error_factories[impl] =
+            std::make_shared<error::ErrorFactory>(this->config.get_error_map(), default_origin);
     }
 
     // setup error_databases, error_managers and error_state_monitors for all requirements
@@ -177,8 +176,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
                 this->subscribe_error(req, type, callback, clear_callback);
             };
         this->req_error_managers[req] = std::make_shared<error::ErrorManagerReq>(
-            std::make_shared<error::ErrorTypeMap>(this->config.get_error_map()), error_database, allowed_error_types,
-            subscribe_error_func);
+            this->config.get_error_map(), error_database, allowed_error_types, subscribe_error_func);
 
         // setup error state monitor
         this->req_error_state_monitors[req] = std::make_shared<error::ErrorStateMonitor>(error_database);


### PR DESCRIPTION
Currently the error type map is copy constructed and then placed into a shared pointer which results in the error map not being really shared between the different classes. This Pr fixes it.
