### PR TITLE
Set ready_received before calling on_ready(), partially reverts #249

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-framework
-    VERSION 0.20.3
+    VERSION 0.20.4
     DESCRIPTION "The open operating system for e-mobility charging stations"
     LANGUAGES CXX C
 )

--- a/everestjs/package.json
+++ b/everestjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "everestjs",
   "main": "index.js",
-  "version": "0.20.2",
+  "version": "0.20.4",
   "description": "EVerest API for node.js",
   "dependencies": {
     "node-addon-api": "^3.2.1"

--- a/everestpy/src/everest/everestpy.cpp
+++ b/everestpy/src/everest/everestpy.cpp
@@ -169,5 +169,5 @@ PYBIND11_MODULE(everestpy, m) {
     log_submodule.def("error", [](const std::string& message) { EVLOG_error << message; });
     log_submodule.def("critical", [](const std::string& message) { EVLOG_critical << message; });
 
-    m.attr("__version__") = "0.20.2";
+    m.attr("__version__") = "0.20.4";
 }

--- a/everestpy/src/everest/framework/__init__.py
+++ b/everestpy/src/everest/framework/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.20.0'
+__version__ = '0.20.4'
 
 try:
     from .everestpy import *

--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "everestrs"
-version = "0.20.2"
+version = "0.20.4"
 dependencies = [
  "clap",
  "cxx",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "everestrs-build"
-version = "0.20.1"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "argh",

--- a/everestrs/everestrs-build/Cargo.toml
+++ b/everestrs/everestrs-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everestrs-build"
-version = "0.20.1"
+version = "0.20.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everestrs"
-version = "0.20.2"
+version = "0.20.4"
 edition = "2021"
 
 [dependencies]

--- a/everestrs/tests/modules/RsOnReadyRaceCondition/config.yaml
+++ b/everestrs/tests/modules/RsOnReadyRaceCondition/config.yaml
@@ -1,4 +1,6 @@
 # Test config for regression tests for the framework.
+settings:
+  ensure_ready: true
 active_modules:
   example_0:
     module: RsOnReadyRaceCondition

--- a/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
+++ b/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
@@ -47,6 +47,9 @@ impl ExampleClientSubscriber for OneClass {
 
 impl OnReadySubscriber for OneClass {
     fn on_ready(&self, publishers: &ModulePublisher) {
+        // Update the flag.
+        self.on_ready_called.store(true, Ordering::Relaxed);
+
         log::info!("Enter Ready");
         // Call the other module.
         publishers.example.max_current(12.3).unwrap();
@@ -59,8 +62,6 @@ impl OnReadySubscriber for OneClass {
 
         // Sleep here to trigger the race condition.
         std::thread::sleep(std::time::Duration::from_secs(1));
-        // Update the flag.
-        self.on_ready_called.store(true, Ordering::Relaxed);
 
         log::info!("Exit Ready!");
     }

--- a/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
+++ b/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
@@ -47,9 +47,6 @@ impl ExampleClientSubscriber for OneClass {
 
 impl OnReadySubscriber for OneClass {
     fn on_ready(&self, publishers: &ModulePublisher) {
-        // Update the flag.
-        self.on_ready_called.store(true, Ordering::Relaxed);
-
         log::info!("Enter Ready");
         // Call the other module.
         publishers.example.max_current(12.3).unwrap();
@@ -62,6 +59,8 @@ impl OnReadySubscriber for OneClass {
 
         // Sleep here to trigger the race condition.
         std::thread::sleep(std::time::Duration::from_secs(1));
+        // Update the flag.
+        self.on_ready_called.store(true, Ordering::Relaxed);
 
         log::info!("Exit Ready!");
     }

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -203,6 +203,7 @@ private:
     std::shared_ptr<error::ErrorStateMonitor> global_error_state_monitor; // nullptr if not enabled in manifest
     std::map<std::string, std::set<std::string>> registered_cmds;
     std::atomic<bool> ready_received;
+    std::atomic<bool> ready_done;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;

--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -202,6 +202,7 @@ private:
     std::shared_ptr<error::ErrorManagerReqGlobal> global_error_manager;   // nullptr if not enabled in manifest
     std::shared_ptr<error::ErrorStateMonitor> global_error_state_monitor; // nullptr if not enabled in manifest
     std::map<std::string, std::set<std::string>> registered_cmds;
+    std::atomic<bool> ensure_module_ready;
     std::atomic<bool> ready_received;
     std::atomic<bool> ready_done;
     std::chrono::seconds remote_cmd_res_timeout;

--- a/include/framework/runtime.hpp
+++ b/include/framework/runtime.hpp
@@ -136,6 +136,7 @@ struct ManagerSettings {
     int controller_rpc_timeout_ms; ///< RPC timeout for controller commands
 
     std::string run_as_user; ///< Username under which EVerest should run
+    bool ensure_ready;       ///< If a module has to return from ready before its other callbacks are called
 
     std::string version_information; ///< Version information string reported on startup of the manager
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1052,6 +1052,16 @@ void ManagerConfig::parse(json config) {
         load_and_validate_manifest(module_id, module_config);
     }
 
+    // set default for ensure_ready
+    for (auto& element : this->main.items()) {
+        const auto& module_id = element.key();
+        auto& module_config = element.value();
+
+        if (not module_config.contains("ensure_ready")) {
+            module_config["ensure_ready"] = this->ms.ensure_ready;
+        }
+    }
+
     if (probe_module_id) {
         setup_probe_module_manifest(*probe_module_id, this->main, this->manifests);
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -66,6 +66,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     this->telemetry_config = this->config.get_telemetry_config();
 
     this->ready_received = false;
+    this->ready_done = false;
     this->on_ready = nullptr;
 
     // setup error_manager_req_global if enabled + error_database + error_state_monitor
@@ -816,6 +817,8 @@ void Everest::handle_ready(const json& data) {
         const auto on_ready_handler = *on_ready;
         on_ready_handler();
     }
+
+    this->ready_done = true;
 
     // TODO(kai): make heartbeat interval configurable, disable it completely until then
     // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -778,7 +778,8 @@ void Everest::signal_ready() {
 
 inline void Everest::ensure_ready() const {
     /// When calling this we actually expect that `ready_received` and `ready_done` are true.
-    while (ensure_module_ready and (not ready_received or not ready_done)) { // In C++20 we might mark it as [[unlikely]]
+    while (ensure_module_ready and
+           (not ready_received or not ready_done)) { // In C++20 we might mark it as [[unlikely]]
         // TODO: introduce a timeout and reduce log spamming
         if (not ready_received) {
             EVLOG_warning << "Module has not received `ready` yet.";

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -777,7 +777,7 @@ void Everest::signal_ready() {
 inline void Everest::ensure_ready() const {
     /// When calling this we actually expect that `ready_received` is true.
     while (!ready_received) { // In C++20 we might mark it as [[unlikely]]
-        EVLOG_warning << "Module is has not processed `ready` yet.";
+        EVLOG_warning << "Module has not processed `ready` yet.";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 }
@@ -808,14 +808,14 @@ void Everest::handle_ready(const json& data) {
         return;
     }
 
+    this->ready_received = true;
+
     // call module ready handler
     EVLOG_debug << "Framework now ready to process events, calling module ready handler";
     if (this->on_ready != nullptr) {
         const auto on_ready_handler = *on_ready;
         on_ready_handler();
     }
-
-    this->ready_received = true;
 
     // TODO(kai): make heartbeat interval configurable, disable it completely until then
     // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -343,6 +343,8 @@ ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& 
 
     run_as_user = settings.value("run_as_user", "");
 
+    ensure_ready = settings.value("ensure_ready", false);
+
     auto version_information_path = data_dir / VERSION_INFORMATION_FILE;
     if (fs::exists(version_information_path)) {
         std::ifstream ifs(version_information_path.string());

--- a/schemas/config.yaml
+++ b/schemas/config.yaml
@@ -67,6 +67,8 @@ properties:
         type: boolean
       run_as_user:
         type: string
+      ensure_ready:
+        type: boolean
     additionalProperties: false
   active_modules:
     type: object
@@ -79,6 +81,12 @@ properties:
         properties:
           standalone:
             description: Indicates to the manager that the module will be started standalone
+            type: boolean
+          ensure_ready:
+            description: >-
+              Ensure that the module has returned from its init and ready functions
+              before any variable subscription callbacks are called.
+              This overwrites the global ensure_ready setting
             type: boolean
           module:
             description: Module name (e.g. directory name in the modules subdirectory)


### PR DESCRIPTION
This still ensures that handlers in modules only receive variable subscriptions and cmd calls after the ready signal has been received on framework level, as implemented in #249.

Delaying ready_received until after on_ready() has been called would lead to some modules that depend on each other to hang. While this slightly relaxes the prevention of the observed race-condition, the window is still narrower than before and we can still ensure that every module has successfully performed its init() and therefore should be ready to receive commands.

Add a new settings (and per-module override) `ensure_ready`:
This controls the behavior of the framework to either:
- ensure that the module has returned from its init and ready functions before any variable subscription callbacks are called.
- enable or disable this behavior on a per-module basis

By default this setting is turned off, reflecting the old behavior of the framework