### PR TITLE
Additional everestpy runtime settings ctor

### DIFF
--- a/everestpy/src/everest/everestpy.cpp
+++ b/everestpy/src/everest/everestpy.cpp
@@ -22,10 +22,20 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(everestpy, m) {
 
+    py::class_<Everest::MQTTSettings>(m, "MQTTSettings")
+        .def(py::init<>())
+        .def_readwrite("broker_socket_path", &Everest::MQTTSettings::broker_socket_path)
+        .def_readwrite("broker_host", &Everest::MQTTSettings::broker_host)
+        .def_readwrite("broker_port", &Everest::MQTTSettings::broker_port)
+        .def_readwrite("everest_prefix", &Everest::MQTTSettings::everest_prefix)
+        .def_readwrite("external_prefix", &Everest::MQTTSettings::external_prefix)
+        .def("uses_socket", &Everest::MQTTSettings::uses_socket);
+
     // FIXME (aw): add m.doc?
     py::class_<RuntimeSession>(m, "RuntimeSession")
         .def(py::init<>())
-        .def(py::init<const std::string&, const std::string&>());
+        .def(py::init<const std::string&, const std::string&>())
+        .def(py::init<const Everest::MQTTSettings&, const std::string&>());
 
     py::class_<ModuleInfo::Paths>(m, "ModuleInfoPaths")
         .def_readonly("etc", &ModuleInfo::Paths::etc)

--- a/everestpy/src/everest/misc.cpp
+++ b/everestpy/src/everest/misc.cpp
@@ -63,18 +63,14 @@ RuntimeSession::RuntimeSession(const std::string& prefix, const std::string& con
     // We extract the settings from the config file so everest-testing doesn't break
     const auto ms = Everest::ManagerSettings(prefix, config_file);
 
-    Everest::Logging::init(ms.runtime_settings->logging_config_file.string());
+    this->logging_config_file = ms.runtime_settings->logging_config_file;
 
     this->mqtt_settings = ms.mqtt_settings;
 }
 
 RuntimeSession::RuntimeSession() {
-    const auto module_id = get_variable_from_env("EV_MODULE");
-
-    namespace fs = std::filesystem;
-    const fs::path logging_config_file =
+    this->logging_config_file =
         Everest::assert_file(get_variable_from_env("EV_LOG_CONF_FILE"), "Default logging config");
-    Everest::Logging::init(logging_config_file.string(), module_id);
 
     this->mqtt_settings = get_mqtt_settings_from_env();
 }

--- a/everestpy/src/everest/misc.cpp
+++ b/everestpy/src/everest/misc.cpp
@@ -53,6 +53,17 @@ static Everest::MQTTSettings get_mqtt_settings_from_env() {
     }
 }
 
+RuntimeSession::RuntimeSession(const Everest::MQTTSettings& mqtt_settings, const std::string& logging_config) {
+    this->mqtt_settings = mqtt_settings;
+    if (logging_config.empty()) {
+        this->logging_config_file = Everest::assert_dir(Everest::defaults::PREFIX, "Default prefix") /
+                                    std::filesystem::path(Everest::defaults::SYSCONF_DIR) /
+                                    Everest::defaults::NAMESPACE / Everest::defaults::LOGGING_CONFIG_NAME;
+    } else {
+        this->logging_config_file = Everest::assert_file(logging_config, "Default logging config");
+    }
+}
+
 /// This is just kept for compatibility
 RuntimeSession::RuntimeSession(const std::string& prefix, const std::string& config_file) {
     EVLOG_warning

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -22,8 +22,13 @@ public:
         return mqtt_settings;
     }
 
+    const std::filesystem::path& get_logging_config_file() const {
+        return logging_config_file;
+    }
+
 private:
     Everest::MQTTSettings mqtt_settings;
+    std::filesystem::path logging_config_file;
 };
 
 struct Interface {

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -14,10 +14,14 @@ const std::string get_variable_from_env(const std::string& variable, const std::
 
 class RuntimeSession {
 public:
+    /// \brief Allows python modules to directly pass \p mqtt_settings as well as a \p logging_config
     RuntimeSession(const Everest::MQTTSettings& mqtt_settings, const std::string& logging_config);
 
+    [[deprecated("Consider switching to the newer RuntimeSession() or RuntimeSession(mqtt_settings, logging_config) "
+                 "ctors that receive module configuration via MQTT")]]
     RuntimeSession(const std::string& prefix, const std::string& config_file);
 
+    /// \brief Get settings and configuration via MQTT based on certain environment variables
     RuntimeSession();
 
     const Everest::MQTTSettings& get_mqtt_settings() const {

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -14,6 +14,8 @@ const std::string get_variable_from_env(const std::string& variable, const std::
 
 class RuntimeSession {
 public:
+    RuntimeSession(const Everest::MQTTSettings& mqtt_settings, const std::string& logging_config);
+
     RuntimeSession(const std::string& prefix, const std::string& config_file);
 
     RuntimeSession();

--- a/everestpy/src/everest/misc.hpp
+++ b/everestpy/src/everest/misc.hpp
@@ -18,8 +18,8 @@ public:
     RuntimeSession(const Everest::MQTTSettings& mqtt_settings, const std::string& logging_config);
 
     [[deprecated("Consider switching to the newer RuntimeSession() or RuntimeSession(mqtt_settings, logging_config) "
-                 "ctors that receive module configuration via MQTT")]]
-    RuntimeSession(const std::string& prefix, const std::string& config_file);
+                 "ctors that receive module configuration via MQTT")]] RuntimeSession(const std::string& prefix,
+                                                                                      const std::string& config_file);
 
     /// \brief Get settings and configuration via MQTT based on certain environment variables
     RuntimeSession();

--- a/everestpy/src/everest/module.cpp
+++ b/everestpy/src/everest/module.cpp
@@ -23,6 +23,8 @@ Module::Module(const RuntimeSession& session) : Module(get_variable_from_env("EV
 Module::Module(const std::string& module_id_, const RuntimeSession& session_) :
     module_id(module_id_), session(session_) {
 
+    Everest::Logging::init(session.get_logging_config_file().string(), module_id);
+
     this->mqtt_abstraction = std::make_shared<Everest::MQTTAbstraction>(session.get_mqtt_settings());
     this->mqtt_abstraction->connect();
     this->mqtt_abstraction->spawn_main_loop_thread();


### PR DESCRIPTION
Add an additional RuntimeSettings ctor to everestpy that accepts a MQTTSettings object

This allows eg. everest-testing to directly set the required MQTT connectivity information without having to specify environment variables.

Move init of logging into Module ctor since the module id is only available there