### PR TITLE
Manager: fix deadlock on shutdown

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 
 #include <cstdlib>
 #include <errno.h>
@@ -263,7 +264,10 @@ struct ModuleReadyInfo {
 };
 
 // FIXME (aw): these are globals here, because they are used in the ready callback handlers
-std::map<std::string, ModuleReadyInfo> modules_ready;
+using ModulesReadyType = std::unordered_map<std::string, ModuleReadyInfo>;
+ModulesReadyType modules_ready;
+// Don't hold the mutex and use any function of the `mqtt_abstraction` since the
+// mutex is also held inside the `ready` handler which can deadlock.
 std::mutex modules_ready_mutex;
 
 static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstraction& mqtt_abstraction,
@@ -454,17 +458,19 @@ static std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbs
 static void shutdown_modules(const std::map<pid_t, std::string>& modules, ManagerConfig& config,
                              MQTTAbstraction& mqtt_abstraction) {
 
+    ModulesReadyType modules_ready_moved;
     {
         const std::lock_guard<std::mutex> lck(modules_ready_mutex);
-
-        for (const auto& module : modules_ready) {
-            const auto& ready_info = module.second;
-            const auto& module_name = module.first;
-            const std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
-            mqtt_abstraction.unregister_handler(topic, ready_info.ready_token);
-        }
-
+        modules_ready_moved = std::move(modules_ready);
+        // Probably not needed after our move but lets be explicit.
         modules_ready.clear();
+    }
+
+    for (const auto& module : modules_ready_moved) {
+        const auto& ready_info = module.second;
+        const auto& module_name = module.first;
+        const std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
+        mqtt_abstraction.unregister_handler(topic, ready_info.ready_token);
     }
 
     for (const auto& child : modules) {


### PR DESCRIPTION
We hold the `modules_ready_moved` in the on ready handler and when unregistering the ready handlers in the mqtt abstraction. The mqtt abstraction itself has a mutex which it locks when changing the handlers or receiving a message. If we shutdown while we're receiving an on-ready this can lead to a deadlock.

Below are snippet from a deadlock observed
```
Everest::MessageHandler> > >::erase(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#14 0x00005bd771ef29a3 in std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Everest::MessageHandler, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, Everest::MessageHandler> > >::erase(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#15 0x00005bd771eeb1c1 in Everest::MQTTAbstractionImpl::unregister_handler(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<TypedHandler> const&) ()
#16 0x00005bd771e93eb5 in Everest::MQTTAbstraction::unregister_handler(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<TypedHandler> const&) ()
#17 0x00005bd771d6af0d in shutdown_modules(std::map<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<int>, std::allocator<std::pair<int const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, Everest::ManagerConfig&, Everest::MQTTAbstraction&) ()
#18 0x00005bd771d6e784 in boot(boost::program_options::variables_map const&) ()
``` 