### PR TITLE
Re-introduce --config parameter for C++ Modules for compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.20.0
+    VERSION 0.20.1
     DESCRIPTION "The open operating system for e-mobility charging stations"
     LANGUAGES CXX C
 )

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -589,6 +589,7 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
     desc.add_options()("module,m", po::value<std::string>(),
                        "Which module should be executed (module id from config file)");
     desc.add_options()("dontvalidateschema", "Don't validate json schema on every message");
+    desc.add_options()("config", po::value<std::string>(), "Just kept for compatibility, not used anymore.");
     desc.add_options()("log_config", po::value<std::string>(), "The path to a custom logging config");
     desc.add_options()("mqtt_broker_socket_path", po::value<std::string>(), "The MQTT broker socket path");
     desc.add_options()("mqtt_broker_host", po::value<std::string>(), "The MQTT broker hostname");

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -402,7 +402,7 @@ ModuleLoader::ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks, Ve
         if (!this->parse_command_line(argc, argv)) {
             this->should_exit = true;
         }
-    }  catch (std::exception& e) {
+    } catch (std::exception& e) {
         std::cout << "Error during command line parsing: " << e.what() << "\n";
         this->should_exit = true;
     }
@@ -626,7 +626,8 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
 
     if (vm.count("config") != 0) {
         std::cout
-            << "--config is not used anymore, modules request their config automatically via MQTT" << "\n"
+            << "--config is not used anymore, modules request their config automatically via MQTT"
+            << "\n"
             << "If you want to influence this config loading behavior you can specify the appropriate --mqtt_* flags"
             << "\n";
     }

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -620,6 +620,13 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
         return false;
     }
 
+    if (vm.count("config") != 0) {
+        std::cout
+            << "--config is not used anymore, modules request their config automatically via MQTT" << "\n"
+            << "If you want to influence this config loading behavior you can specify the appropriate --mqtt_* flags"
+            << "\n";
+    }
+
     std::string mqtt_broker_socket_path;
     if (vm.count("mqtt_broker_socket_path") != 0) {
         mqtt_broker_socket_path = vm["mqtt_broker_socket_path"].as<std::string>();

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -398,15 +398,19 @@ ModuleCallbacks::ModuleCallbacks(
 
 ModuleLoader::ModuleLoader(int argc, char* argv[], ModuleCallbacks callbacks, VersionInformation version_information) :
     runtime_settings(nullptr), callbacks(std::move(callbacks)), version_information(std::move(version_information)) {
-    if (!this->parse_command_line(argc, argv)) {
+    try {
+        if (!this->parse_command_line(argc, argv)) {
+            this->should_exit = true;
+        }
+    }  catch (std::exception& e) {
+        std::cout << "Error during command line parsing: " << e.what() << "\n";
         this->should_exit = true;
-        return;
     }
 }
 
 int ModuleLoader::initialize() {
     if (this->should_exit) {
-        return 0;
+        return EXIT_FAILURE;
     }
     Logging::init(this->logging_config_file.string(), this->module_id);
 


### PR DESCRIPTION
This was removed since it wasn't needed anymore since configs are distributed via MQTT It is re-introduced purely for compatibility reasons

Additionally catch the exception that can be thrown during command line parsing and exit cleanly