### PR TITLE
Rust: fix optional connections and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *build
 *build-cross
 build*
+!build.rs
 !everestrs-build
 target
 bazel-bin

--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "everestrs"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "clap",
  "cxx",

--- a/everestrs/everestrs-build/src/codegen.rs
+++ b/everestrs/everestrs-build/src/codegen.rs
@@ -791,7 +791,7 @@ pub fn emit(manifest_path: PathBuf, everest_core: Vec<PathBuf>) -> Result<String
     let module_config = emit_config(manifest.config);
     let requires_with_generics = requires
         .iter()
-        .any(|elem| elem.min_connections != 0 || elem.max_connections != 1);
+        .any(|elem| elem.min_connections != 1 || elem.max_connections != 1);
 
     let involved_errors = provided_interfaces
         .iter()

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everestrs"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 
 [dependencies]

--- a/everestrs/tests/modules/RsOptionalConnection/BUILD.bazel
+++ b/everestrs/tests/modules/RsOptionalConnection/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["build.rs"],
+    edition="2021",
+    build_script_env = {
+        "EVEREST_CORE_ROOT": "../..",
+    },
+    deps = [
+        "@everest-framework//everestrs/everestrs-build",
+    ],
+    data= [
+        "//everestrs/tests/types",
+        "//everestrs/tests/interfaces",
+        "//everestrs/tests/errors",
+        "manifest.yaml",
+    ],
+)
+
+# For now just a compilation test
+rust_binary(
+    name = "RsOptionalConnection",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    edition = "2021",
+    deps = [
+        "@crate_index//:log",
+        "@everest-framework//everestrs/everestrs",
+        "@everest-framework//everestrs/everestrs:everestrs_sys",
+        "@everest-framework//everestrs/everestrs:everestrs_bridge",
+        ":build_script",
+    ],
+)

--- a/everestrs/tests/modules/RsOptionalConnection/build.rs
+++ b/everestrs/tests/modules/RsOptionalConnection/build.rs
@@ -1,0 +1,13 @@
+use everestrs_build::Builder;
+
+pub fn main() {
+    Builder::new(
+        "manifest.yaml",
+        vec![std::env::var("EVEREST_CORE_ROOT").unwrap_or("../../..".to_string())],
+    )
+    .generate()
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=manifest.yaml");
+}

--- a/everestrs/tests/modules/RsOptionalConnection/manifest.yaml
+++ b/everestrs/tests/modules/RsOptionalConnection/manifest.yaml
@@ -1,0 +1,15 @@
+description: The tests how to use optinal connections in Rust
+provides:
+  foobar:
+    interface: example
+    description: An example interface.
+requires:
+  optional_connection:
+    interface: example
+    min_connections: 0
+    max_connections: 1
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Everest authors
+enable_external_mqtt: false

--- a/everestrs/tests/modules/RsOptionalConnection/src/main.rs
+++ b/everestrs/tests/modules/RsOptionalConnection/src/main.rs
@@ -1,0 +1,57 @@
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+use generated::{
+    Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module,
+    ModulePublisher, OnReadySubscriber,
+};
+use std::sync::Arc;
+use std::{thread, time};
+
+pub struct OptionalConnection {}
+
+impl ExampleServiceSubscriber for OptionalConnection {
+    fn uses_something(&self, _context: &Context, key: String) -> ::everestrs::Result<bool> {
+        log::info!("Received {key}");
+        Ok(&key == "hello")
+    }
+}
+
+impl ExampleClientSubscriber for OptionalConnection {
+    fn on_max_current(&self, _context: &Context, value: f64) {
+        log::info!("Received {value}");
+    }
+
+    fn on_error_raised(&self, _context: &Context, error: crate::generated::errors::example::Error) {
+        log::info!("Recieved an error {error:?}");
+    }
+
+    fn on_error_cleared(
+        &self,
+        _context: &Context,
+        error: crate::generated::errors::example::Error,
+    ) {
+        log::info!("Cleared an error {error:?} - what a relief");
+    }
+}
+
+impl OnReadySubscriber for OptionalConnection {
+    fn on_ready(&self, publishers: &ModulePublisher) {
+        log::info!("Ready");
+        if let Some(publisher) = publishers.optional_connection_slots.get(0) {
+            let res = publisher.uses_something("hello".to_string()).unwrap();
+            assert!(res);
+        }
+    }
+}
+
+fn main() {
+    let one_class = Arc::new(OptionalConnection {});
+    let _module = Module::new(one_class.clone(), one_class.clone(), |_index| {one_class.clone()});
+    log::info!("Module initialized");
+
+    loop {
+        let dt = time::Duration::from_millis(250);
+        thread::sleep(dt);
+    }
+}


### PR DESCRIPTION
We would not emit generics if we have only optional (min 0 max 1) require interfaces