### PR TITLE
Refactor schema loading and validation

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -75,6 +75,19 @@ void loader(const nlohmann::json_uri& uri, nlohmann::json& schema);
 void format_checker(const std::string& format, const std::string& value);
 
 ///
+/// \brief loads and validates a json schema at the provided \p path
+///
+/// \returns the loaded json schema as a json object as well as a related schema validator
+std::tuple<nlohmann::json, nlohmann::json_schema::json_validator> load_schema(const fs::path& path);
+
+///
+/// \brief loads the config.json and manifest.json in the schemes subfolder of
+/// the provided \p schemas_dir
+///
+/// \returns the loaded configs and related validators
+SchemaValidation load_schemas(const fs::path& schemas_dir);
+
+///
 /// \brief Base class for configs
 ///
 class ConfigBase {
@@ -353,19 +366,6 @@ public:
     /// the json schema validator when it encounters it. Throws an exception
     /// otherwise
     void ref_loader(const nlohmann::json_uri& uri, nlohmann::json& schema);
-
-    ///
-    /// \brief loads the config.json and manifest.json in the schemes subfolder of
-    /// the provided \p schemas_dir
-    ///
-    /// \returns the loaded configs and related validators
-    static SchemaValidation load_schemas(const fs::path& schemas_dir);
-
-    ///
-    /// \brief loads and validates a json schema at the provided \p path
-    ///
-    /// \returns the loaded json schema as a json object as well as a related schema validator
-    static std::tuple<nlohmann::json, nlohmann::json_schema::json_validator> load_schema(const fs::path& path);
 
     ///
     /// \brief loads all module manifests relative to the \p main_dir

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -30,12 +30,25 @@ struct RuntimeSettings;
 ///
 /// \brief A structure that contains all available schemas
 ///
-struct schemas {
+struct Schemas {
     nlohmann::json config;                 ///< The config schema
     nlohmann::json manifest;               ///< The manifest scheme
     nlohmann::json interface;              ///< The interface schema
     nlohmann::json type;                   ///< The type schema
     nlohmann::json error_declaration_list; ///< The error-declaration-list schema
+};
+
+struct Validators {
+    std::unique_ptr<nlohmann::json_schema::json_validator> config;
+    std::unique_ptr<nlohmann::json_schema::json_validator> manifest;
+    std::unique_ptr<nlohmann::json_schema::json_validator> type;
+    std::unique_ptr<nlohmann::json_schema::json_validator> interface;
+    std::unique_ptr<nlohmann::json_schema::json_validator> error_declaration_list;
+};
+
+struct SchemaValidation {
+    Schemas schemas;
+    Validators validators;
 };
 
 ///
@@ -51,6 +64,17 @@ struct ImplementationInfo {
 };
 
 ///
+/// \brief A simple json schema loader that uses the builtin draft7 schema of
+/// the json schema validator when it encounters it, throws an exception
+/// otherwise
+void loader(const nlohmann::json_uri& uri, nlohmann::json& schema);
+
+///
+/// \brief An extension to the default format checker of the json schema
+/// validator supporting uris
+void format_checker(const std::string& format, const std::string& value);
+
+///
 /// \brief Base class for configs
 ///
 class ConfigBase {
@@ -62,7 +86,7 @@ protected:
     nlohmann::json interfaces;
     nlohmann::json interface_definitions;
     nlohmann::json types;
-    schemas _schemas;
+    Schemas schemas;
 
     std::unordered_map<std::string, ModuleTierMappings> tier_mappings;
     // experimental caches
@@ -190,6 +214,8 @@ class ManagerConfig : public ConfigBase {
 private:
     const ManagerSettings& ms;
     std::unordered_map<std::string, std::optional<TelemetryConfig>> telemetry_configs;
+    Validators validators;
+    std::unique_ptr<nlohmann::json_schema::json_validator> draft7_validator;
 
     ///
     /// \brief loads and validates the manifest of the module \p module_id using the provided \p module config
@@ -332,14 +358,15 @@ public:
     /// \brief loads the config.json and manifest.json in the schemes subfolder of
     /// the provided \p schemas_dir
     ///
-    /// \returns the config and manifest schemas
-    static schemas load_schemas(const fs::path& schemas_dir);
+    /// \returns the loaded configs and related validators
+    static SchemaValidation load_schemas(const fs::path& schemas_dir);
 
     ///
     /// \brief loads and validates a json schema at the provided \p path
     ///
-    /// \returns the loaded json schema as a json object
-    static nlohmann::json load_schema(const fs::path& path);
+    /// \returns the loaded json schema as a json object as well as a related schema validator
+    static std::tuple<nlohmann::json, std::unique_ptr<nlohmann::json_schema::json_validator>>
+    load_schema(const fs::path& path);
 
     ///
     /// \brief loads all module manifests relative to the \p main_dir
@@ -352,25 +379,14 @@ public:
     ///
     /// \returns a set of object keys
     static std::set<std::string> keys(const nlohmann::json& object);
-
-    ///
-    /// \brief A simple json schema loader that uses the builtin draft7 schema of
-    /// the json schema validator when it encounters it, throws an exception
-    /// otherwise
-    static void loader(const nlohmann::json_uri& uri, nlohmann::json& schema);
-
-    ///
-    /// \brief An extension to the default format checker of the json schema
-    /// validator supporting uris
-    static void format_checker(const std::string& format, const std::string& value);
 };
 } // namespace Everest
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
-template <> struct adl_serializer<Everest::schemas> {
-    static void to_json(nlohmann::json& j, const Everest::schemas& s);
+template <> struct adl_serializer<Everest::Schemas> {
+    static void to_json(nlohmann::json& j, const Everest::Schemas& s);
 
-    static void from_json(const nlohmann::json& j, Everest::schemas& s);
+    static void from_json(const nlohmann::json& j, Everest::Schemas& s);
 };
 NLOHMANN_JSON_NAMESPACE_END
 

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -39,11 +39,11 @@ struct Schemas {
 };
 
 struct Validators {
-    std::unique_ptr<nlohmann::json_schema::json_validator> config;
-    std::unique_ptr<nlohmann::json_schema::json_validator> manifest;
-    std::unique_ptr<nlohmann::json_schema::json_validator> type;
-    std::unique_ptr<nlohmann::json_schema::json_validator> interface;
-    std::unique_ptr<nlohmann::json_schema::json_validator> error_declaration_list;
+    nlohmann::json_schema::json_validator config;
+    nlohmann::json_schema::json_validator manifest;
+    nlohmann::json_schema::json_validator type;
+    nlohmann::json_schema::json_validator interface;
+    nlohmann::json_schema::json_validator error_declaration_list;
 };
 
 struct SchemaValidation {
@@ -365,8 +365,7 @@ public:
     /// \brief loads and validates a json schema at the provided \p path
     ///
     /// \returns the loaded json schema as a json object as well as a related schema validator
-    static std::tuple<nlohmann::json, std::unique_ptr<nlohmann::json_schema::json_validator>>
-    load_schema(const fs::path& path);
+    static std::tuple<nlohmann::json, nlohmann::json_schema::json_validator> load_schema(const fs::path& path);
 
     ///
     /// \brief loads all module manifests relative to the \p main_dir

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -48,9 +48,37 @@ struct ParsedConfigMap {
     std::set<std::string> unknown_config_entries;
 };
 
+void loader(const json_uri& uri, json& schema) {
+    BOOST_LOG_FUNCTION();
+
+    if (uri.location() == "http://json-schema.org/draft-07/schema") {
+        schema = nlohmann::json_schema::draft7_schema_builtin;
+        return;
+    }
+
+    // TODO(kai): think about supporting more urls here
+    EVTHROW(EverestInternalError(fmt::format("{} is not supported for schema loading at the moment\n", uri.url())));
+}
+
+void format_checker(const std::string& format, const std::string& value) {
+    BOOST_LOG_FUNCTION();
+
+    if (format == "uri") {
+        if (value.find("://") == std::string::npos) {
+            EVTHROW(std::invalid_argument("URI does not contain :// - invalid"));
+        }
+    } else if (format == "uri-reference") {
+        if (!std::regex_match(value, type_uri_regex)) {
+            EVTHROW(std::invalid_argument("Type URI is malformed."));
+        }
+    } else {
+        nlohmann::json_schema::default_string_format_check(format, value);
+    }
+}
+
 static void validate_config_schema(const json& config_map_schema) {
     // iterate over every config entry
-    json_validator validator(Config::loader, Config::format_checker);
+    json_validator validator(loader, format_checker);
     for (const auto& config_item : config_map_schema.items()) {
         if (!config_item.value().contains("default")) {
             continue;
@@ -92,7 +120,7 @@ static ParsedConfigMap parse_config_map(const json& config_map_schema, const jso
         } else if (config_entry.contains("default")) {
             config_entry_value = config_entry.at("default"); // use default value defined in manifest
         }
-        json_validator validator(Config::loader, Config::format_checker);
+        json_validator validator(loader, format_checker);
         validator.set_root_schema(config_entry);
         try {
             auto patch = validator.validate(config_entry_value);
@@ -340,7 +368,7 @@ const json& ConfigBase::get_settings() const {
 
 const json ConfigBase::get_schemas() const {
     BOOST_LOG_FUNCTION();
-    return this->_schemas;
+    return this->schemas;
 }
 
 json ConfigBase::get_error_types() {
@@ -484,9 +512,7 @@ void ManagerConfig::load_and_validate_manifest(const std::string& module_id, con
             this->manifests[module_name] = load_yaml(manifest_path);
         }
 
-        json_validator validator(Config::loader, Config::format_checker);
-        validator.set_root_schema(this->_schemas.manifest);
-        const auto patch = validator.validate(this->manifests[module_name]);
+        const auto patch = this->validators.manifest->validate(this->manifests[module_name]);
         if (!patch.is_null()) {
             // extend manifest with default values
             this->manifests[module_name] = this->manifests[module_name].patch(patch);
@@ -614,7 +640,7 @@ std::tuple<json, int64_t> ManagerConfig::load_and_validate_with_schema(const fs:
     int64_t validation_ms = 0;
 
     const auto start_time_validate = std::chrono::system_clock::now();
-    json_validator validator(Config::loader, Config::format_checker);
+    json_validator validator(loader, format_checker);
     validator.set_root_schema(schema);
     validator.validate(json_to_validate);
     const auto end_time_validate = std::chrono::system_clock::now();
@@ -648,9 +674,7 @@ json ManagerConfig::load_interface_file(const std::string& intf_name) {
         // this subschema can not use allOf with the draft-07 schema because that will cause our validator to
         // add all draft-07 default values which never validate (the {"not": true} default contradicts everything)
         // --> validating against draft-07 will be done in an extra step below
-        json_validator validator(Config::loader, Config::format_checker);
-        validator.set_root_schema(this->_schemas.interface);
-        auto patch = validator.validate(interface_json);
+        auto patch = this->validators.interface->validate(interface_json);
         if (!patch.is_null()) {
             // extend config entry with default values
             interface_json = interface_json.patch(patch);
@@ -663,7 +687,6 @@ json ManagerConfig::load_interface_file(const std::string& intf_name) {
         }
 
         // validate every cmd arg/result and var definition against draft-07 schema
-        validator.set_root_schema(draft07);
         for (auto& var_entry : interface_json["vars"].items()) {
             auto& var_value = var_entry.value();
             // erase "description"
@@ -684,7 +707,7 @@ json ManagerConfig::load_interface_file(const std::string& intf_name) {
                     }
                 }
             }
-            validator.validate(var_value);
+            this->draft7_validator->validate(var_value);
         }
         for (auto& cmd_entry : interface_json["cmds"].items()) {
             auto& cmd = interface_json["cmds"][cmd_entry.key()];
@@ -698,14 +721,14 @@ json ManagerConfig::load_interface_file(const std::string& intf_name) {
                 if (arg_entry.contains("description")) {
                     arg_entry.erase("description");
                 }
-                validator.validate(arg_entry);
+                this->draft7_validator->validate(arg_entry);
             }
             auto& result = interface_json["cmds"][cmd_entry.key()]["result"];
             // erase "description"
             if (result.contains("description")) {
                 result.erase("description");
             }
-            validator.validate(result);
+            this->draft7_validator->validate(result);
         }
 
         return interface_json;
@@ -904,7 +927,7 @@ void ManagerConfig::parse(json config) {
                     EVLOG_verbose << fmt::format("Loading type file at: {}", fs::canonical(type_file_path).c_str());
 
                     const auto [type_json, validate_ms] =
-                        load_and_validate_with_schema(type_file_path, this->_schemas.type);
+                        load_and_validate_with_schema(type_file_path, this->schemas.type);
                     total_time_validation_ms += validate_ms;
 
                     this->types[type_path] = type_json.at("types");
@@ -935,7 +958,7 @@ void ManagerConfig::parse(json config) {
                     EVLOG_verbose << fmt::format("Loading error file at: {}", fs::canonical(error_file_path).c_str());
 
                     const auto [error_json, validate_ms] =
-                        load_and_validate_with_schema(error_file_path, this->_schemas.error_declaration_list);
+                        load_and_validate_with_schema(error_file_path, this->schemas.error_declaration_list);
                     total_time_validation_ms += validate_ms;
 
                 } catch (const std::exception& e) {
@@ -1049,8 +1072,12 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
     this->interfaces = json({});
     this->interface_definitions = json({});
     this->types = json({});
-    this->_schemas = Config::load_schemas(this->ms.schemas_dir);
+    auto schema_validation = Config::load_schemas(this->ms.schemas_dir);
+    this->schemas = schema_validation.schemas;
+    this->validators = std::move(schema_validation.validators);
     this->error_map = error::ErrorTypeMap(this->ms.errors_dir);
+    this->draft7_validator = std::make_unique<json_validator>(loader, format_checker);
+    this->draft7_validator->set_root_schema(draft07);
 
     // load and process config file
     const fs::path config_path = this->ms.config_file;
@@ -1072,9 +1099,7 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
             EVLOG_verbose << "No user-config provided.";
         }
 
-        json_validator validator(Config::loader, Config::format_checker);
-        validator.set_root_schema(this->_schemas.config);
-        const auto patch = validator.validate(complete_config);
+        const auto patch = this->validators.config->validate(complete_config);
         if (!patch.is_null()) {
             // extend config with default values
             complete_config = complete_config.patch(patch);
@@ -1119,7 +1144,7 @@ Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : Conf
         this->telemetry_config = serialized_config.at("telemetry_config");
     }
 
-    this->_schemas = serialized_config.at("schemas");
+    this->schemas = serialized_config.at("schemas");
     this->error_map = error::ErrorTypeMap();
     this->error_map.load_error_types_map(serialized_config.at("error_map"));
 }
@@ -1254,21 +1279,33 @@ void Config::ref_loader(const json_uri& uri, json& schema) {
     EVTHROW(EverestInternalError(fmt::format("{} is not supported for schema loading at the moment\n", uri.url())));
 }
 
-schemas Config::load_schemas(const fs::path& schemas_dir) {
+SchemaValidation Config::load_schemas(const fs::path& schemas_dir) {
     BOOST_LOG_FUNCTION();
-    schemas schemas;
+    SchemaValidation schema_validation;
 
     EVLOG_debug << fmt::format("Loading base schema files for config and manifests... from: {}", schemas_dir.string());
-    schemas.config = Config::load_schema(schemas_dir / "config.yaml");
-    schemas.manifest = Config::load_schema(schemas_dir / "manifest.yaml");
-    schemas.interface = Config::load_schema(schemas_dir / "interface.yaml");
-    schemas.type = Config::load_schema(schemas_dir / "type.yaml");
-    schemas.error_declaration_list = Config::load_schema(schemas_dir / "error-declaration-list.yaml");
+    auto [config_schema, config_val] = Config::load_schema(schemas_dir / "config.yaml");
+    schema_validation.schemas.config = config_schema;
+    schema_validation.validators.config = std::move(config_val);
+    auto [manifest_schema, manifest_val] = Config::load_schema(schemas_dir / "manifest.yaml");
+    schema_validation.schemas.manifest = manifest_schema;
+    schema_validation.validators.manifest = std::move(manifest_val);
+    auto [interface_schema, interface_val] = Config::load_schema(schemas_dir / "interface.yaml");
+    schema_validation.schemas.interface = interface_schema;
+    schema_validation.validators.interface = std::move(interface_val);
+    auto [type_schema, type_val] = Config::load_schema(schemas_dir / "type.yaml");
+    schema_validation.schemas.type = type_schema;
+    schema_validation.validators.type = std::move(type_val);
+    auto [error_declaration_list_schema, error_declaration_list_val] =
+        Config::load_schema(schemas_dir / "error-declaration-list.yaml");
+    schema_validation.schemas.error_declaration_list = error_declaration_list_schema;
+    schema_validation.validators.error_declaration_list = std::move(error_declaration_list_val);
 
-    return schemas;
+    return schema_validation;
 }
 
-json Config::load_schema(const fs::path& path) {
+std::tuple<nlohmann::json, std::unique_ptr<nlohmann::json_schema::json_validator>>
+Config::load_schema(const fs::path& path) {
     BOOST_LOG_FUNCTION();
 
     if (!fs::exists(path)) {
@@ -1278,18 +1315,19 @@ json Config::load_schema(const fs::path& path) {
 
     EVLOG_debug << fmt::format("Loading schema file at: {}", fs::canonical(path).string());
 
-    const json schema = load_yaml(path);
+    json schema = load_yaml(path);
 
-    json_validator validator(Config::loader, Config::format_checker);
+    auto validator = std::make_unique<json_validator>(loader, format_checker);
 
     try {
-        validator.set_root_schema(schema);
+        validator->set_root_schema(schema);
     } catch (const std::exception& e) {
         EVLOG_AND_THROW(EverestInternalError(
             fmt::format("Validation of schema '{}' failed, here is why: {}", path.string(), e.what())));
     }
 
-    return schema;
+    return std::make_tuple<nlohmann::json, std::unique_ptr<nlohmann::json_schema::json_validator>>(
+        std::move(schema), std::move(validator));
 }
 
 json Config::load_all_manifests(const std::string& modules_dir, const std::string& schemas_dir) {
@@ -1297,7 +1335,7 @@ json Config::load_all_manifests(const std::string& modules_dir, const std::strin
 
     json manifests = json({});
 
-    const schemas schemas = Config::load_schemas(schemas_dir);
+    auto schema_validation = Config::load_schemas(schemas_dir);
 
     const fs::path modules_path = fs::path(modules_dir);
 
@@ -1313,9 +1351,7 @@ json Config::load_all_manifests(const std::string& modules_dir, const std::strin
         try {
             manifests[module_name] = load_yaml(manifest_path);
 
-            json_validator validator(Config::loader, Config::format_checker);
-            validator.set_root_schema(schemas.manifest);
-            validator.validate(manifests.at(module_name));
+            schema_validation.validators.manifest->validate(manifests.at(module_name));
         } catch (const std::exception& e) {
             EVLOG_AND_THROW(EverestConfigError(
                 fmt::format("Failed to load and parse module manifest file of module {}: {}", module_name, e.what())));
@@ -1345,38 +1381,10 @@ std::set<std::string> Config::keys(const json& object) {
     return keys;
 }
 
-void Config::loader(const json_uri& uri, json& schema) {
-    BOOST_LOG_FUNCTION();
-
-    if (uri.location() == "http://json-schema.org/draft-07/schema") {
-        schema = nlohmann::json_schema::draft7_schema_builtin;
-        return;
-    }
-
-    // TODO(kai): think about supporting more urls here
-    EVTHROW(EverestInternalError(fmt::format("{} is not supported for schema loading at the moment\n", uri.url())));
-}
-
-void Config::format_checker(const std::string& format, const std::string& value) {
-    BOOST_LOG_FUNCTION();
-
-    if (format == "uri") {
-        if (value.find("://") == std::string::npos) {
-            EVTHROW(std::invalid_argument("URI does not contain :// - invalid"));
-        }
-    } else if (format == "uri-reference") {
-        if (!std::regex_match(value, type_uri_regex)) {
-            EVTHROW(std::invalid_argument("Type URI is malformed."));
-        }
-    } else {
-        nlohmann::json_schema::default_string_format_check(format, value);
-    }
-}
-
 } // namespace Everest
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
-void adl_serializer<Everest::schemas>::to_json(nlohmann::json& j, const Everest::schemas& s) {
+void adl_serializer<Everest::Schemas>::to_json(nlohmann::json& j, const Everest::Schemas& s) {
     j = {{"config", s.config},
          {"manifest", s.manifest},
          {"interface", s.interface},
@@ -1384,7 +1392,7 @@ void adl_serializer<Everest::schemas>::to_json(nlohmann::json& j, const Everest:
          {"error_declaration_list", s.error_declaration_list}};
 }
 
-void adl_serializer<Everest::schemas>::from_json(const nlohmann::json& j, Everest::schemas& s) {
+void adl_serializer<Everest::Schemas>::from_json(const nlohmann::json& j, Everest::Schemas& s) {
     s.config = j.at("config");
     s.manifest = j.at("manifest");
     s.interface = j.at("interface");

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -76,8 +76,7 @@ void format_checker(const std::string& format, const std::string& value) {
     }
 }
 
-std::tuple<nlohmann::json, nlohmann::json_schema::json_validator>
-load_schema(const fs::path& path) {
+std::tuple<nlohmann::json, nlohmann::json_schema::json_validator> load_schema(const fs::path& path) {
     BOOST_LOG_FUNCTION();
 
     if (!fs::exists(path)) {
@@ -98,8 +97,8 @@ load_schema(const fs::path& path) {
             fmt::format("Validation of schema '{}' failed, here is why: {}", path.string(), e.what())));
     }
 
-    return std::make_tuple<nlohmann::json, nlohmann::json_schema::json_validator>(
-        std::move(schema), std::move(validator));
+    return std::make_tuple<nlohmann::json, nlohmann::json_schema::json_validator>(std::move(schema),
+                                                                                  std::move(validator));
 }
 
 SchemaValidation load_schemas(const fs::path& schemas_dir) {

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -76,6 +76,57 @@ void format_checker(const std::string& format, const std::string& value) {
     }
 }
 
+std::tuple<nlohmann::json, nlohmann::json_schema::json_validator>
+load_schema(const fs::path& path) {
+    BOOST_LOG_FUNCTION();
+
+    if (!fs::exists(path)) {
+        EVLOG_AND_THROW(
+            EverestInternalError(fmt::format("Schema file does not exist at: {}", fs::absolute(path).string())));
+    }
+
+    EVLOG_debug << fmt::format("Loading schema file at: {}", fs::canonical(path).string());
+
+    json schema = load_yaml(path);
+
+    auto validator = nlohmann::json_schema::json_validator(loader, format_checker);
+
+    try {
+        validator.set_root_schema(schema);
+    } catch (const std::exception& e) {
+        EVLOG_AND_THROW(EverestInternalError(
+            fmt::format("Validation of schema '{}' failed, here is why: {}", path.string(), e.what())));
+    }
+
+    return std::make_tuple<nlohmann::json, nlohmann::json_schema::json_validator>(
+        std::move(schema), std::move(validator));
+}
+
+SchemaValidation load_schemas(const fs::path& schemas_dir) {
+    BOOST_LOG_FUNCTION();
+    SchemaValidation schema_validation;
+
+    EVLOG_debug << fmt::format("Loading base schema files for config and manifests... from: {}", schemas_dir.string());
+    auto [config_schema, config_val] = load_schema(schemas_dir / "config.yaml");
+    schema_validation.schemas.config = config_schema;
+    schema_validation.validators.config = std::move(config_val);
+    auto [manifest_schema, manifest_val] = load_schema(schemas_dir / "manifest.yaml");
+    schema_validation.schemas.manifest = manifest_schema;
+    schema_validation.validators.manifest = std::move(manifest_val);
+    auto [interface_schema, interface_val] = load_schema(schemas_dir / "interface.yaml");
+    schema_validation.schemas.interface = interface_schema;
+    schema_validation.validators.interface = std::move(interface_val);
+    auto [type_schema, type_val] = load_schema(schemas_dir / "type.yaml");
+    schema_validation.schemas.type = type_schema;
+    schema_validation.validators.type = std::move(type_val);
+    auto [error_declaration_list_schema, error_declaration_list_val] =
+        load_schema(schemas_dir / "error-declaration-list.yaml");
+    schema_validation.schemas.error_declaration_list = error_declaration_list_schema;
+    schema_validation.validators.error_declaration_list = std::move(error_declaration_list_val);
+
+    return schema_validation;
+}
+
 static void validate_config_schema(const json& config_map_schema) {
     // iterate over every config entry
     json_validator validator(loader, format_checker);
@@ -1072,7 +1123,7 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
     this->interfaces = json({});
     this->interface_definitions = json({});
     this->types = json({});
-    auto schema_validation = Config::load_schemas(this->ms.schemas_dir);
+    auto schema_validation = load_schemas(this->ms.schemas_dir);
     this->schemas = schema_validation.schemas;
     this->validators = std::move(schema_validation.validators);
     this->error_map = error::ErrorTypeMap(this->ms.errors_dir);
@@ -1279,63 +1330,12 @@ void Config::ref_loader(const json_uri& uri, json& schema) {
     EVTHROW(EverestInternalError(fmt::format("{} is not supported for schema loading at the moment\n", uri.url())));
 }
 
-SchemaValidation Config::load_schemas(const fs::path& schemas_dir) {
-    BOOST_LOG_FUNCTION();
-    SchemaValidation schema_validation;
-
-    EVLOG_debug << fmt::format("Loading base schema files for config and manifests... from: {}", schemas_dir.string());
-    auto [config_schema, config_val] = Config::load_schema(schemas_dir / "config.yaml");
-    schema_validation.schemas.config = config_schema;
-    schema_validation.validators.config = std::move(config_val);
-    auto [manifest_schema, manifest_val] = Config::load_schema(schemas_dir / "manifest.yaml");
-    schema_validation.schemas.manifest = manifest_schema;
-    schema_validation.validators.manifest = std::move(manifest_val);
-    auto [interface_schema, interface_val] = Config::load_schema(schemas_dir / "interface.yaml");
-    schema_validation.schemas.interface = interface_schema;
-    schema_validation.validators.interface = std::move(interface_val);
-    auto [type_schema, type_val] = Config::load_schema(schemas_dir / "type.yaml");
-    schema_validation.schemas.type = type_schema;
-    schema_validation.validators.type = std::move(type_val);
-    auto [error_declaration_list_schema, error_declaration_list_val] =
-        Config::load_schema(schemas_dir / "error-declaration-list.yaml");
-    schema_validation.schemas.error_declaration_list = error_declaration_list_schema;
-    schema_validation.validators.error_declaration_list = std::move(error_declaration_list_val);
-
-    return schema_validation;
-}
-
-std::tuple<nlohmann::json, nlohmann::json_schema::json_validator>
-Config::load_schema(const fs::path& path) {
-    BOOST_LOG_FUNCTION();
-
-    if (!fs::exists(path)) {
-        EVLOG_AND_THROW(
-            EverestInternalError(fmt::format("Schema file does not exist at: {}", fs::absolute(path).string())));
-    }
-
-    EVLOG_debug << fmt::format("Loading schema file at: {}", fs::canonical(path).string());
-
-    json schema = load_yaml(path);
-
-    auto validator = nlohmann::json_schema::json_validator(loader, format_checker);
-
-    try {
-        validator.set_root_schema(schema);
-    } catch (const std::exception& e) {
-        EVLOG_AND_THROW(EverestInternalError(
-            fmt::format("Validation of schema '{}' failed, here is why: {}", path.string(), e.what())));
-    }
-
-    return std::make_tuple<nlohmann::json, nlohmann::json_schema::json_validator>(
-        std::move(schema), std::move(validator));
-}
-
 json Config::load_all_manifests(const std::string& modules_dir, const std::string& schemas_dir) {
     BOOST_LOG_FUNCTION();
 
     json manifests = json({});
 
-    auto schema_validation = Config::load_schemas(schemas_dir);
+    auto schema_validation = load_schemas(schemas_dir);
 
     const fs::path modules_path = fs::path(modules_dir);
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -347,7 +347,7 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, json
             try {
                 json_validator validator(
                     [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); },
-                    Config::format_checker);
+                    format_checker);
                 validator.set_root_schema(cmd_definition.at("arguments").at(arg_name));
                 validator.validate(json_args.at(arg_name));
             } catch (const std::exception& e) {
@@ -437,8 +437,7 @@ void Everest::publish_var(const std::string& impl_id, const std::string& var_nam
         const auto var_definition = impl_intf.at("vars").at(var_name);
         try {
             json_validator validator(
-                [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); },
-                Config::format_checker);
+                [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); }, format_checker);
             validator.set_root_schema(var_definition);
             validator.validate(value);
         } catch (const std::exception& e) {
@@ -492,7 +491,7 @@ void Everest::subscribe_var(const Requirement& req, const std::string& var_name,
             try {
                 json_validator validator(
                     [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); },
-                    Config::format_checker);
+                    format_checker);
                 validator.set_root_schema(requirement_manifest_vardef);
                 validator.validate(data);
             } catch (const std::exception& e) {
@@ -857,7 +856,7 @@ void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_nam
                     }
                     json_validator validator(
                         [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); },
-                        Config::format_checker);
+                        format_checker);
                     validator.set_root_schema(cmd_definition.at("arguments").at(arg_name));
                     validator.validate(data.at("args").at(arg_name));
                 }
@@ -883,7 +882,7 @@ void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_nam
                       (!cmd_definition.contains("result") || cmd_definition.at("result").is_null()))) {
                     json_validator validator(
                         [this](const json_uri& uri, json& schema) { this->config.ref_loader(uri, schema); },
-                        Config::format_checker);
+                        format_checker);
                     validator.set_root_schema(cmd_definition.at("result"));
                     validator.validate(res_data.at("retval"));
                 }


### PR DESCRIPTION
Now when a schema is loaded a validator for it is instantiated as well
Then validators can then be re-used instead of instantiating new ones for the same schema multiple times