### PR TITLE
Set rust-version to 1.74 to ensure Cargo.lock version 3 is used

### DIFF
--- a/everestrs/everestrs-build/Cargo.toml
+++ b/everestrs/everestrs-build/Cargo.toml
@@ -2,6 +2,7 @@
 name = "everestrs-build"
 version = "0.20.1"
 edition = "2021"
+rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "everestrs"
 version = "0.20.2"
 edition = "2021"
+rust-version = "1.74"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }


### PR DESCRIPTION
1.74. is the Rust version which is in the WORKSPACE.bazel, this doesn't yet understand Cargo.lock version 4 A more recent system cargo would set version = 4 when running cargo generate-lockfile unless a appropriate rust-version is set