### PR TITLE
Fix multiple compiler warnings

### DIFF
--- a/include/utils/mqtt_abstraction.hpp
+++ b/include/utils/mqtt_abstraction.hpp
@@ -97,9 +97,9 @@ public:
     void unregister_handler(const std::string& topic, const Token& token);
 
 private:
-    std::unique_ptr<MQTTAbstractionImpl> mqtt_abstraction;
     std::string everest_prefix;
     std::string external_prefix;
+    std::unique_ptr<MQTTAbstractionImpl> mqtt_abstraction;
 };
 } // namespace Everest
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -515,7 +515,6 @@ std::vector<Fulfillment> ConfigBase::resolve_requirement(const std::string& modu
     // check for connections for this requirement
     const auto& module_config = this->module_configs.at(module_id);
     const auto module_name = module_config.module_name;
-    const auto& requirement = this->manifests.at(module_name).at("requires").at(requirement_id);
     if (module_config.connections.find(requirement_id) == module_config.connections.end()) {
         return {}; // return an empty array if our config does not contain any connections for this
                    // requirement id

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -45,14 +45,14 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     mqtt_abstraction(mqtt_abstraction),
     config(config_),
     module_id(std::move(module_id_)),
+    ready_received(false),
+    ready_processed(false),
     remote_cmd_res_timeout(remote_cmd_res_timeout_seconds),
     validate_data_with_schema(validate_data_with_schema),
     mqtt_everest_prefix(mqtt_abstraction->get_everest_prefix()),
     mqtt_external_prefix(mqtt_abstraction->get_external_prefix()),
     telemetry_prefix(telemetry_prefix),
-    telemetry_enabled(telemetry_enabled),
-    ready_received(false),
-    ready_processed(false) {
+    telemetry_enabled(telemetry_enabled) {
     BOOST_LOG_FUNCTION();
 
     EVLOG_debug << "Initializing EVerest framework...";
@@ -163,11 +163,12 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
 
         // setup error manager
         // clang-format off
-        const auto& requires = this->module_manifest.at("requires");
-        const std::string interface_name = requires.at(req.id).at("interface");
+        const auto& module_requires = this->module_manifest.at("requires");
+        const std::string interface_name = module_requires.at(req.id).at("interface");
         // clang-format on
-        if (requires.at(req.id).contains("ignore") && requires.at(req.id).at("ignore").contains("errors") &&
-            requires.at(req.id).at("ignore").at("errors").get<bool>()) {
+        if (module_requires.at(req.id).contains("ignore") &&
+            module_requires.at(req.id).at("ignore").contains("errors") &&
+            module_requires.at(req.id).at("ignore").at("errors").get<bool>()) {
             EVLOG_debug << "Ignoring errors for module " << req.id;
             continue;
         }

--- a/src/controller/rpc.cpp
+++ b/src/controller/rpc.cpp
@@ -187,7 +187,7 @@ nlohmann::json RPC::ipc_request(const std::string& method, const nlohmann::json&
     }
 
     const auto id = new_call.first->first;
-    auto call_result_future = std::move(new_call.first->second.get_future());
+    auto call_result_future = new_call.first->second.get_future();
 
     lock.unlock();
 

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -259,7 +259,7 @@ void Server::Impl::push(const nlohmann::json& msg) {
     }
 
     for (auto session : sessions) {
-        session->push_output_data(std::move(msg.dump()));
+        session->push_output_data(msg.dump());
     }
     lws_cancel_service(context);
 }


### PR DESCRIPTION
- reordering of various members
- unused variable "requirement"
- unnecessary moves
- rename variable "requires" to "module_requires" because "requires is a C++20 keyword