### PR TITLE
Erase MessageHandler for topics without any registered handlers

### DIFF
--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -364,11 +364,10 @@ void MQTTAbstractionImpl::on_mqtt_message(const Message& message) {
         }
         lock.unlock();
 
-        // TODO(kai): this should maybe not even be a warning since it can happen that we unsubscribe from a topic and
-        // have removed the message handler but the MQTT unsubscribe didn't complete yet and we still receive messages
-        // on this topic that we can just ignore
+        // It can happen that we unsubscribe from a topic and have removed the message handler but the MQTT unsubscribe
+        // didn't complete yet and we still receive messages on this topic that we can just ignore
         if (!found) {
-            EVLOG_warning << fmt::format("Internal error: topic '{}' should have a matching handler!", topic);
+            EVLOG_verbose << fmt::format("Topic '{}' should have a matching handler!", topic);
         }
     } catch (boost::exception& e) {
         EVLOG_critical << fmt::format("Caught MQTT on_message boost::exception:\n{}",

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -452,11 +452,12 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
     if (this->message_handlers.count(topic) == 0) {
         this->message_handlers.emplace(std::piecewise_construct, std::forward_as_tuple(topic), std::forward_as_tuple());
     }
+
+    const auto subscription_necessary = (this->mqtt_is_connected && this->message_handlers.at(topic).count_handlers() == 0);
+
     this->message_handlers.at(topic).add_handler(handler);
 
-    // only subscribe for this topic if we aren't already and the mqtt client is connected
-    // if we are not connected the on_mqtt_connect() callback will subscribe to the topic
-    if (this->mqtt_is_connected && this->message_handlers.at(topic).count_handlers() == 1) {
+    if (subscription_necessary) {
         EVLOG_verbose << fmt::format("Subscribing to {}", topic);
         this->subscribe(topic, qos);
     }

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -453,15 +453,15 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
     if (this->message_handlers.count(topic) == 0) {
         this->message_handlers.emplace(std::piecewise_construct, std::forward_as_tuple(topic), std::forward_as_tuple());
     }
-    this->message_handlers[topic].add_handler(handler);
+    this->message_handlers.at(topic).add_handler(handler);
 
     // only subscribe for this topic if we aren't already and the mqtt client is connected
     // if we are not connected the on_mqtt_connect() callback will subscribe to the topic
-    if (this->mqtt_is_connected && this->message_handlers[topic].count_handlers() == 1) {
+    if (this->mqtt_is_connected && this->message_handlers.at(topic).count_handlers() == 1) {
         EVLOG_verbose << fmt::format("Subscribing to {}", topic);
         this->subscribe(topic, qos);
     }
-    EVLOG_verbose << fmt::format("#handler[{}] = {}", topic, this->message_handlers[topic].count_handlers());
+    EVLOG_verbose << fmt::format("#handler[{}] = {}", topic, this->message_handlers.at(topic).count_handlers());
 }
 
 void MQTTAbstractionImpl::unregister_handler(const std::string& topic, const Token& token) {

--- a/lib/mqtt_abstraction_impl.cpp
+++ b/lib/mqtt_abstraction_impl.cpp
@@ -453,7 +453,8 @@ void MQTTAbstractionImpl::register_handler(const std::string& topic, std::shared
         this->message_handlers.emplace(std::piecewise_construct, std::forward_as_tuple(topic), std::forward_as_tuple());
     }
 
-    const auto subscription_necessary = (this->mqtt_is_connected && this->message_handlers.at(topic).count_handlers() == 0);
+    const auto subscription_necessary =
+        (this->mqtt_is_connected && this->message_handlers.at(topic).count_handlers() == 0);
 
     this->message_handlers.at(topic).add_handler(handler);
 


### PR DESCRIPTION
This drastically reduces the amount of lingering threads just hanging around and doing absolutely nothing