### PR TITLE
Changed parse_everest_config to parse_module_configs

### DIFF
--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -102,7 +102,7 @@ struct ConfigurationParameter;
 struct ModuleConfig;
 using ModuleId = std::string;
 using RequirementId = std::string;
-using ConfigEntry = std::variant<std::string, bool, int, double>;
+using ConfigEntry = std::variant<std::string, bool, int, double, fs::path>;
 using ImplementationIdentifier = std::string;
 using ModuleConnections = std::map<RequirementId, std::vector<Fulfillment>>;
 using ModuleConfigurations = std::map<ModuleId, ModuleConfig>;
@@ -162,14 +162,6 @@ struct ConfigurationParameter {
 
     bool validate_type() const;
 };
-
-/// \brief Struct that contains the settings for the EVerest framework and all module configurations. It can represent a
-/// full YAML configuration file.
-struct EverestConfig {
-    Settings settings;
-    std::map<ModuleId, ModuleConfig> module_configs;
-};
-
 /// \brief Struct that contains the configuration of an EVerest module
 struct ModuleConfig {
     bool standalone;
@@ -184,7 +176,7 @@ struct ModuleConfig {
     ModuleTierMappings mapping;
 };
 
-EverestConfig parse_everest_config(const nlohmann::json& config);
+ModuleConfigurations parse_module_configs(const nlohmann::json& config);
 Settings parse_settings(const nlohmann::json& settings_json);
 
 Datatype string_to_datatype(const std::string& str);

--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -102,7 +102,7 @@ struct ConfigurationParameter;
 struct ModuleConfig;
 using ModuleId = std::string;
 using RequirementId = std::string;
-using ConfigEntry = std::variant<std::string, bool, int, double, fs::path>;
+using ConfigEntry = std::variant<std::string, bool, int, double>;
 using ImplementationIdentifier = std::string;
 using ModuleConnections = std::map<RequirementId, std::vector<Fulfillment>>;
 using ModuleConfigurations = std::map<ModuleId, ModuleConfig>;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -1143,8 +1143,8 @@ ManagerConfig::ManagerConfig(const ManagerSettings& ms) : ConfigBase(ms.mqtt_set
 
         this->settings = this->ms.runtime_settings;
         // this config is parsed from the file, it doesnt contain any defaults or patches!
-        auto everest_config = parse_everest_config(complete_config);
-        this->parse(everest_config.module_configs);
+        auto module_configs = parse_module_configs(complete_config.value("active_modules", json::object()));
+        this->parse(module_configs);
         // now the config is parsed, validated and patched!
     } catch (const std::exception& e) {
         EVLOG_AND_THROW(EverestConfigError(fmt::format("Failed to load and parse config file: {}", e.what())));

--- a/lib/config/types.cpp
+++ b/lib/config/types.cpp
@@ -232,16 +232,14 @@ ModuleConfig parse_module_config(const std::string& module_id, const json& modul
     return module_config;
 }
 
-EverestConfig parse_everest_config(const json& config) {
-    EverestConfig everest_config;
+ModuleConfigurations parse_module_configs(const json& active_modules_json) {
+    ModuleConfigurations module_configs;
 
-    json modules = config.value("active_modules", json::object());
-    for (auto module = modules.begin(); module != modules.end(); ++module) {
-        everest_config.module_configs.insert({module.key(), parse_module_config(module.key(), module.value())});
+    for (auto module = active_modules_json.begin(); module != active_modules_json.end(); ++module) {
+        module_configs.insert({module.key(), parse_module_config(module.key(), module.value())});
     }
 
-    everest_config.settings = parse_settings(config.value("settings", json::object()));
-    return everest_config;
+    return module_configs;
 }
 
 Datatype string_to_datatype(const std::string& str) {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -212,43 +212,44 @@ SCENARIO("Check everest config parsing", "[!throws]") {
     GIVEN("A complete and valid config") {
         auto config = Everest::load_yaml(valid_complete_config_json);
         THEN("It should not throw") {
-            CHECK_NOTHROW(everest::config::parse_everest_config(config));
+            CHECK_NOTHROW(everest::config::parse_module_configs(config.value("active_modules", json::object())));
         }
     }
     GIVEN("A valid config that misses module connections") {
         auto config = Everest::load_yaml(valid_complete_config_json);
         config["active_modules"]["valid_module_requires"].erase("connections");
         THEN("It should not throw") {
-            CHECK_NOTHROW(everest::config::parse_everest_config(config));
+            CHECK_NOTHROW(everest::config::parse_module_configs(config.value("active_modules", json::object())));
         }
     }
     GIVEN("A valid config that misses a mapping") {
         auto config = Everest::load_yaml(valid_complete_config_json);
         config["active_modules"]["valid_module"].erase("mapping");
         THEN("It should not throw") {
-            CHECK_NOTHROW(everest::config::parse_everest_config(config));
+            CHECK_NOTHROW(everest::config::parse_module_configs(config.value("active_modules", json::object())));
         }
     }
     GIVEN("A config where a module is missing the 'module' field") {
         auto config = Everest::load_yaml(valid_complete_config_json);
         config["active_modules"]["valid_module"].erase("module");
         THEN("It should throw ConfigParseException for missing 'module'") {
-            CHECK_THROWS_AS(everest::config::parse_everest_config(config), ConfigParseException);
+            CHECK_THROWS_AS(everest::config::parse_module_configs(config.value("active_modules", json::object())),
+                            ConfigParseException);
         }
     }
     GIVEN("A config with only 'active_modules' and no 'settings'") {
         json config;
         config["active_modules"] = {{"valid_module", {{"module", "TESTValidManifest"}}}};
         THEN("It should not throw and parse default settings") {
-            CHECK_NOTHROW(everest::config::parse_everest_config(config));
+            CHECK_NOTHROW(everest::config::parse_module_configs(config.value("active_modules", json::object())));
         }
     }
     GIVEN("A config with empty 'active_modules'") {
         json config;
         config["active_modules"] = json::object(); // empty object
         THEN("It should not throw and result in no modules") {
-            auto result = everest::config::parse_everest_config(config);
-            CHECK(result.module_configs.empty());
+            auto result = everest::config::parse_module_configs(config.value("active_modules", json::object()));
+            CHECK(result.empty());
         }
     }
 
@@ -257,7 +258,7 @@ SCENARIO("Check everest config parsing", "[!throws]") {
         config["active_modules"] = {
             {"test_module", {{"module", "test"}, {"config_module", {{"param1", json::array({1, 2, 3})}}}}}};
         THEN("It should throw due to unsupported config parameter type") {
-            CHECK_THROWS(everest::config::parse_everest_config(config));
+            CHECK_THROWS(everest::config::parse_module_configs(config.value("active_modules", json::object())));
         }
     }
 }


### PR DESCRIPTION
Changed parse_everest_config to parse_module_configs . Parsing the complete config including settings and modules is never required.