### PR TITLE
feat: Add command line options to specify boot source

### DIFF
--- a/docs/ConfigSourceBootLogic.puml
+++ b/docs/ConfigSourceBootLogic.puml
@@ -1,0 +1,42 @@
+@startuml
+title Boot Source Decision Based on config, db, source
+
+start
+
+if ("config AND db are provided") then (yes)
+    if ("source is missing") then (yes)
+        :Error: source required when both config and db are set;
+        stop
+    else (no)
+        if ("source == db") then (yes)
+            :Boot from Database;
+            stop
+        else if ("source == config") then (yes)
+            :Boot from YAML Config;
+            stop
+        else if ("source == db_fallback_config") then (yes)
+            :Check if DB is valid;
+            if ("valid") then (yes)
+                :Boot from Database;
+                stop
+            else (no)
+                :Boot from YAML Config;
+                stop
+            endif
+        else (no)
+            :Error: Unknown source value;
+            stop
+        endif
+    endif
+else if ("config is provided") then (yes)
+    :Boot from YAML Config;
+    stop
+else if ("db is provided") then (yes)
+    :Boot from Database;
+    stop
+else (no)
+    :Error: Neither config nor db provided;
+    stop
+endif
+
+@enduml

--- a/include/utils/config/settings.hpp
+++ b/include/utils/config/settings.hpp
@@ -42,6 +42,8 @@ void populate_runtime_settings(RuntimeSettings& runtime_settings, const fs::path
                                const fs::path& logging_config_file, const std::string& telemetry_prefix,
                                bool telemetry_enabled, bool validate_schema);
 
+struct DatabaseTag {};
+
 /// \brief Settings needed by the manager to load and validate a config
 struct ManagerSettings {
     fs::path configs_dir;          ///< Directory that contains EVerest configs
@@ -72,14 +74,21 @@ struct ManagerSettings {
 
     /// \brief Constructor that initializes the ManagerSettings with the given database path. Boot source is set to
     /// Database.
-    ManagerSettings(const std::string& db);
+    ManagerSettings(const std::string& prefix, const std::string& db, DatabaseTag);
 
     /// \brief Constructor that initializes the ManagerSettings with the given prefix, config file and database path.
     /// Boot Source is set to DatabaseFallbackYaml.
     ManagerSettings(const std::string& prefix, const std::string& config, const std::string& db);
 
     /// \brief Initializes the ManagerSettings with the given settings and prefix.
-    void init_settings(const everest::config::Settings& settings, const fs::path& prefix);
+    void init_settings(const everest::config::Settings& settings);
+
+    /// \brief Initializes the ManagerSettings based on the user provided \p config file or fallback options
+    void init_config_file(const std::string& config);
+
+    /// \brief Initializes the ManagerSettings prefix and data_dir base on user provided \p prefix or the default
+    /// prefix.
+    void init_prefix_and_data_dir(const std::string& prefix);
 };
 } // namespace Everest
 

--- a/include/utils/config/settings.hpp
+++ b/include/utils/config/settings.hpp
@@ -9,10 +9,17 @@
 #include <nlohmann/json.hpp>
 
 #include <utils/config/mqtt_settings.hpp>
+#include <utils/config/types.hpp>
 
 namespace Everest {
 
 namespace fs = std::filesystem;
+
+enum class ConfigBootSource {
+    YamlFile = 1,
+    Database = 2,
+    DatabaseFallbackYaml = 3
+};
 
 /// \brief EVerest framework runtime settings needed to successfully run modules
 struct RuntimeSettings {
@@ -55,8 +62,24 @@ struct ManagerSettings {
 
     MQTTSettings mqtt_settings;       ///< MQTT connection settings
     RuntimeSettings runtime_settings; ///< Runtime settings needed to successfully run modules
+    ConfigBootSource boot_source;
 
+    ManagerSettings() = default;
+
+    /// \brief Constructor that initializes the ManagerSettings with the given prefix and config file. Boot source is
+    /// set to YamlFile.
     ManagerSettings(const std::string& prefix, const std::string& config);
+
+    /// \brief Constructor that initializes the ManagerSettings with the given database path. Boot source is set to
+    /// Database.
+    ManagerSettings(const std::string& db);
+
+    /// \brief Constructor that initializes the ManagerSettings with the given prefix, config file and database path.
+    /// Boot Source is set to DatabaseFallbackYaml.
+    ManagerSettings(const std::string& prefix, const std::string& config, const std::string& db);
+
+    /// \brief Initializes the ManagerSettings with the given settings and prefix.
+    void init_settings(const everest::config::Settings& settings, const fs::path& prefix);
 };
 } // namespace Everest
 

--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -12,8 +12,6 @@
 #include <variant>
 #include <vector>
 
-#include <utils/config/settings.hpp>
-
 class ConfigParseException : public std::exception {
 public:
     enum ParseErrorType {

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -38,6 +38,8 @@ ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& 
     // if prefix or config is empty, we assume they have not been set!
     // if they have been set, check their validity, otherwise bail out!
 
+    this->boot_source = ConfigBootSource::YamlFile;
+
     if (config_.length() != 0) {
         try {
             config_file = assert_file(config_, "User profided config");
@@ -109,7 +111,20 @@ ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& 
             prefix = assert_dir(defaults::PREFIX, "Default prefix");
         }
     }
+    init_settings(settings, prefix);
+}
 
+ManagerSettings::ManagerSettings(const std::string& db) {
+    this->boot_source = ConfigBootSource::Database;
+    throw BootException("Database boot source is not supported in this version of EVerest");
+}
+
+ManagerSettings::ManagerSettings(const std::string& prefix, const std::string& config, const std::string& db) {
+    this->boot_source = ConfigBootSource::DatabaseFallbackYaml;
+    throw BootException("Database fallback YAML boot source is not supported in this version of EVerest");
+}
+
+void ManagerSettings::init_settings(const everest::config::Settings& settings, const fs::path& prefix) {
     fs::path etc_dir;
     {
         // etc directory

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -40,91 +40,35 @@ ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& 
 
     this->boot_source = ConfigBootSource::YamlFile;
 
-    if (config_.length() != 0) {
-        try {
-            config_file = assert_file(config_, "User profided config");
-        } catch (const BootException& e) {
-            if (has_extension(config_file, ".yaml")) {
-                throw;
-            }
-
-            // otherwise, we propbably got a simple config file name
-        }
-    }
-
-    fs::path prefix;
-    if (prefix_.length() != 0) {
-        // user provided
-        prefix = assert_dir(prefix_, "User provided prefix");
-    }
-
-    if (config_file.empty()) {
-        auto config_file_prefix = prefix;
-        if (config_file_prefix.empty()) {
-            config_file_prefix = assert_dir(defaults::PREFIX, "Default prefix");
-        }
-
-        if (config_file_prefix.string() == "/usr") {
-            // we're going to look in /etc, which isn't prefixed by /usr
-            config_file_prefix = "/";
-        }
-
-        if (config_.length() != 0) {
-            // user provided short form
-
-            const auto user_config_file =
-                config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / fmt::format("{}.yaml", config_);
-
-            const auto short_form_alias = fmt::format("User provided (by using short form: '{}')", config_);
-
-            config_file = assert_file(user_config_file, short_form_alias);
-        } else {
-            // default
-            config_file =
-                assert_file(config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / defaults::CONFIG_NAME,
-                            "Default config");
-        }
-    }
-
-    // now the config file should have been found
-    if (config_file.empty()) {
-        throw std::runtime_error("Assertion for found config file failed");
-    }
-
-    config = load_yaml(config_file);
-    if (config == nullptr) {
-        EVLOG_info << "Config file is null, treating it as empty";
-        config = json::object();
-    } else if (!config.is_object()) {
-        throw BootException(fmt::format("Config file '{}' is not an object", config_file.string()));
-    }
+    init_prefix_and_data_dir(prefix_);
+    init_config_file(config_);
     const auto settings = everest::config::parse_settings(config.value("settings", json::object()));
-    if (prefix.empty()) {
-        if (settings.prefix.has_value()) {
-            const auto settings_prefix = settings.prefix.value();
-            if (!settings_prefix.is_absolute()) {
-                throw BootException("Setting a non-absolute directory for the prefix is not allowed");
-            }
-
-            prefix = assert_dir(settings_prefix, "Config provided prefix");
-        } else {
-            prefix = assert_dir(defaults::PREFIX, "Default prefix");
-        }
+    if (settings.prefix.has_value()) {
+        EVLOG_warning << "Setting the prefix in the config file is deprecated. Please use the --prefix command line "
+                         "option instead.";
     }
-    init_settings(settings, prefix);
+    init_settings(settings);
 }
 
-ManagerSettings::ManagerSettings(const std::string& db) {
+ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& db_, DatabaseTag) {
     this->boot_source = ConfigBootSource::Database;
+    init_prefix_and_data_dir(prefix_);
     throw BootException("Database boot source is not supported in this version of EVerest");
 }
 
-ManagerSettings::ManagerSettings(const std::string& prefix, const std::string& config, const std::string& db) {
+ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& config_, const std::string& db_) {
     this->boot_source = ConfigBootSource::DatabaseFallbackYaml;
+    init_prefix_and_data_dir(prefix_);
     throw BootException("Database fallback YAML boot source is not supported in this version of EVerest");
 }
 
-void ManagerSettings::init_settings(const everest::config::Settings& settings, const fs::path& prefix) {
+void ManagerSettings::init_settings(const everest::config::Settings& settings) {
+    if (this->runtime_settings.prefix.empty()) {
+        throw std::runtime_error(
+            "Prefix must be set before initializing the settings. Please call init_prefix_and_data_dir() first.");
+    }
+
+    const auto prefix = this->runtime_settings.prefix;
     fs::path etc_dir;
     {
         // etc directory
@@ -355,6 +299,80 @@ void ManagerSettings::init_settings(const everest::config::Settings& settings, c
 
     populate_runtime_settings(this->runtime_settings, prefix, etc_dir, data_dir, modules_dir, logging_config_file,
                               telemetry_prefix, telemetry_enabled, validate_schema);
+}
+
+void ManagerSettings::init_prefix_and_data_dir(const std::string& prefix_) {
+    fs::path prefix;
+    if (prefix_.length() != 0) {
+        // user provided
+        prefix = assert_dir(prefix_, "User provided prefix");
+    }
+    if (prefix.empty()) {
+        prefix = assert_dir(defaults::PREFIX, "Default prefix");
+    }
+    runtime_settings.data_dir =
+        assert_dir((prefix / defaults::DATAROOT_DIR / defaults::NAMESPACE).string(), "Default share directory");
+    runtime_settings.prefix = prefix;
+}
+
+void ManagerSettings::init_config_file(const std::string& config_) {
+    if (this->runtime_settings.prefix.empty()) {
+        throw std::runtime_error(
+            "Prefix must be set before initializing the config file. Please call init_prefix_and_data_dir() first.");
+    }
+
+    if (config_.length() != 0) {
+        try {
+            config_file = assert_file(config_, "User profided config");
+        } catch (const BootException& e) {
+            if (has_extension(config_file, ".yaml")) {
+                throw;
+            }
+
+            // otherwise, we propbably got a simple config file name
+        }
+    }
+
+    if (config_file.empty()) {
+        auto config_file_prefix = this->runtime_settings.prefix;
+        if (config_file_prefix.empty()) {
+            config_file_prefix = assert_dir(defaults::PREFIX, "Default prefix");
+        }
+
+        if (config_file_prefix.string() == "/usr") {
+            // we're going to look in /etc, which isn't prefixed by /usr
+            config_file_prefix = "/";
+        }
+
+        if (config_.length() != 0) {
+            // user provided short form
+
+            const auto user_config_file =
+                config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / fmt::format("{}.yaml", config_);
+
+            const auto short_form_alias = fmt::format("User provided (by using short form: '{}')", config_);
+
+            config_file = assert_file(user_config_file, short_form_alias);
+        } else {
+            // default
+            config_file =
+                assert_file(config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / defaults::CONFIG_NAME,
+                            "Default config");
+        }
+    }
+
+    // now the config file should have been found
+    if (config_file.empty()) {
+        throw std::runtime_error("Assertion for found config file failed");
+    }
+
+    config = load_yaml(config_file);
+    if (config == nullptr) {
+        EVLOG_info << "Config file is null, treating it as empty";
+        config = json::object();
+    } else if (!config.is_object()) {
+        throw BootException(fmt::format("Config file '{}' is not an object", config_file.string()));
+    }
 }
 
 ModuleCallbacks::ModuleCallbacks(

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -583,6 +583,7 @@ ConfigBootSource parse_config_boot_source(const std::string& config_opt, const s
         // only db option given, use database
         return ConfigBootSource::Database;
     }
+    throw std::logic_error("Could not parse config boot source, this should never happen.");
 }
 
 int boot(const po::variables_map& vm) {
@@ -601,7 +602,7 @@ int boot(const po::variables_map& vm) {
         ms = ManagerSettings(prefix_opt, config_opt);
         break;
     case ConfigBootSource::Database:
-        ms = ManagerSettings(db_opt);
+        ms = ManagerSettings(prefix_opt, db_opt, DatabaseTag{});
         break;
     case ConfigBootSource::DatabaseFallbackYaml:
         ms = ManagerSettings(prefix_opt, config_opt, db_opt);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -906,7 +906,7 @@ int main(int argc, char* argv[]) {
                        "looked up in the default config directory");
     desc.add_options()("db", po::value<std::string>(), "Full path to the configuration database file");
     desc.add_options()("source", po::value<std::string>(),
-                       "Source from which the configuration shall be loaded, either 'config' or 'db'");
+                       "Source from which the configuration shall be loaded: 'yaml', 'db' or 'db_fallback_yaml'");
     desc.add_options()("status-fifo", po::value<std::string>()->default_value(""),
                        "Path to a named pipe, that shall be used for status updates from the manager");
     desc.add_options()("retain-topics", "Retain configuration MQTT topics setup by manager for inspection, by default "

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -551,13 +551,64 @@ static ControllerHandle start_controller(const ManagerSettings& ms) {
 }
 #endif
 
+ConfigBootSource parse_config_boot_source(const std::string& config_opt, const std::string& db_opt,
+                                          const std::string& config_source_opt) {
+    if (config_opt.empty() and db_opt.empty()) {
+        // no config or db option given, use default
+        return ConfigBootSource::YamlFile;
+    }
+    if (!config_opt.empty() && !db_opt.empty()) {
+        if (config_source_opt.empty()) {
+            throw BootException(
+                "Both config and db options are set, but no source option is given. "
+                "Please specify the source of the config (yaml, db or db_fallback_yaml) with --source.");
+        }
+        if (config_source_opt == "yaml") {
+            return ConfigBootSource::YamlFile;
+        } else if (config_source_opt == "db") {
+            return ConfigBootSource::Database;
+        } else if (config_source_opt == "db_fallback_yaml") {
+            // use database, but fall back to yaml if database is not initialized or valid
+            return ConfigBootSource::DatabaseFallbackYaml;
+        } else {
+            throw BootException(fmt::format("Invalid source option: {}. Expected 'yaml', 'db' or 'db_fallback_yaml'.",
+                                            config_source_opt));
+        }
+    }
+    if (!config_opt.empty()) {
+        // only config option given, use yaml file
+        return ConfigBootSource::YamlFile;
+    }
+    if (!db_opt.empty()) {
+        // only db option given, use database
+        return ConfigBootSource::Database;
+    }
+}
+
 int boot(const po::variables_map& vm) {
     const bool check = (vm.count("check") != 0);
 
     const auto prefix_opt = parse_string_option(vm, "prefix");
     const auto config_opt = parse_string_option(vm, "config");
+    const auto db_opt = parse_string_option(vm, "db");
+    const auto config_source_opt = parse_string_option(vm, "source");
+    ConfigBootSource boot_source = parse_config_boot_source(config_opt, db_opt, config_source_opt);
 
-    const auto ms = ManagerSettings(prefix_opt, config_opt);
+    ManagerSettings ms;
+
+    switch (boot_source) {
+    case ConfigBootSource::YamlFile:
+        ms = ManagerSettings(prefix_opt, config_opt);
+        break;
+    case ConfigBootSource::Database:
+        ms = ManagerSettings(db_opt);
+        break;
+    case ConfigBootSource::DatabaseFallbackYaml:
+        ms = ManagerSettings(prefix_opt, config_opt, db_opt);
+        break;
+    default:
+        throw BootException(fmt::format("Invalid boot source: {}", static_cast<int>(boot_source)));
+    }
 
     Logging::init(ms.runtime_settings.logging_config_file.string());
 
@@ -852,6 +903,9 @@ int main(int argc, char* argv[]) {
     desc.add_options()("config", po::value<std::string>(),
                        "Full path to a config file.  If the file does not exist and has no extension, it will be "
                        "looked up in the default config directory");
+    desc.add_options()("db", po::value<std::string>(), "Full path to the configuration database file");
+    desc.add_options()("source", po::value<std::string>(),
+                       "Source from which the configuration shall be loaded, either 'config' or 'db'");
     desc.add_options()("status-fifo", po::value<std::string>()->default_value(""),
                        "Path to a named pipe, that shall be used for status updates from the manager");
     desc.add_options()("retain-topics", "Retain configuration MQTT topics setup by manager for inspection, by default "


### PR DESCRIPTION
Add boot source selection logic for config and database inputs to manager process:
- Introduce ConfigBootSource enum to represent boot origin
- Add CLI options: --db and --source (yaml, db, db_fallback_yaml)
- Implement boot source resolution
- Add ManagerSettings constructors for all boot source types (some not yet supported)
- Include PlantUML diagram documenting boot logic

The actual usage of the new CLI options to add database support is done within https://github.com/EVerest/everest-framework/pull/267 , which shall follow up on this PR.