### PR TITLE
fix: address compiler warnings (clang)

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -48,8 +48,6 @@ const static std::regex type_uri_regex{R"(^((?:\/[a-zA-Z0-9\-\_]+)+#\/[a-zA-Z0-9
 class Config {
 private:
     std::shared_ptr<RuntimeSettings> rs;
-    bool manager;
-
     json main;
 
     json manifests;

--- a/include/utils/error.hpp
+++ b/include/utils/error.hpp
@@ -71,14 +71,14 @@ struct Error {
     Error();
     ErrorType type;
     ErrorSubType sub_type;
-    std::string description;
     std::string message;
-    Severity severity;
+    std::string description;
     ImplementationIdentifier origin;
+    std::string vendor_id;
+    Severity severity;
     time_point timestamp;
     UUID uuid;
     State state;
-    std::string vendor_id;
 };
 
 using ErrorHandle = UUID;

--- a/include/utils/error/error_database.hpp
+++ b/include/utils/error/error_database.hpp
@@ -17,6 +17,7 @@ public:
     using EditErrorFunc = std::function<void(ErrorPtr)>;
 
     ErrorDatabase() = default;
+    virtual ~ErrorDatabase() = default;
 
     virtual void add_error(ErrorPtr error) = 0;
     virtual std::list<ErrorPtr> get_errors(const std::list<ErrorFilter>& filters) const = 0;

--- a/include/utils/error/error_factory.hpp
+++ b/include/utils/error/error_factory.hpp
@@ -44,6 +44,8 @@ public:
     void set_default_vendor_id(std::string vendor_id);
 
 private:
+    const std::shared_ptr<ErrorTypeMap> error_type_map;
+
     std::optional<ImplementationIdentifier> default_origin;
     std::optional<Severity> default_severity;
     std::optional<State> default_state;
@@ -51,8 +53,6 @@ private:
     std::optional<ErrorSubType> default_sub_type;
     std::optional<std::string> default_message;
     std::optional<std::string> default_vendor_id;
-
-    const std::shared_ptr<ErrorTypeMap> error_type_map;
 
     void set_description(Error& error) const;
 };

--- a/include/utils/error/error_manager_impl.hpp
+++ b/include/utils/error/error_manager_impl.hpp
@@ -57,12 +57,12 @@ private:
     bool can_be_cleared(const ErrorType& type, const ErrorSubType& sub_type) const;
     bool can_be_cleared(const ErrorType& type) const;
 
+    std::shared_ptr<ErrorTypeMap> error_type_map;
+    std::shared_ptr<ErrorDatabase> database;
+    std::list<ErrorType> allowed_error_types;
+
     PublishErrorFunc publish_raised_error;
     PublishErrorFunc publish_cleared_error;
-
-    std::shared_ptr<ErrorDatabase> database;
-    std::shared_ptr<ErrorTypeMap> error_type_map;
-    std::list<ErrorType> allowed_error_types;
 
     const bool validate_error_types;
 };

--- a/include/utils/error/error_manager_req.hpp
+++ b/include/utils/error/error_manager_req.hpp
@@ -40,11 +40,11 @@ private:
     void on_error_cleared(const Error& error);
     void on_error(const Error& error, const bool raised) const;
 
-    SubscribeErrorFunc subscribe_error_func;
-
     std::shared_ptr<ErrorTypeMap> error_type_map;
     std::shared_ptr<ErrorDatabase> database;
     std::list<ErrorType> allowed_error_types;
+
+    SubscribeErrorFunc subscribe_error_func;
 };
 
 } // namespace error

--- a/include/utils/error/error_manager_req_global.hpp
+++ b/include/utils/error/error_manager_req_global.hpp
@@ -32,15 +32,15 @@ private:
         ErrorCallback clear_callback;
     };
 
-    std::list<Subscription> subscriptions;
-
     void on_error_raised(const Error& error);
     void on_error_cleared(const Error& error);
 
-    SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func;
-
     std::shared_ptr<ErrorTypeMap> error_type_map;
     std::shared_ptr<ErrorDatabase> database;
+
+    SubscribeGlobalAllErrorsFunc subscribe_global_all_errors_func;
+
+    std::list<Subscription> subscriptions;
 };
 
 } // namespace error

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -25,7 +25,7 @@ public:
         SCHEMA
     };
     ConfigParseException(ParseErrorType err_t, const std::string& entry, const std::string& what = "") :
-        err_t(err_t), entry(entry), what(what) {};
+        err_t(err_t), entry(entry), what(what){};
 
     const ParseErrorType err_t;
     const std::string entry;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -25,7 +25,7 @@ public:
         SCHEMA
     };
     ConfigParseException(ParseErrorType err_t, const std::string& entry, const std::string& what = "") :
-        err_t(err_t), entry(entry), what(what){};
+        err_t(err_t), entry(entry), what(what) {};
 
     const ParseErrorType err_t;
     const std::string entry;
@@ -397,7 +397,7 @@ std::tuple<json, int> Config::load_and_validate_with_schema(const fs::path& file
 Config::Config(std::shared_ptr<RuntimeSettings> rs) : Config(rs, false) {
 }
 
-Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), manager(manager) {
+Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs) {
     BOOST_LOG_FUNCTION();
 
     this->manifests = json({});
@@ -530,8 +530,6 @@ Config::Config(std::shared_ptr<RuntimeSettings> rs, bool manager) : rs(rs), mana
     }
 
     if (probe_module_id) {
-        auto& manifest = this->manifests["ProbeModule"];
-
         setup_probe_module_manifest(*probe_module_id, this->main, this->manifests);
 
         load_and_validate_manifest(*probe_module_id, this->main.at(*probe_module_id));

--- a/lib/error/error_manager_impl.cpp
+++ b/lib/error/error_manager_impl.cpp
@@ -68,7 +68,7 @@ std::list<ErrorPtr> ErrorManagerImpl::clear_error(const ErrorType& type, const b
     std::list<ErrorPtr> res = database->remove_errors(filters);
     std::stringstream ss;
     ss << "Cleared " << res.size() << " errors of type " << type << " with sub_types:" << std::endl;
-    for (const ErrorPtr error : res) {
+    for (const ErrorPtr& error : res) {
         this->publish_cleared_error(*error);
         ss << "  - " << error->sub_type << std::endl;
     }
@@ -100,7 +100,7 @@ std::list<ErrorPtr> ErrorManagerImpl::clear_all_errors() {
     std::list<ErrorPtr> res = database->remove_errors(filters);
     std::stringstream ss;
     ss << "Cleared " << res.size() << " errors:" << std::endl;
-    for (const ErrorPtr error : res) {
+    for (const ErrorPtr& error : res) {
         error->state = State::ClearedByModule;
         this->publish_cleared_error(*error);
         ss << "  - type: " << error->type << ", sub_type: " << error->sub_type << std::endl;

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -726,7 +726,7 @@ UnsubscribeToken Everest::provide_external_mqtt_handler(const std::string& topic
 
     std::string external_topic = fmt::format("{}{}", this->mqtt_external_prefix, topic);
 
-    Handler external_handler = [this, handler, external_topic](json const& data) {
+    Handler external_handler = [handler, external_topic](json const& data) {
         EVLOG_verbose << fmt::format("Incoming external mqtt data for topic '{}'...", external_topic);
         if (!data.is_string()) {
             EVLOG_AND_THROW(EverestInternalError("External mqtt result is not a string (that should never happen)"));


### PR DESCRIPTION
Changes to address the following warnings

```
[2/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_error_error_factory.cpp.o
../everest/everest-framework/lib/error/error_factory.cpp:32:5: warning: field 'error_type_map' will be initialized after field 'default_origin' [-Wreorder-ctor]
   32 |     error_type_map(error_type_map_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_origin(default_origin_)
   33 |     default_origin(default_origin_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_severity(default_severity_)
   34 |     default_severity(default_severity_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_state(default_state_)
   35 |     default_state(default_state_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_type(default_type_)
   36 |     default_type(default_type_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_sub_type(default_sub_type_)
   37 |     default_sub_type(default_sub_type_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_message(default_message_)
   38 |     default_message(default_message_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     default_vendor_id(default_vendor_id_)
   39 |     default_vendor_id(default_vendor_id_) {
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     error_type_map(error_type_map_)
1 warning generated.
[3/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_error_error_manager_req_global.cpp.o
../everest/everest-framework/lib/error/error_manager_req_global.cpp:17:5: warning: initializer order does not match the declaration order [-Wreorder-ctor]
   16 |     error_type_map(error_type_map_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     subscriptions({})
   17 |     database(error_database_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
      |     subscribe_global_all_errors_func(subscribe_global_all_errors_func_)
   18 |     subscribe_global_all_errors_func(subscribe_global_all_errors_func_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     error_type_map(error_type_map_)
   19 |     subscriptions({}) {
      |     ~~~~~~~~~~~~~~~~~
      |     database(error_database_)
../everest/everest-framework/lib/error/error_manager_req_global.cpp:17:5: note: field 'database' will be initialized after field 'subscribe_global_all_errors_func'
   17 |     database(error_database_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
../everest/everest-framework/lib/error/error_manager_req_global.cpp:18:5: note: field 'subscribe_global_all_errors_func' will be initialized after field 'subscriptions'
   18 |     subscribe_global_all_errors_func(subscribe_global_all_errors_func_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[4/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_error_error_manager_impl.cpp.o
../everest/everest-framework/lib/error/error_manager_impl.cpp:24:5: warning: initializer order does not match the declaration order [-Wreorder-ctor]
   24 |     error_type_map(error_type_map_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     publish_raised_error(publish_raised_error_)
   25 |     database(error_database_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
      |     publish_cleared_error(publish_cleared_error_)
   26 |     allowed_error_types(allowed_error_types_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     database(error_database_)
   27 |     publish_raised_error(publish_raised_error_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     error_type_map(error_type_map_)
   28 |     publish_cleared_error(publish_cleared_error_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     allowed_error_types(allowed_error_types_)
../everest/everest-framework/lib/error/error_manager_impl.cpp:24:5: note: field 'error_type_map' will be initialized after field 'database'
   24 |     error_type_map(error_type_map_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../everest/everest-framework/lib/error/error_manager_impl.cpp:26:5: note: field 'allowed_error_types' will be initialized after field 'publish_raised_error'
   26 |     allowed_error_types(allowed_error_types_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../everest/everest-framework/lib/error/error_manager_impl.cpp:71:25: warning: loop variable 'error' creates a copy from type 'const ErrorPtr' (aka 'const shared_ptr<Error>') [-Wrange-loop-construct]
   71 |     for (const ErrorPtr error : res) {
      |                         ^
../everest/everest-framework/lib/error/error_manager_impl.cpp:71:10: note: use reference type 'const ErrorPtr &' (aka 'const shared_ptr<Error> &') to prevent copying
   71 |     for (const ErrorPtr error : res) {
      |          ^~~~~~~~~~~~~~~~~~~~~~
      |                         &
../everest/everest-framework/lib/error/error_manager_impl.cpp:103:25: warning: loop variable 'error' creates a copy from type 'const ErrorPtr' (aka 'const shared_ptr<Error>') [-Wrange-loop-construct]
  103 |     for (const ErrorPtr error : res) {
      |                         ^
../everest/everest-framework/lib/error/error_manager_impl.cpp:103:10: note: use reference type 'const ErrorPtr &' (aka 'const shared_ptr<Error> &') to prevent copying
  103 |     for (const ErrorPtr error : res) {
      |          ^~~~~~~~~~~~~~~~~~~~~~
      |                         &
3 warnings generated.
[12/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_error_error.cpp.o
../everest/everest-framework/lib/error/error.cpp:42:5: warning: initializer order does not match the declaration order [-Wreorder-ctor]
   42 |     message(message_),
      |     ^~~~~~~~~~~~~~~~~
      |     description(description_)
   43 |     description(description_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
      |     message(message_)
   44 |     origin(origin_),
      |     ~~~~~~~~~~~~~~~
      |     severity(severity_)
   45 |     vendor_id(vendor_id_),
      |     ~~~~~~~~~~~~~~~~~~~~~
      |     origin(origin_)
   46 |     severity(severity_),
      |     ~~~~~~~~~~~~~~~~~~~
      |     timestamp(timestamp_)
   47 |     timestamp(timestamp_),
      |     ~~~~~~~~~~~~~~~~~~~~~
      |     uuid(uuid_)
   48 |     uuid(uuid_),
      |     ~~~~~~~~~~~
      |     state(state_)
   49 |     state(state_) {
      |     ~~~~~~~~~~~~~
      |     vendor_id(vendor_id_)
../everest/everest-framework/lib/error/error.cpp:42:5: note: field 'message' will be initialized after field 'description'
   42 |     message(message_),
      |     ^~~~~~~~~~~~~~~~~
../everest/everest-framework/lib/error/error.cpp:45:5: note: field 'vendor_id' will be initialized after field 'severity'
   45 |     vendor_id(vendor_id_),
      |     ^~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[13/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_error_error_manager_req.cpp.o
../everest/everest-framework/lib/error/error_manager_req.cpp:21:5: warning: field 'allowed_error_types' will be initialized after field 'subscribe_error_func' [-Wreorder-ctor]
   19 |     error_type_map(error_type_map_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     subscribe_error_func(subscribe_error_func_)
   20 |     database(error_database_),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
      |     error_type_map(error_type_map_)
   21 |     allowed_error_types(allowed_error_types_),
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     database(error_database_)
   22 |     subscribe_error_func(subscribe_error_func_) {
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     allowed_error_types(allowed_error_types_)
1 warning generated.
[20/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_runtime.cpp.o
In file included from ../everest/everest-framework/lib/runtime.cpp:4:
In file included from ../everest/everest-framework/include/framework/runtime.hpp:12:
In file included from ../everest/everest-framework/include/framework/ModuleAdapter.hpp:6:
In file included from ../everest/everest-framework/include/framework/everest.hpp:13:
In file included from ../everest/liblog/include/everest/exceptions.hpp:7:
../everest/liblog/include/everest/metamacros.hpp:42:22: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
   42 |     metamacro_at(20, ##__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
      |                      ^
1 warning generated.
[21/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_everest.cpp.o
../everest/everest-framework/lib/everest.cpp:729:33: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  729 |     Handler external_handler = [this, handler, external_topic](json const& data) {
      |                                 ^~~~~
In file included from ../everest/everest-framework/lib/everest.cpp:3:
In file included from /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/future:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/condition_variable:44:
In file included from /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:33:
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_construct.h:151:7: warning: destructor called on non-final 'Everest::error::ErrorDatabaseMap' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
  151 |       __pointer->~_Tp();
      |       ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:675:9: note: in instantiation of function template specialization 'std::_Destroy<Everest::error::ErrorDatabaseMap>' requested here
  675 |         { std::_Destroy(__p); }
      |                ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:613:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<Everest::error::ErrorDatabaseMap>' requested here
  613 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:599:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<Everest::error::ErrorDatabaseMap, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  599 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:972:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<Everest::error::ErrorDatabaseMap, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<>' requested here
  972 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:1712:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<Everest::error::ErrorDatabaseMap, std::allocator<void>>' requested here
 1712 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr.h:464:4: note: in instantiation of function template specialization 'std::__shared_ptr<Everest::error::ErrorDatabaseMap>::__shared_ptr<std::allocator<void>>' requested here
  464 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr.h:1009:14: note: in instantiation of function template specialization 'std::shared_ptr<Everest::error::ErrorDatabaseMap>::shared_ptr<std::allocator<void>>' requested here
 1009 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
../everest/everest-framework/lib/everest.cpp:70:79: note: in instantiation of function template specialization 'std::make_shared<Everest::error::ErrorDatabaseMap>' requested here
   70 |         std::shared_ptr<error::ErrorDatabaseMap> global_error_database = std::make_shared<error::ErrorDatabaseMap>();
      |                                                                               ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_construct.h:151:19: note: qualify call to silence this warning
  151 |       __pointer->~_Tp();
      |                   ^
2 warnings generated.
[22/59] Compiling C++ object everest/libframework.so.1.0.0.p/everest-framework_lib_config.cpp.o
../everest/everest-framework/lib/config.cpp:533:15: warning: unused variable 'manifest' [-Wunused-variable]
  533 |         auto& manifest = this->manifests["ProbeModule"];
      |               ^~~~~~~~
In file included from ../everest/everest-framework/lib/config.cpp:14:
In file included from ../everest/everest-framework/include/framework/runtime.hpp:12:
In file included from ../everest/everest-framework/include/framework/ModuleAdapter.hpp:6:
In file included from ../everest/everest-framework/include/framework/everest.hpp:15:
../everest/everest-framework/include/utils/config.hpp:51:10: warning: private field 'manager' is not used [-Wunused-private-field]
   51 |     bool manager;
      |          ^
2 warnings generated.
```