### PR TITLE
Partially revert #249

### DIFF
--- a/include/framework/everest.hpp
+++ b/include/framework/everest.hpp
@@ -189,6 +189,11 @@ public:
     ///
     void register_on_ready_handler(const std::function<void()>& handler);
 
+    ///
+    /// \brief  Blocks until ready is processed;
+    ///
+    void ensure_ready() const;
+
 private:
     std::shared_ptr<MQTTAbstraction> mqtt_abstraction;
     Config config;
@@ -203,6 +208,7 @@ private:
     std::shared_ptr<error::ErrorStateMonitor> global_error_state_monitor; // nullptr if not enabled in manifest
     std::map<std::string, std::set<std::string>> registered_cmds;
     std::atomic<bool> ready_received;
+    std::atomic<bool> ready_processed;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;
@@ -217,9 +223,6 @@ private:
     std::optional<TelemetryConfig> telemetry_config;
     bool telemetry_enabled;
     std::optional<ModuleTierMappings> module_tier_mappings;
-
-    /// Blocks until ready is processed;
-    void ensure_ready() const;
 
     void handle_ready(const nlohmann::json& data);
 

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -49,7 +49,9 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     mqtt_everest_prefix(mqtt_abstraction->get_everest_prefix()),
     mqtt_external_prefix(mqtt_abstraction->get_external_prefix()),
     telemetry_prefix(telemetry_prefix),
-    telemetry_enabled(telemetry_enabled) {
+    telemetry_enabled(telemetry_enabled),
+    ready_received(false),
+    ready_processed(false) {
     BOOST_LOG_FUNCTION();
 
     EVLOG_debug << "Initializing EVerest framework...";
@@ -65,7 +67,6 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     this->module_classes = this->config.get_interfaces()[this->module_name];
     this->telemetry_config = this->config.get_telemetry_config();
 
-    this->ready_received = false;
     this->on_ready = nullptr;
 
     // setup error_manager_req_global if enabled + error_database + error_state_monitor
@@ -486,10 +487,6 @@ void Everest::subscribe_var(const Requirement& req, const std::string& var_name,
         EVLOG_verbose << fmt::format(
             "Incoming {}->{}", this->config.printable_identifier(requirement_module_id, requirement_impl_id), var_name);
 
-        // Prevent a race condition where some other module might have received its on-ready
-        // already, starts publishing variables and this module is not ready yet
-        ensure_ready();
-
         if (this->validate_data_with_schema) {
             // check data and ignore it if not matching (publishing it should have been prohibited already)
             try {
@@ -560,9 +557,6 @@ void Everest::subscribe_error(const Requirement& req, const error::ErrorType& er
             return;
         }
 
-        // Prevent a race condition where some other module might have received its on-ready
-        // already, starts publishing errors and this module is not ready yet
-        ensure_ready();
         switch (error.state) {
         case error::State::Active:
             EVLOG_debug << fmt::format("Incoming error {}->{}",
@@ -775,9 +769,9 @@ void Everest::signal_ready() {
 }
 
 inline void Everest::ensure_ready() const {
-    /// When calling this we actually expect that `ready_received` is true.
-    while (!ready_received) { // In C++20 we might mark it as [[unlikely]]
-        EVLOG_warning << "Module is has not processed `ready` yet.";
+    /// When calling this we actually expect that `ready_processed` is true.
+    while (!ready_processed) { // In C++20 we might mark it as [[unlikely]]
+        EVLOG_warning << "Module has not processed `ready` yet.";
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 }
@@ -808,6 +802,8 @@ void Everest::handle_ready(const json& data) {
         return;
     }
 
+    this->ready_received = true;
+
     // call module ready handler
     EVLOG_debug << "Framework now ready to process events, calling module ready handler";
     if (this->on_ready != nullptr) {
@@ -815,7 +811,7 @@ void Everest::handle_ready(const json& data) {
         on_ready_handler();
     }
 
-    this->ready_received = true;
+    this->ready_processed = true;
 
     // TODO(kai): make heartbeat interval configurable, disable it completely until then
     // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);
@@ -838,9 +834,6 @@ void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_nam
     // define command wrapper
     const auto wrapper = [this, cmd_topic, impl_id, cmd_name, handler, cmd_definition](const std::string&, json data) {
         BOOST_LOG_FUNCTION();
-
-        // TODO(ddo) Add here the ready_received / ensure_ready() check once we can report
-        // errors from Rpcs. Right now this would lead to a deadlock.
 
         std::set<std::string> arg_names;
         if (cmd_definition.contains("arguments")) {


### PR DESCRIPTION
Introduce an additonal ready_processed flag

Make ensure_ready public so that language bindings that need it can make use of it

Remove ensure_ready() calls from subscribe_error/var()