### PR TITLE
Add defaults for datatype and mutability, remove Path datatype

### DIFF
--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -113,6 +113,7 @@ enum class Mutability {
 };
 
 enum class Datatype {
+    Unknown,
     String,
     Decimal,
     Integer,

--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -100,7 +100,7 @@ struct ConfigurationParameter;
 struct ModuleConfig;
 using ModuleId = std::string;
 using RequirementId = std::string;
-using ConfigEntry = std::variant<std::string, bool, int, double, fs::path>;
+using ConfigEntry = std::variant<std::string, bool, int, double>;
 using ImplementationIdentifier = std::string;
 using ModuleConnections = std::map<RequirementId, std::vector<Fulfillment>>;
 using ModuleConfigurations = std::map<ModuleId, ModuleConfig>;
@@ -116,8 +116,7 @@ enum class Datatype {
     String,
     Decimal,
     Integer,
-    Boolean,
-    Path
+    Boolean
 };
 
 struct Settings {

--- a/include/utils/config/types.hpp
+++ b/include/utils/config/types.hpp
@@ -147,8 +147,8 @@ struct Settings {
 /// \brief Struct that contains the characteristics of a configuration parameter including its datatype, mutability and
 /// unit
 struct ConfigurationParameterCharacteristics {
-    Datatype datatype;
-    Mutability mutability;
+    Datatype datatype = Datatype::Unknown;
+    Mutability mutability = Mutability::ReadOnly;
     std::optional<std::string> unit;
 };
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -15,6 +15,7 @@
 
 #include <framework/runtime.hpp>
 #include <utils/config.hpp>
+#include <utils/config/types.hpp>
 #include <utils/formatter.hpp>
 #include <utils/yaml_loader.hpp>
 
@@ -197,8 +198,19 @@ static ParsedConfigMap parse_config_map(const json& config_map_schema,
 
         json config_entry_value;
         if (config_parameter_map.find(config_entry_name) != config_parameter_map.end()) {
-            config_parameter_map[config_entry_name].characteristics.datatype =
-                string_to_datatype(config_entry.at("type"));
+            const auto& expected_datatype = config_parameter_map.at(config_entry_name).characteristics.datatype;
+            const auto& actual_datatype = string_to_datatype(config_entry.at("type"));
+            if (expected_datatype != actual_datatype) {
+                // allow discrepancy when expected datatype is Integer but the actual datatype is Decimal which can
+                // present as Integer in the json representation
+                if (not(expected_datatype == Datatype::Integer and actual_datatype == Datatype::Decimal)) {
+                    throw ConfigParseException(
+                        ConfigParseException::SCHEMA, config_entry_name,
+                        "Expected and actualy datatypes disagree: " + datatype_to_string(expected_datatype) + " vs " +
+                            datatype_to_string(actual_datatype));
+                }
+            }
+            config_parameter_map[config_entry_name].characteristics.datatype = actual_datatype;
 
             config_entry_value = config_parameter_map[config_entry_name].value; // implicit conversion to json
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -239,9 +239,6 @@ static ParsedConfigMap parse_config_map(const json& config_map_schema,
         case Datatype::Boolean:
             config_param.value = config_entry_value.get<bool>();
             break;
-        case Datatype::Path:
-            config_param.value = std::filesystem::path(config_entry_value.get<std::string>());
-            break;
         default:
             throw ConfigParseException(ConfigParseException::SCHEMA, config_entry_name,
                                        "Unsupported datatype in config: " + config_entry.at("type").get<std::string>());

--- a/lib/config/sqlite_storage.cpp
+++ b/lib/config/sqlite_storage.cpp
@@ -119,8 +119,6 @@ GenericResponseStatus SqliteStorage::write_module_configs(const ModuleConfigurat
                     std::string value;
                     if (std::holds_alternative<std::string>(param.value)) {
                         value = std::get<std::string>(param.value);
-                    } else if (std::holds_alternative<fs::path>(param.value)) {
-                        value = std::get<fs::path>(param.value).string();
                     } else {
                         const nlohmann::json temp = param.value;
                         value = temp.dump();

--- a/lib/config/types.cpp
+++ b/lib/config/types.cpp
@@ -116,7 +116,6 @@ ModuleConfigurationParameters parse_config_parameters(const json& config_json) {
         ConfigurationParameter param;
         param.name = name;
 
-        // we cant parse to fs::path
         if (jval.is_string()) {
             param.value = jval.get<std::string>();
         } else if (jval.is_boolean()) {
@@ -211,8 +210,6 @@ ConfigEntry parse_config_value(Datatype datatype, const std::string& value_str) 
             return std::stoi(value_str);
         case Datatype::Boolean:
             return value_str == "true" || value_str == "1";
-        case Datatype::Path:
-            return std::filesystem::path(value_str);
         default:
             throw std::out_of_range("Unsupported datatype: " + datatype_to_string(datatype));
         }
@@ -273,8 +270,6 @@ Datatype string_to_datatype(const std::string& str) {
         return Datatype::Integer;
     } else if (str == "boolean" or "bool") {
         return Datatype::Boolean;
-    } else if (str == "path") {
-        return Datatype::Path;
     }
     throw std::out_of_range("Could not convert: " + str + " to Datatype");
 }
@@ -289,8 +284,6 @@ std::string datatype_to_string(const Datatype datatype) {
         return "integer";
     case Datatype::Boolean:
         return "bool";
-    case Datatype::Path:
-        return "path";
     }
     throw std::out_of_range("Could not convert Datatype to string");
 }

--- a/lib/config/types.cpp
+++ b/lib/config/types.cpp
@@ -275,6 +275,8 @@ Datatype string_to_datatype(const std::string& str) {
         return Datatype::Integer;
     } else if (str == "boolean" or "bool") {
         return Datatype::Boolean;
+    } else if (str == "unknown") {
+        return Datatype::Unknown;
     }
     throw std::out_of_range("Could not convert: " + str + " to Datatype");
 }
@@ -289,6 +291,8 @@ std::string datatype_to_string(const Datatype datatype) {
         return "integer";
     case Datatype::Boolean:
         return "bool";
+    case Datatype::Unknown:
+        return "unknown";
     }
     throw std::out_of_range("Could not convert Datatype to string");
 }

--- a/lib/config/types.cpp
+++ b/lib/config/types.cpp
@@ -115,15 +115,20 @@ ModuleConfigurationParameters parse_config_parameters(const json& config_json) {
     auto parse_entry = [](const std::string& name, const json& jval) -> ConfigurationParameter {
         ConfigurationParameter param;
         param.name = name;
+        param.characteristics.mutability = Mutability::ReadOnly;
 
         if (jval.is_string()) {
             param.value = jval.get<std::string>();
+            param.characteristics.datatype = Datatype::String;
         } else if (jval.is_boolean()) {
             param.value = jval.get<bool>();
+            param.characteristics.datatype = Datatype::Boolean;
         } else if (jval.is_number_integer()) {
             param.value = jval.get<int>();
+            param.characteristics.datatype = Datatype::Integer;
         } else if (jval.is_number_float()) {
             param.value = jval.get<double>();
+            param.characteristics.datatype = Datatype::Decimal;
         } else {
             throw std::runtime_error("Unsupported JSON type for config parameter: " + name);
         }

--- a/tests/test_config_sqlite.cpp
+++ b/tests/test_config_sqlite.cpp
@@ -46,10 +46,6 @@ std::map<ModuleId, ModuleConfig> get_example_module_configs() {
     characteristics2.datatype = Datatype::String;
     characteristics2.mutability = Mutability::ReadOnly;
 
-    ConfigurationParameterCharacteristics characteristics3;
-    characteristics3.datatype = Datatype::Path;
-    characteristics3.mutability = Mutability::ReadWrite;
-
     ConfigurationParameterCharacteristics characteristics4;
     characteristics4.datatype = Datatype::Decimal;
     characteristics4.mutability = Mutability::ReadWrite;
@@ -68,11 +64,6 @@ std::map<ModuleId, ModuleConfig> get_example_module_configs() {
     param2.value = std::string("example_value");
     param2.characteristics = characteristics2;
 
-    ConfigurationParameter param3;
-    param3.name = "path_param";
-    param3.value = fs::path("/example/path");
-    param3.characteristics = characteristics3;
-
     ConfigurationParameter param4;
     param4.name = "decimal_param";
     param4.value = 42.23;
@@ -85,7 +76,6 @@ std::map<ModuleId, ModuleConfig> get_example_module_configs() {
 
     module_config.configuration_parameters["!module"].push_back({param1});
     module_config.configuration_parameters["implementation_id1"].push_back({param2});
-    module_config.configuration_parameters["!module"].push_back({param3});
     module_config.configuration_parameters["!module"].push_back({param4});
     module_config.configuration_parameters["!module"].push_back({param5});
 
@@ -156,11 +146,6 @@ TEST_CASE("Database operations", "[db_operation]") {
         REQUIRE(response2.status == GetSetResponseStatus::OK);
         REQUIRE(response2.configuration_parameter.has_value());
         REQUIRE(std::get<std::string>(response2.configuration_parameter.value().value) == "example_value");
-
-        auto response3 = storage.get_configuration_parameter({"example_module", "path_param"});
-        REQUIRE(response3.status == GetSetResponseStatus::OK);
-        REQUIRE(response3.configuration_parameter.has_value());
-        REQUIRE(std::get<fs::path>(response3.configuration_parameter.value().value) == fs::path("/example/path"));
 
         auto response4 = storage.get_configuration_parameter({"example_module", "decimal_param"});
         REQUIRE(response4.status == GetSetResponseStatus::OK);


### PR DESCRIPTION
Add defaults for datatype and mutability of characteristics

Remove Path datatype since it is not used or needed

Throw a ConfigParse exception if the expected and actual datatype isn't compatible