### PR TITLE
Restructure MQTT config distribution

### DIFF
--- a/everestjs/conversions.cpp
+++ b/everestjs/conversions.cpp
@@ -54,6 +54,14 @@ Everest::json convertToJson(const Napi::Value& value) {
                         napi_valuetype_strings[value.Type()]));
 }
 
+Everest::json convertToConfigMap(const Everest::json& json_config) {
+    json config_map;
+    for (auto& entry : json_config.items()) {
+        config_map[entry.key()] = entry.value().at("value");
+    }
+    return config_map;
+}
+
 Everest::TelemetryMap convertToTelemetryMap(const Napi::Object& obj) {
     BOOST_LOG_FUNCTION();
     Everest::TelemetryMap telemetry;

--- a/everestjs/conversions.hpp
+++ b/everestjs/conversions.hpp
@@ -29,6 +29,7 @@ static const char* const napi_valuetype_strings[] = {
 };
 
 Everest::json convertToJson(const Napi::Value& value);
+Everest::json convertToConfigMap(const Everest::json& json_config);
 Everest::TelemetryMap convertToTelemetryMap(const Napi::Object& obj);
 Napi::Value convertToNapiValue(const Napi::Env& env, const Everest::json& value);
 

--- a/everestjs/everestjs.cpp
+++ b/everestjs/everestjs.cpp
@@ -885,14 +885,15 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         auto module_config_prop = Napi::Object::New(env);
         auto module_config_impl_prop = Napi::Object::New(env);
 
-        for (auto& config_map : module_config.items()) {
+        for (const auto& config_map : module_config.items()) {
+            const auto& json_config_map = convertToConfigMap(config_map.value());
             if (config_map.key() == "!module") {
                 module_config_prop.DefineProperty(Napi::PropertyDescriptor::Value(
-                    "module", convertToNapiValue(env, config_map.value()), napi_enumerable));
+                    "module", convertToNapiValue(env, json_config_map), napi_enumerable));
                 continue;
             }
             module_config_impl_prop.DefineProperty(Napi::PropertyDescriptor::Value(
-                config_map.key(), convertToNapiValue(env, config_map.value()), napi_enumerable));
+                config_map.key(), convertToNapiValue(env, json_config_map), napi_enumerable));
         }
         module_config_prop.DefineProperty(
             Napi::PropertyDescriptor::Value("impl", module_config_impl_prop, napi_enumerable));

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -287,7 +287,7 @@ public:
 
     ///
     /// \returns the commands that the modules \p module_name implements from the given implementation \p impl_id
-    nlohmann::json get_module_cmds(const std::string& module_name, const std::string& impl_id);
+    const nlohmann::json& get_module_cmds(const std::string& module_name, const std::string& impl_id);
 
     ///
     /// \brief A RequirementInitialization contains everything needed to initialize a requirement in user code. This
@@ -301,7 +301,7 @@ public:
 
     ///
     /// \returns a json object that contains the module config options
-    nlohmann::json get_module_json_config(const std::string& module_id);
+    const nlohmann::json& get_module_json_config(const std::string& module_id);
 
     ///
     /// \brief assemble basic information about the module (id, name,

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -260,10 +260,6 @@ public:
     explicit ManagerConfig(const ManagerSettings& ms);
 
     ///
-    /// \brief Serialize the config to json
-    nlohmann::json serialize();
-
-    ///
     /// \returns a TelemetryConfig if this has been configured for the given \p module_id
     std::optional<TelemetryConfig> get_telemetry_config(const std::string& module_id);
 };

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -104,7 +104,8 @@ static ParsedConfigMap parse_config_map(const json& config_map_schema, const jso
             throw ConfigParseException(ConfigParseException::SCHEMA, config_entry_name, err.what());
         }
 
-        parsed_config_map[config_entry_name] = json::object({{"value", config_entry_value}, {"type", config_entry.at("type")}});
+        parsed_config_map[config_entry_name] =
+            json::object({{"value", config_entry_value}, {"type", config_entry.at("type")}});
     }
 
     return {parsed_config_map, unknown_config_entries};

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1080,9 +1080,8 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
             complete_config = complete_config.patch(patch);
         }
 
-        const auto config = complete_config.at("active_modules");
         this->settings = this->ms.get_runtime_settings();
-        this->parse(config);
+        this->parse(complete_config.at("active_modules"));
     } catch (const std::exception& e) {
         EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse config file: {}", e.what())));
     }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -104,7 +104,7 @@ static ParsedConfigMap parse_config_map(const json& config_map_schema, const jso
             throw ConfigParseException(ConfigParseException::SCHEMA, config_entry_name, err.what());
         }
 
-        parsed_config_map[config_entry_name] = config_entry_value;
+        parsed_config_map[config_entry_name] = json::object({{"value", config_entry_value}, {"type", config_entry.at("type")}});
     }
 
     return {parsed_config_map, unknown_config_entries};
@@ -1128,7 +1128,7 @@ bool Config::module_provides(const std::string& module_name, const std::string& 
     return (provides.find(impl_id) != provides.end());
 }
 
-json Config::get_module_cmds(const std::string& module_name, const std::string& impl_id) {
+const json& Config::get_module_cmds(const std::string& module_name, const std::string& impl_id) {
     return this->module_config_cache.at(module_name).cmds.at(impl_id);
 }
 
@@ -1156,14 +1156,12 @@ ModuleConfigs Config::get_module_configs(const std::string& module_id) const {
         const json manifest = this->manifests.at(module_type);
 
         for (const auto& conf_map : config_maps.items()) {
-            const json config_schema = (conf_map.key() == "!module")
-                                           ? manifest.at("config")
-                                           : manifest.at("provides").at(conf_map.key()).at("config");
             ConfigMap processed_conf_map;
             for (const auto& entry : conf_map.value().items()) {
-                const json entry_type = config_schema.at(entry.key()).at("type");
+                const auto& entry_value = entry.value();
+                const json entry_type = entry_value.at("type");
                 ConfigEntry value;
-                const json& data = entry.value();
+                const json& data = entry_value.at("value");
 
                 if (data.is_string()) {
                     value = data.get<std::string>();
@@ -1193,9 +1191,9 @@ ModuleConfigs Config::get_module_configs(const std::string& module_id) const {
 }
 
 // FIXME (aw): check if module_id does not exist
-json Config::get_module_json_config(const std::string& module_id) {
+const json& Config::get_module_json_config(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
-    return this->main[module_id]["config_maps"];
+    return this->main.at(module_id).at("config_maps");
 }
 
 ModuleInfo Config::get_module_info(const std::string& module_id) const {

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1088,10 +1088,6 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
     }
 }
 
-json ManagerConfig::serialize() {
-    return json::object({{"main", this->main}, {"module_names", this->module_names}});
-}
-
 std::optional<TelemetryConfig> ManagerConfig::get_telemetry_config(const std::string& module_id) {
     BOOST_LOG_FUNCTION();
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -229,11 +229,11 @@ void Everest::heartbeat() {
 void Everest::publish_metadata() {
     BOOST_LOG_FUNCTION();
 
-    const auto module_info = this->config.get_module_info(this->module_id);
-    const auto manifest = this->config.get_manifests().at(module_info.name);
+    const auto& module_name = this->config.get_module_name(this->module_id);
+    const auto& manifest = this->config.get_manifests().at(module_name);
 
     json metadata = json({});
-    metadata["module"] = module_info.name;
+    metadata["module"] = module_name;
     if (manifest.contains("provides")) {
         metadata["provides"] = json({});
 

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -92,8 +92,18 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto schemas = mqtt->get(schemas_topic, QOS::QOS2);
     result["schemas"] = schemas;
 
+    const auto module_names_topic = fmt::format("{}module_names", everest_prefix);
+    const auto module_names = mqtt->get(module_names_topic, QOS::QOS2);
+    result["module_names"] = module_names;
+
     const auto manifests_topic = fmt::format("{}manifests", everest_prefix);
-    const auto manifests = mqtt->get(manifests_topic, QOS::QOS2);
+    auto manifests = json::object();
+    for (const auto& module_name : module_names) {
+        auto manifest_topic = fmt::format("{}manifests/{}", everest_prefix, module_name.get<std::string>());
+        auto manifest = mqtt->get(manifest_topic, QOS::QOS2);
+        manifests[module_name] = manifest;
+    }
+
     result["manifests"] = manifests;
 
     const auto error_types_map_topic = fmt::format("{}error_types_map", everest_prefix);
@@ -104,9 +114,6 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto module_config_cache = mqtt->get(module_config_cache_topic, QOS::QOS2);
     result["module_config_cache"] = module_config_cache;
 
-    const auto module_names_topic = fmt::format("{}module_names", everest_prefix);
-    const auto module_names = mqtt->get(module_names_topic, QOS::QOS2);
-    result["module_names"] = module_names;
 
     return result;
 }

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -104,6 +104,10 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto module_config_cache = mqtt->get(module_config_cache_topic, QOS::QOS2);
     result["module_config_cache"] = module_config_cache;
 
+    const auto module_names_topic = fmt::format("{}module_names", everest_prefix);
+    const auto module_names = mqtt->get(module_names_topic, QOS::QOS2);
+    result["module_names"] = module_names;
+
     return result;
 }
 

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -114,7 +114,6 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto module_config_cache = mqtt->get(module_config_cache_topic, QOS::QOS2);
     result["module_config_cache"] = module_config_cache;
 
-
     return result;
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -290,6 +290,8 @@ void cleanup_retained_topics(ManagerConfig& config, MQTTAbstraction& mqtt_abstra
     mqtt_abstraction.publish(fmt::format("{}error_types_map", mqtt_everest_prefix), std::string(), QOS::QOS2, true);
 
     mqtt_abstraction.publish(fmt::format("{}module_config_cache", mqtt_everest_prefix), std::string(), QOS::QOS2, true);
+
+    mqtt_abstraction.publish(fmt::format("{}module_names", mqtt_everest_prefix), std::string(), QOS::QOS2, true);
 }
 
 static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstraction& mqtt_abstraction,
@@ -352,10 +354,13 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
     mqtt_abstraction.publish(fmt::format("{}module_config_cache", ms.mqtt_settings.everest_prefix), module_config_cache,
                              QOS::QOS2, true);
 
+    mqtt_abstraction.publish(fmt::format("{}module_names", ms.mqtt_settings.everest_prefix), module_names, QOS::QOS2,
+                             true);
+
     for (const auto& module_name_entry : module_names) {
         const auto& module_name = module_name_entry.first;
         const auto& module_type = module_name_entry.second;
-        json serialized_mod_config = json::object({{"module_names", module_names}});
+        json serialized_mod_config = json::object();
         serialized_mod_config["module_config"] = json::object();
         serialized_mod_config["module_config"][module_name] = main_config.at(module_name);
         // add mappings of fulfillments

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -344,7 +344,13 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
     mqtt_abstraction.publish(fmt::format("{}schemas", ms.mqtt_settings.everest_prefix), schemas, QOS::QOS2, true);
 
     const auto manifests = config.get_manifests();
-    mqtt_abstraction.publish(fmt::format("{}manifests", ms.mqtt_settings.everest_prefix), manifests, QOS::QOS2, true);
+
+    for (const auto& manifest : manifests.items()) {
+        auto manifest_copy = manifest.value();
+        manifest_copy.erase("config");
+        mqtt_abstraction.publish(fmt::format("{}manifests/{}", ms.mqtt_settings.everest_prefix, manifest.key()),
+                                 manifest_copy, QOS::QOS2, true);
+    }
 
     const auto error_types_map = config.get_error_types();
     mqtt_abstraction.publish(fmt::format("{}error_types_map", ms.mqtt_settings.everest_prefix), error_types_map,

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -171,18 +171,6 @@ SCENARIO("Check Config Constructor", "[!throws]") {
             }());
         }
     }
-    GIVEN("A valid config with a valid module serialized") {
-        auto ms =
-            Everest::ManagerSettings(bin_dir + "valid_module_config/", bin_dir + "valid_module_config/config.yaml");
-        THEN("It should not throw at all") {
-            CHECK_NOTHROW([&]() {
-                auto mc = Everest::ManagerConfig(ms);
-                auto serialized = mc.serialize();
-                CHECK(serialized.at("module_names").size() == 1);
-                CHECK(serialized.at("module_names").at("valid_module") == "TESTValidManifest");
-            }());
-        }
-    }
     GIVEN("A valid config in legacy json format with a valid module") {
         auto ms = Everest::ManagerSettings(bin_dir + "valid_module_config_json/",
                                            bin_dir + "valid_module_config_json/config.json");


### PR DESCRIPTION
- publish manifests individually on retained topics instead in one big blob
- change module/impl config entry format to include its type, this removes the need for the whole config schema just to determine the type
- reorder the config handler before the ready handler in manager to reflect the order of operations taken during initialization of a module
- smaller optimizations