### PR TITLE
Fix default logging file path

### DIFF
--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -714,10 +714,14 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
             assert_file(command_line_logging_config_file, "Command line provided logging config");
 
     } else {
-        auto default_logging_config_file = assert_dir(defaults::PREFIX, "Default prefix") /
-                                           fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE /
-                                           defaults::LOGGING_CONFIG_NAME;
+        auto default_logging_config_file =
+            fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE / defaults::LOGGING_CONFIG_NAME;
 
+        if (std::strcmp(defaults::PREFIX, "/usr") != 0) {
+            default_logging_config_file = defaults::PREFIX / default_logging_config_file;
+        } else {
+            default_logging_config_file = fs::path("/") / default_logging_config_file;
+        }
         this->logging_config_file = assert_file(default_logging_config_file, "Default logging config");
     }
 


### PR DESCRIPTION
* with prefix is: /usr/etc/everest
* without the prefix: /etc/everest

Until now it was not an executed code path since the config file was provided as argument thus parsed instead of default values taken.