### PR TITLE
Optimize config distribution via MQTT

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -317,6 +317,8 @@ private:
 
     void populate_module_config_cache();
 
+    void populate_error_map();
+
 public:
     ///
     /// \brief creates a new Config object form the given \p mqtt_settings and \p config

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -315,6 +315,8 @@ private:
     std::optional<TelemetryConfig> telemetry_config;
     std::unordered_map<std::string, ConfigCache> module_config_cache;
 
+    void populate_module_config_cache();
+
 public:
     ///
     /// \brief creates a new Config object form the given \p mqtt_settings and \p config

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -111,7 +111,6 @@ protected:
     std::unordered_map<std::string, ModuleTierMappings> tier_mappings;
     // experimental caches
     std::unordered_map<std::string, std::string> module_names;
-    std::unordered_map<std::string, ConfigCache> module_config_cache;
 
     error::ErrorTypeMap error_map;
 
@@ -183,10 +182,6 @@ public:
     ///
     /// \returns a json object that contains the types
     const nlohmann::json& get_types() const;
-
-    ///
-    /// \returns the module config cache
-    std::unordered_map<std::string, ConfigCache> get_module_config_cache();
 
     ///
     /// \return the cached mapping of module ids to module names
@@ -318,6 +313,7 @@ public:
 class Config : public ConfigBase {
 private:
     std::optional<TelemetryConfig> telemetry_config;
+    std::unordered_map<std::string, ConfigCache> module_config_cache;
 
 public:
     ///

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1177,7 +1177,6 @@ std::optional<TelemetryConfig> ManagerConfig::get_telemetry_config(const std::st
 Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : ConfigBase(mqtt_settings) {
     this->main = serialized_config.value("module_config", json({}));
     this->manifests = serialized_config.value("manifests", json({}));
-    this->interfaces = serialized_config.value("module_provides", json({}));
     this->interface_definitions = serialized_config.value("interface_definitions", json({}));
     this->types = serialized_config.value("types", json({}));
     this->module_names = serialized_config.at("module_names");
@@ -1187,9 +1186,11 @@ Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : Conf
     for (const auto& [module_id, module_name] : this->module_names) {
         this->module_config_cache[module_id] = ConfigCache();
         const std::set<std::string> provided_impls = Config::keys(this->manifests[module_name]["provides"]);
+        this->interfaces[module_name] = json({});
         this->module_config_cache[module_name].provides_impl = provided_impls;
         for (const auto& impl_id : provided_impls) {
             auto intf_name = this->manifests[module_name]["provides"][impl_id]["interface"].get<std::string>();
+            this->interfaces[module_name][impl_id] = intf_name;
             this->module_config_cache[module_name].cmds[impl_id] = this->interface_definitions.at(intf_name).at("cmds");
         }
     }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1201,7 +1201,9 @@ Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : Conf
         this->telemetry_config = serialized_config.at("telemetry_config");
     }
 
-    this->schemas = serialized_config.at("schemas");
+    if (serialized_config.contains("schemas")) {
+        this->schemas = serialized_config.at("schemas");
+    }
     this->error_map = error::ErrorTypeMap();
     this->error_map.load_error_types_map(serialized_config.at("error_map"));
 }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1326,11 +1326,12 @@ json Config::get_interface_definition(const std::string& interface_name) const {
 void Config::populate_module_config_cache() {
     for (const auto& [module_id, module_name] : this->module_names) {
         this->module_config_cache[module_id] = ConfigCache();
-        const std::set<std::string> provided_impls = Config::keys(this->manifests[module_name]["provides"]);
+        const std::set<std::string> provided_impls = Config::keys(this->manifests.at(module_name).at("provides"));
         this->interfaces[module_name] = json({});
         this->module_config_cache[module_name].provides_impl = provided_impls;
         for (const auto& impl_id : provided_impls) {
-            auto intf_name = this->manifests[module_name]["provides"][impl_id]["interface"].get<std::string>();
+            auto intf_name =
+                this->manifests.at(module_name).at("provides").at(impl_id).at("interface").get<std::string>();
             this->interfaces[module_name][impl_id] = intf_name;
             this->module_config_cache[module_name].cmds[impl_id] = this->interface_definitions.at(intf_name).at("cmds");
         }

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1307,7 +1307,7 @@ json Config::get_interface_definition(const std::string& interface_name) const {
 
 void Config::populate_module_config_cache() {
     for (const auto& [module_id, module_name] : this->module_names) {
-        this->module_config_cache[module_id] = ConfigCache();
+        this->module_config_cache[module_name] = ConfigCache();
         const std::set<std::string> provided_impls = Config::keys(this->manifests.at(module_name).at("provides"));
         this->interfaces[module_name] = json({});
         this->module_config_cache[module_name].provides_impl = provided_impls;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1194,26 +1194,8 @@ Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : Conf
         this->schemas = serialized_config.at("schemas");
     }
 
-    // FIXME: move this to its own function
     // create error type map from interface definitions
-    // TODO: move this code to manager and distribute the error information centrally again (split over multiple topics)
-    // since there can be some redundancies with eg. generic errors that might be in multiple interfaces
-    // remove the "errors" entry from the interface definitions that are shared via MQTT, this could reduce their size a
-    // bit since it limits the amount of shared redundant information
-    json error_types_map = json({});
-    for (const auto& [interface_name, interface_definition] : this->interface_definitions.items()) {
-        for (const auto& [error_namespace, errors] : interface_definition.at("errors").items()) {
-            for (const auto& [error_key, error_definition] : errors.items()) {
-                const auto error_type_name = fmt::format("{}/{}", error_definition.at("namespace").get<std::string>(),
-                                                         error_definition.at("name").get<std::string>());
-                if (not error_types_map.contains(error_type_name)) {
-                    error_types_map[error_type_name] = error_definition.at("description").get<std::string>();
-                }
-            }
-        }
-    }
-    this->error_map = error::ErrorTypeMap();
-    this->error_map.load_error_types_map(error_types_map);
+    this->populate_error_map();
 }
 
 error::ErrorTypeMap Config::get_error_map() const {
@@ -1336,6 +1318,27 @@ void Config::populate_module_config_cache() {
             this->module_config_cache[module_name].cmds[impl_id] = this->interface_definitions.at(intf_name).at("cmds");
         }
     }
+}
+
+void Config::populate_error_map() {
+    // TODO(kai): distribute the error information centrally again? (split over multiple
+    // topics) since there can be some redundancies with eg. generic errors that might be in multiple interfaces
+    // then remove the "errors" entry from the interface definitions that are shared via MQTT, this could reduce their
+    // size a bit since it limits the amount of shared redundant information
+    json error_types_map = json({});
+    for (const auto& [interface_name, interface_definition] : this->interface_definitions.items()) {
+        for (const auto& [error_namespace, errors] : interface_definition.at("errors").items()) {
+            for (const auto& [error_key, error_definition] : errors.items()) {
+                const auto error_type_name = fmt::format("{}/{}", error_definition.at("namespace").get<std::string>(),
+                                                         error_definition.at("name").get<std::string>());
+                if (not error_types_map.contains(error_type_name)) {
+                    error_types_map[error_type_name] = error_definition.at("description").get<std::string>();
+                }
+            }
+        }
+    }
+    this->error_map = error::ErrorTypeMap();
+    this->error_map.load_error_types_map(error_types_map);
 }
 
 void Config::ref_loader(const json_uri& uri, json& schema) {

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1208,6 +1208,10 @@ Config::Config(const MQTTSettings& mqtt_settings, json serialized_config) : Conf
 
     // FIXME: move this to its own function
     // create error type map from interface definitions
+    // TODO: move this code to manager and distribute the error information centrally again (split over multiple topics)
+    // since there can be some redundancies with eg. generic errors that might be in multiple interfaces
+    // remove the "errors" entry from the interface definitions that are shared via MQTT, this could reduce their size a
+    // bit since it limits the amount of shared redundant information
     json error_types_map = json({});
     for (const auto& [interface_name, interface_definition] : this->interface_definitions.items()) {
         for (const auto& [error_namespace, errors] : interface_definition.at("errors").items()) {

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -88,9 +88,12 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto settings = mqtt->get(settings_topic, QOS::QOS2);
     result["settings"] = settings;
 
-    const auto schemas_topic = fmt::format("{}schemas", everest_prefix);
-    const auto schemas = mqtt->get(schemas_topic, QOS::QOS2);
-    result["schemas"] = schemas;
+    bool validate_schema = settings.value("validate_schema", json(false)).get<bool>();
+    if (validate_schema) {
+        const auto schemas_topic = fmt::format("{}schemas", everest_prefix);
+        const auto schemas = mqtt->get(schemas_topic, QOS::QOS2);
+        result["schemas"] = schemas;
+    }
 
     const auto module_names_topic = fmt::format("{}module_names", everest_prefix);
     const auto module_names = mqtt->get(module_names_topic, QOS::QOS2);

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -110,10 +110,6 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     const auto error_types_map = mqtt->get(error_types_map_topic, QOS::QOS2);
     result["error_map"] = error_types_map;
 
-    const auto module_config_cache_topic = fmt::format("{}module_config_cache", everest_prefix);
-    const auto module_config_cache = mqtt->get(module_config_cache_topic, QOS::QOS2);
-    result["module_config_cache"] = module_config_cache;
-
     return result;
 }
 

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -109,10 +109,6 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
 
     result["manifests"] = manifests;
 
-    const auto error_types_map_topic = fmt::format("{}error_types_map", everest_prefix);
-    const auto error_types_map = mqtt->get(error_types_map_topic, QOS::QOS2);
-    result["error_map"] = error_types_map;
-
     return result;
 }
 

--- a/lib/module_config.cpp
+++ b/lib/module_config.cpp
@@ -80,10 +80,6 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
 
     result["types"] = type_definitions;
 
-    const auto module_provides_topic = fmt::format("{}module_provides", everest_prefix);
-    const auto module_provides = mqtt->get(module_provides_topic, QOS::QOS2);
-    result["module_provides"] = module_provides;
-
     const auto settings_topic = fmt::format("{}settings", everest_prefix);
     const auto settings = mqtt->get(settings_topic, QOS::QOS2);
     result["settings"] = settings;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -314,9 +314,10 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
     const auto settings = config.get_settings();
     mqtt_abstraction.publish(fmt::format("{}settings", ms.mqtt_settings.everest_prefix), settings, QOS::QOS2, true);
 
-    const auto schemas = config.get_schemas();
-    mqtt_abstraction.publish(fmt::format("{}schemas", ms.mqtt_settings.everest_prefix), schemas, QOS::QOS2, true);
-
+    if (ms.runtime_settings->validate_schema) {
+        const auto schemas = config.get_schemas();
+        mqtt_abstraction.publish(fmt::format("{}schemas", ms.mqtt_settings.everest_prefix), schemas, QOS::QOS2, true);
+    }
     const auto manifests = config.get_manifests();
 
     for (const auto& manifest : manifests.items()) {

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -340,6 +340,9 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
         json serialized_mod_config = json::object();
         serialized_mod_config["module_config"] = json::object();
         serialized_mod_config["module_config"][module_name] = main_config.at(module_name);
+        // remove redundant config_implementation and config_module
+        serialized_mod_config["module_config"][module_name].erase("config_implementation");
+        serialized_mod_config["module_config"][module_name].erase("config_module");
         // add mappings of fulfillments
         const auto fulfillments = config.get_fulfillments(module_name);
         serialized_mod_config["mappings"] = json::object();

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -330,10 +330,6 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
     mqtt_abstraction.publish(fmt::format("{}error_types_map", ms.mqtt_settings.everest_prefix), error_types_map,
                              QOS::QOS2, true);
 
-    const auto module_config_cache = config.get_module_config_cache();
-    mqtt_abstraction.publish(fmt::format("{}module_config_cache", ms.mqtt_settings.everest_prefix), module_config_cache,
-                             QOS::QOS2, true);
-
     mqtt_abstraction.publish(fmt::format("{}module_names", ms.mqtt_settings.everest_prefix), module_names, QOS::QOS2,
                              true);
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -307,10 +307,6 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
             type_definition.value(), QOS::QOS2, true);
     }
 
-    const auto module_provides = config.get_interfaces();
-    mqtt_abstraction.publish(fmt::format("{}module_provides", ms.mqtt_settings.everest_prefix), module_provides,
-                             QOS::QOS2, true);
-
     const auto settings = config.get_settings();
     mqtt_abstraction.publish(fmt::format("{}settings", ms.mqtt_settings.everest_prefix), settings, QOS::QOS2, true);
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -327,10 +327,6 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
                                  manifest_copy, QOS::QOS2, true);
     }
 
-    const auto error_types_map = config.get_error_types();
-    mqtt_abstraction.publish(fmt::format("{}error_types_map", ms.mqtt_settings.everest_prefix), error_types_map,
-                             QOS::QOS2, true);
-
     mqtt_abstraction.publish(fmt::format("{}module_names", ms.mqtt_settings.everest_prefix), module_names, QOS::QOS2,
                              true);
 


### PR DESCRIPTION
- Create module_config_cache directly in module Config
The information is already available to the module and does not have to be transmitted via MQTT redundantly
- Only distribute schemas via MQTT when validate_schema is set to true in settings
- Remove redundant "config_implementation" and "config_module" entries
The content of these is already provided via the "config_maps" entry in the distributed configuration for each module
- Do not distribute redundant error_types_map
Create it in modules from the interface descriptions
- Remove redundant module_provides from MQTT config distribution
This can be computed by each module from the available data
