### PR TITLE
Rust: Add ignoring of variables and errors

### DIFF
--- a/everestrs/everestrs-build/src/codegen.rs
+++ b/everestrs/everestrs-build/src/codegen.rs
@@ -1,7 +1,7 @@
 use crate::schema::{
     self,
     interface::ErrorReference,
-    manifest::{ConfigEntry, ConfigEnum},
+    manifest::{ConfigEntry, ConfigEnum, Ignore},
     types::{DataTypes, ObjectOptions, StringOptions, Type, TypeBase, TypeEnum},
     ErrorList, Interface, Manifest,
 };
@@ -751,7 +751,22 @@ pub fn emit(manifest_path: PathBuf, everest_core: Vec<PathBuf>) -> Result<String
 
     let mut required_interfaces = HashMap::with_capacity(manifest.requires.len());
     let mut requires = Vec::with_capacity(manifest.requires.len());
+    // We remove the intersection off all ignored interfaces from the trait
+    // signature.
+    let mut ignored = HashMap::with_capacity(manifest.requires.len());
     for (implementation_id, imp) in manifest.requires {
+        ignored
+            .entry(imp.interface.clone())
+            .and_modify(|merged_ignore: &mut Ignore| {
+                merged_ignore.vars = merged_ignore
+                    .vars
+                    .intersection(&imp.ignore.vars)
+                    .cloned()
+                    .collect();
+
+                merged_ignore.errors = merged_ignore.errors & imp.ignore.errors;
+            })
+            .or_insert(imp.ignore);
         if !required_interfaces.contains_key(&imp.interface) {
             let interface_context =
                 InterfaceContext::from_yaml(&mut yaml_repo, &imp.interface, &mut type_refs)?;
@@ -764,6 +779,20 @@ pub fn emit(manifest_path: PathBuf, everest_core: Vec<PathBuf>) -> Result<String
             min_connections: imp.min_connections.unwrap_or(1),
             max_connections: imp.max_connections.unwrap_or(1),
         })
+    }
+
+    // Remove those interfaces which were never used.
+    for (interface, merged_ignore) in ignored.into_iter() {
+        required_interfaces
+            .entry(interface)
+            .and_modify(|interface| {
+                interface
+                    .vars
+                    .retain(|cmd| !merged_ignore.vars.contains(&cmd.name));
+                if merged_ignore.errors {
+                    interface.errors.clear();
+                }
+            });
     }
 
     let mut type_module_root = TypeModuleContext::default();

--- a/everestrs/everestrs-build/src/codegen.rs
+++ b/everestrs/everestrs-build/src/codegen.rs
@@ -781,8 +781,19 @@ pub fn emit(manifest_path: PathBuf, everest_core: Vec<PathBuf>) -> Result<String
         })
     }
 
-    // Remove those interfaces which were never used.
     for (interface, merged_ignore) in ignored.into_iter() {
+        // Check if all ignored interfaces are known.
+        if let Some(required_interface) = required_interfaces.get(&interface) {
+            if let Some(unknown_var) = merged_ignore.vars.iter().find(|&ignored_var| {
+                required_interface
+                    .vars
+                    .iter()
+                    .find(|&required_var| &required_var.name == ignored_var).is_none()
+            }) {
+                panic!("The interface `{interface}` cannot ignore unkown variable `{unknown_var}`");
+            }
+        }
+        // Remove those interfaces which were never used.
         required_interfaces
             .entry(interface)
             .and_modify(|interface| {

--- a/everestrs/everestrs-build/src/schema/interface.rs
+++ b/everestrs/everestrs-build/src/schema/interface.rs
@@ -35,7 +35,7 @@ pub struct InterfaceFromEverest {
 #[serde(deny_unknown_fields)]
 pub struct Command {
     // Note: EVerest config over mqtt does not return descriptions even so
-    // they should be necessary.    
+    // they should be necessary.
     #[serde(default)]
     pub description: String,
     #[serde(default)]

--- a/everestrs/everestrs-build/src/schema/manifest.rs
+++ b/everestrs/everestrs-build/src/schema/manifest.rs
@@ -1,6 +1,6 @@
 use super::types::{BooleanOptions, IntegerOptions, NumberOptions, StringOptions};
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -43,6 +43,18 @@ pub struct RequiresEntry {
     pub interface: String,
     pub min_connections: Option<i64>,
     pub max_connections: Option<i64>,
+    #[serde(default)]
+    pub ignore: Ignore,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Ignore {
+    #[serde(default)]
+    pub vars: HashSet<String>,
+
+    #[serde(default)]
+    pub errors: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -154,8 +154,7 @@ void Module::subscribe_all_errors(const Runtime& rt) const {
     const auto manifest = config_->get_manifests().at(module_name);
     const auto requires = manifest.at("requires");
     for (const Requirement& req : config_->get_requirements(module_id_)) {
-        if (requires.at(req.id).contains("ignore") &&
-            requires.at(req.id).at("ignore").contains("errors") &&
+        if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
             requires.at(req.id).at("ignore").at("errors").get<bool>()) {
             continue;
         }

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -151,8 +151,12 @@ void Module::subscribe_variable(const Runtime& rt, rust::String implementation_i
 
 void Module::subscribe_all_errors(const Runtime& rt) const {
     for (const Requirement& req : config_->get_requirements(module_id_)) {
-        const auto error_manager_ptr = handle_->get_error_manager_req(req);
-        if (error_manager_ptr == nullptr) {
+        std::shared_ptr<Everest::error::ErrorManagerReq> error_manager_ptr = nullptr;
+        try {
+            error_manager_ptr = handle_->get_error_manager_req(req);
+        } catch (const std::runtime_error& ex) {
+            // This is expected if the manifest has `irgnore.errors=true`
+            // configured.
             continue;
         }
         const auto handle_ptr = handle_.get();

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -155,7 +155,7 @@ void Module::subscribe_all_errors(const Runtime& rt) const {
         try {
             error_manager_ptr = handle_->get_error_manager_req(req);
         } catch (const std::runtime_error& ex) {
-            // This is expected if the manifest has `irgnore.errors=true`
+            // This is expected if the manifest has `ignore.errors=true`
             // configured.
             continue;
         }

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -152,7 +152,11 @@ void Module::subscribe_variable(const Runtime& rt, rust::String implementation_i
 void Module::subscribe_all_errors(const Runtime& rt) const {
     const std::string& module_name = config_->get_main_config().at(module_id_).at("module");
     const auto manifest = config_->get_manifests().at(module_name);
+    // It seems that the current version of clang-format in our Ci wants to
+    // reformat the line below.
+    // clang-format off
     const auto& requires = manifest.at("requires");
+    // clang-format on
     for (const Requirement& req : config_->get_requirements(module_id_)) {
         if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
             requires.at(req.id).at("ignore").at("errors").get<bool>()) {

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -152,7 +152,7 @@ void Module::subscribe_variable(const Runtime& rt, rust::String implementation_i
 void Module::subscribe_all_errors(const Runtime& rt) const {
     const std::string& module_name = config_->get_main_config().at(module_id_).at("module");
     const auto manifest = config_->get_manifests().at(module_name);
-    const auto requires = manifest.at("requires");
+    const auto& requires = manifest.at("requires");
     for (const Requirement& req : config_->get_requirements(module_id_)) {
         if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
             requires.at(req.id).at("ignore").at("errors").get<bool>()) {

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -150,8 +150,6 @@ void Module::subscribe_variable(const Runtime& rt, rust::String implementation_i
 }
 
 void Module::subscribe_all_errors(const Runtime& rt) const {
-    const std::string& module_name = config_->get_main_config().at(module_id_).at("module");
-    const auto manifest = config_->get_manifests().at(module_name);
     for (const Requirement& req : config_->get_requirements(module_id_)) {
         const auto error_manager_ptr = handle_->get_error_manager_req(req);
         if (error_manager_ptr == nullptr) {

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -150,7 +150,15 @@ void Module::subscribe_variable(const Runtime& rt, rust::String implementation_i
 }
 
 void Module::subscribe_all_errors(const Runtime& rt) const {
+    const std::string& module_name = config_->get_main_config().at(module_id_).at("module");
+    const auto manifest = config_->get_manifests().at(module_name);
+    const auto requires = manifest.at("requires");
     for (const Requirement& req : config_->get_requirements(module_id_)) {
+        if (requires.at(req.id).contains("ignore") &&
+            requires.at(req.id).at("ignore").contains("errors") &&
+            requires.at(req.id).at("ignore").at("errors").get<bool>()) {
+            continue;
+        }
         const auto handle_ptr = handle_.get();
         handle_->get_error_manager_req(req)->subscribe_all_errors(
             [&rt, req, handle_ptr](Everest::error::Error error) {

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -583,6 +583,9 @@ impl Runtime {
 
             for i in 0usize..connection {
                 for (name, _) in interface.vars.iter() {
+                    if requires.ignore.vars.contains(name) {
+                        continue;
+                    }
                     self.cpp_module.subscribe_variable(
                         self,
                         implementation_id.clone(),

--- a/everestrs/tests/modules/RsIgnore/BUILD.bazel
+++ b/everestrs/tests/modules/RsIgnore/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+load("@python3_10//:defs.bzl", "interpreter")
+load("//bazel:everest_env.bzl", "everest_test")
+load("//bazel:modules_def.bzl", "rs_everest_module")
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["build.rs"],
+    edition="2021",
+    build_script_env = {
+        "EVEREST_CORE_ROOT": "../..",
+    },
+    deps = [
+        "@everest-framework//everestrs/everestrs-build",
+    ],
+    data= [
+        "//everestrs/tests/types",
+        "//everestrs/tests/interfaces",
+        "//everestrs/tests/errors",
+        "manifest.yaml",
+    ],
+)
+
+rust_binary(
+    name = "RsIgnoreBinary",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    edition = "2021",
+    deps = [
+        "@crate_index//:log",
+        "@everest-framework//everestrs/everestrs",
+        "@everest-framework//everestrs/everestrs:everestrs_sys",
+        "@everest-framework//everestrs/everestrs:everestrs_bridge",
+        ":build_script",
+    ],
+)
+
+rs_everest_module(
+    name = "RsIgnore",
+    binary = ":RsIgnoreBinary",
+    manifest = "manifest.yaml",
+)
+
+everest_test(
+    name = "integration_test",
+    modules = [
+        ":RsIgnore",
+    ],
+    config_file = "config.yaml",
+    python_interpreter_target = interpreter,
+    test_script = "test.sh",
+    tags = ["exclusive"]
+)

--- a/everestrs/tests/modules/RsIgnore/build.rs
+++ b/everestrs/tests/modules/RsIgnore/build.rs
@@ -1,0 +1,13 @@
+use everestrs_build::Builder;
+
+pub fn main() {
+    Builder::new(
+        "manifest.yaml",
+        vec![std::env::var("EVEREST_CORE_ROOT").unwrap_or("../../..".to_string())],
+    )
+    .generate()
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=manifest.yaml");
+}

--- a/everestrs/tests/modules/RsIgnore/config.yaml
+++ b/everestrs/tests/modules/RsIgnore/config.yaml
@@ -1,0 +1,14 @@
+# Test config for regression tests for the framework.
+active_modules:
+  example_0:
+    module: RsIgnore
+    connections:
+      other:
+        - module_id: example_1
+          implementation_id: example
+  example_1:
+    module: RsIgnore
+    connections:
+      other:
+        - module_id: example_0
+          implementation_id: example

--- a/everestrs/tests/modules/RsIgnore/manifest.yaml
+++ b/everestrs/tests/modules/RsIgnore/manifest.yaml
@@ -1,0 +1,17 @@
+description: Simple Example
+provides:
+  example:
+    interface: example
+    description: An example interface.
+requires:
+  other:
+    interface: example
+    ignore:
+      vars:
+        - max_current
+      errors: true
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Everest authors
+enable_external_mqtt: false

--- a/everestrs/tests/modules/RsIgnore/src/main.rs
+++ b/everestrs/tests/modules/RsIgnore/src/main.rs
@@ -1,9 +1,9 @@
-//! Integration test for the "ready_received" handling.
+//! Integration test for the "ignore" handling.
 //!
-//! We assume that every module shall recieve first `on_ready` before forwarding
-//! any other call to the user code. The code below recreates the race condition
-//! by making calls to the `other` module from within `on_ready` (and adding a
-//! delay in `on_ready`).
+//! The Rust binding allow you to ignore variables and errors. The variables
+//! are ignored by adding them to the "ignore.vars" list. Errors can only be ignored
+//! at bulk, by setting "ignore.errors" to true. Ignored elements are removed
+//! from the trait and thus don't have to be implemented.
 #![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 

--- a/everestrs/tests/modules/RsIgnore/src/main.rs
+++ b/everestrs/tests/modules/RsIgnore/src/main.rs
@@ -1,0 +1,49 @@
+//! Integration test for the "ready_received" handling.
+//!
+//! We assume that every module shall recieve first `on_ready` before forwarding
+//! any other call to the user code. The code below recreates the race condition
+//! by making calls to the `other` module from within `on_ready` (and adding a
+//! delay in `on_ready`).
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+use generated::errors::example::{Error as ExampleError, ExampleErrorsError};
+use generated::{
+    Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module, ModulePublisher,
+    OnReadySubscriber,
+};
+use std::sync::Arc;
+use std::{thread, time};
+
+pub struct OneClass {}
+
+impl ExampleServiceSubscriber for OneClass {
+    fn uses_something(&self, _context: &Context, _key: String) -> ::everestrs::Result<bool> {
+        Ok(true)
+    }
+}
+
+// The compilation test is that we don't generate the method interfaces for
+// the ignored methods.
+impl ExampleClientSubscriber for OneClass {}
+
+impl OnReadySubscriber for OneClass {
+    fn on_ready(&self, publishers: &ModulePublisher) {
+        // Call the other module. This calls should be ignored.
+        publishers.example.max_current(12.3).unwrap();
+        let error = ExampleError::ExampleErrors(ExampleErrorsError::ExampleErrorA);
+        publishers.example.raise_error(error.clone());
+        publishers.example.clear_error(error);
+    }
+}
+
+fn main() {
+    let one_class = Arc::new(OneClass {});
+    let _module = Module::new(one_class.clone(), one_class.clone(), one_class.clone());
+    log::info!("Module initialized");
+
+    loop {
+        let dt = time::Duration::from_millis(250);
+        thread::sleep(dt);
+    }
+}

--- a/everestrs/tests/modules/RsIgnore/test.sh
+++ b/everestrs/tests/modules/RsIgnore/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "This is a test script"
+sleep 5
+echo "Exit"

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -167,7 +167,13 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         const std::shared_ptr<error::ErrorDatabaseMap> error_database = std::make_shared<error::ErrorDatabaseMap>();
 
         // setup error manager
-        const std::string interface_name = this->module_manifest.at("requires").at(req.id).at("interface");
+        const auto& requires = this->module_manifest.at("requires");
+        if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
+            requires.at(req.id).at("ignore").at("errors").get<bool>()) {
+            EVLOG_warning << "Ignoring " << req.id;
+            continue;
+        }
+        const std::string interface_name = requires.at(req.id).at("interface");
         const json interface_def = this->config.get_interface_definition(interface_name);
         std::list<std::string> allowed_error_types;
         for (const auto& error_namespace_it : interface_def.at("errors").items()) {

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -601,8 +601,7 @@ std::shared_ptr<error::ErrorFactory> Everest::get_error_factory(const std::strin
 
 std::shared_ptr<error::ErrorManagerReq> Everest::get_error_manager_req(const Requirement& req) {
     if (this->req_error_managers.find(req) == this->req_error_managers.end()) {
-        EVLOG_info << fmt::format("Error manager for {} not found", req.id);
-        return nullptr;
+        throw std::runtime_error(fmt::format("Error manager for {} not found", req.id));
     }
     return this->req_error_managers.at(req);
 }

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -173,7 +173,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         // clang-format on
         if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
             requires.at(req.id).at("ignore").at("errors").get<bool>()) {
-            EVLOG_warning << "Ignoring " << req.id;
+            EVLOG_debug << "Ignoring errors for module " << req.id;
             continue;
         }
         const json interface_def = this->config.get_interface_definition(interface_name);
@@ -618,7 +618,7 @@ std::shared_ptr<error::ErrorFactory> Everest::get_error_factory(const std::strin
 
 std::shared_ptr<error::ErrorManagerReq> Everest::get_error_manager_req(const Requirement& req) {
     if (this->req_error_managers.find(req) == this->req_error_managers.end()) {
-        EVLOG_info << fmt::format(" manager for {} not found", req.id);
+        EVLOG_info << fmt::format("Error manager for {} not found", req.id);
         return nullptr;
     }
     return this->req_error_managers.at(req);

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -167,13 +167,15 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         const std::shared_ptr<error::ErrorDatabaseMap> error_database = std::make_shared<error::ErrorDatabaseMap>();
 
         // setup error manager
+        // clang-format off
         const auto& requires = this->module_manifest.at("requires");
+        const std::string interface_name = requires.at(req.id).at("interface");
+        // clang-format on
         if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
             requires.at(req.id).at("ignore").at("errors").get<bool>()) {
             EVLOG_warning << "Ignoring " << req.id;
             continue;
         }
-        const std::string interface_name = requires.at(req.id).at("interface");
         const json interface_def = this->config.get_interface_definition(interface_name);
         std::list<std::string> allowed_error_types;
         for (const auto& error_namespace_it : interface_def.at("errors").items()) {
@@ -616,7 +618,7 @@ std::shared_ptr<error::ErrorFactory> Everest::get_error_factory(const std::strin
 
 std::shared_ptr<error::ErrorManagerReq> Everest::get_error_manager_req(const Requirement& req) {
     if (this->req_error_managers.find(req) == this->req_error_managers.end()) {
-        EVLOG_error << fmt::format("Error manager for {} not found!", req.id);
+        EVLOG_info << fmt::format(" manager for {} not found", req.id);
         return nullptr;
     }
     return this->req_error_managers.at(req);

--- a/schemas/manifest.yaml
+++ b/schemas/manifest.yaml
@@ -109,6 +109,19 @@ properties:
             type: integer
             minimum: 1
             default: 1
+          ignore:
+            type: object
+            properties:
+              vars:
+                type:
+                  - string
+                  - array
+                items:
+                  type: string
+                uniqueItems: true
+              errors:
+                type: boolean
+                default: false
         # don't allow arbitrary additional properties
         additionalProperties: false
     # don't allow arbitrary additional properties

--- a/schemas/manifest.yaml
+++ b/schemas/manifest.yaml
@@ -109,6 +109,7 @@ properties:
             type: integer
             minimum: 1
             default: 1
+          # Used for now for the Rust bindings.
           ignore:
             type: object
             properties:


### PR DESCRIPTION
Currently Rust eagerly subscribes to all vars and error topics. This can increase the number of threads used by the system. With this feature the user can opt out from subscribing to certain topics