### PR TITLE
Consistent version number in bindings

### DIFF
--- a/everestjs/.gitignore
+++ b/everestjs/.gitignore
@@ -1,2 +1,3 @@
 *node_modules
+package.json
 package-lock.json

--- a/everestjs/CMakeLists.txt
+++ b/everestjs/CMakeLists.txt
@@ -51,6 +51,9 @@ if (NOT NODE_ADDON_API_PACKAGE_DIR)
     endif ()
 endif ()
 
+# populate package.json with version information
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/package.json.in" "${CMAKE_CURRENT_SOURCE_DIR}/package.json" @ONLY)
+
 execute_process(
     COMMAND ${NODE} -p "require('node-addon-api').include"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/everestjs/package.json.in
+++ b/everestjs/package.json.in
@@ -1,9 +1,9 @@
 {
   "name": "everestjs",
   "main": "index.js",
-  "version": "0.6.0",
+  "version": "@PROJECT_VERSION@",
   "description": "EVerest API for node.js",
   "dependencies": {
-    "node-addon-api": "^3.2.1"
+    "node-addon-api": "8.1"
   }
 }

--- a/everestpy/setup.cfg
+++ b/everestpy/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = everestpy
-version = attr: everest.framework.__version__
+version = attr: everest.framework.everestpy_version
 author = 'Kai-Uwe Hermann'
 author_email = kh@pionix.de
 description = everest framework python binding
@@ -15,10 +15,11 @@ classifiers =
 [options]
 package_dir =
     = src
-# packages = find:
+packages = find:
 python_requires = >=3.7
 
 [options.packages.find]
+where=src
 exclude =
     tests*
 

--- a/everestpy/src/everest/CMakeLists.txt
+++ b/everestpy/src/everest/CMakeLists.txt
@@ -11,6 +11,14 @@ endif()
 
 pybind11_add_module(everestpy misc.cpp module.cpp everestpy.cpp)
 
+# generate version information header
+evc_generate_version_information()
+target_include_directories(everestpy
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/framework/_version.in" "${CMAKE_CURRENT_SOURCE_DIR}/framework/_version.py" @ONLY)
+
 target_compile_options(everestpy PRIVATE ${COMPILER_WARNING_OPTIONS})
 
 target_link_libraries(everestpy

--- a/everestpy/src/everest/everestpy.cpp
+++ b/everestpy/src/everest/everestpy.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 #include <filesystem>
 #include <fstream>
 
@@ -14,6 +14,7 @@
 #include "misc.hpp"
 #include "module.hpp"
 
+#include <generated/version_information.hpp>
 #include <utils/error.hpp>
 #include <utils/error/error_factory.hpp>
 #include <utils/error/error_state_monitor.hpp>

--- a/everestpy/src/everest/framework/.gitignore
+++ b/everestpy/src/everest/framework/.gitignore
@@ -1,0 +1,1 @@
+_version.py

--- a/everestpy/src/everest/framework/__init__.py
+++ b/everestpy/src/everest/framework/__init__.py
@@ -1,6 +1,13 @@
-__version__ = '0.0.5'
+try:
+    from ._version import __version__ as everestpy_version
+except ImportError:
+    everestpy_version = '0.0.0'
 
 try:
     from .everestpy import *
 except ImportError:
-    from everestpy import *
+    try:
+        from everestpy import *
+    except ImportError:
+        # Unable to import everestpy which can happen during setup.py
+        pass

--- a/everestpy/src/everest/framework/_version.in
+++ b/everestpy/src/everest/framework/_version.in
@@ -1,0 +1,1 @@
+__version__ = "@PROJECT_VERSION@"

--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "everestrs"
-version = "0.1.0"
+version = "0.19.1"
 dependencies = [
  "argh",
  "cxx",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "everestrs-build"
-version = "0.1.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "argh",

--- a/everestrs/everestrs-build/Cargo.toml
+++ b/everestrs/everestrs-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everestrs-build"
-version = "0.1.0"
+version = "0.19.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everestrs"
-version = "0.1.0"
+version = "0.19.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
- everestpy: replace hardcoded version with version number that's ultimately populated by CMake
- everestjs: generate package.json containing the version information with CMake
- everestrs: TODO, since this is not just built by CMake, but also Bazel and Cargo, this should be kept in-sync manually, maybe enforced by a linter rule