### PR TITLE
Fix error message on module cannot be loaded

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -474,12 +474,16 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
             modules_to_spawn.emplace_back(module_name, printable_module_name, ModuleStartInfo::Language::python,
                                           fs::canonical(python_module_path), capabilities);
         } else {
+            if (module_name == "probe" || module_type == "ProbeModule") {
+                EVLOG_error <<  "You are trying to start the probe module as binary, please check "
+                                "your test case, did you add \"@pytest.mark.probe_module\" to your test case?";
+            }
             throw std::runtime_error(
                 fmt::format("module: {} ({}) cannot be loaded because no Binary, JavaScript or Python "
                             "module has been found\n"
                             "  checked paths:\n"
                             "    binary: {}\n"
-                            "    js:  {}\n",
+                            "    js:  {}\n"
                             "    py:  {}\n", module_name, module_type, binary_path.string(),
                             javascript_library_path.string(), python_module_path.string()));
         }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -475,8 +475,8 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
                                           fs::canonical(python_module_path), capabilities);
         } else {
             if (module_name == "probe" || module_type == "ProbeModule") {
-                EVLOG_error <<  "You are trying to start the probe module as binary, please check "
-                                "your test case, did you add \"@pytest.mark.probe_module\" to your test case?";
+                EVLOG_error << "You are trying to start the probe module as binary, please check "
+                               "your test case, did you add \"@pytest.mark.probe_module\" to your test case?";
             }
             throw std::runtime_error(
                 fmt::format("module: {} ({}) cannot be loaded because no Binary, JavaScript or Python "
@@ -484,8 +484,9 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
                             "  checked paths:\n"
                             "    binary: {}\n"
                             "    js:  {}\n"
-                            "    py:  {}\n", module_name, module_type, binary_path.string(),
-                            javascript_library_path.string(), python_module_path.string()));
+                            "    py:  {}\n",
+                            module_name, module_type, binary_path.string(), javascript_library_path.string(),
+                            python_module_path.string()));
         }
     }
 


### PR DESCRIPTION
* Remove comma in fmt::format call
* Add detection for missing `@pytest.mark.probe_module` marker in test code