### PR TITLE
Use liblog v0.3.0 to be able to reinitialize logging

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -330,7 +330,7 @@
   "moduleExtensions": {
     "//third-party/bazel:extension.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "pFkcrVXBqlZcOtKIyE0iYM3f7wDInJ/8tl8VepyYUJo=",
+        "bzlTransitiveDigest": "KqRJF0V3CDs8x0DqeyMqrqrCFu/rDCHgShcHW8W2Z+M=",
         "usagesDigest": "mQBUTHwmYvpx9LXR0YDe9XRgPEQ0dNm3VJnQlmnE4Tw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -339,9 +339,9 @@
           "com_github_everest_liblog": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/EVerest/liblog/archive/763a56a4bf194e7cf1cab7446e993c376ce933fa.tar.gz",
-              "sha256": "6d1f4238f8984cbe0dea9d7bc2c3771ca803387b5215a2b42df0c850bd561770",
-              "strip_prefix": "liblog-763a56a4bf194e7cf1cab7446e993c376ce933fa",
+              "url": "https://github.com/EVerest/liblog/archive/08ff519b647beaa51f8f25ab04b88c079ca253a7.tar.gz",
+              "sha256": "32c5e419e63bffd094dcdf13adf9da7db1942029d575e7ace7559a434da967f5",
+              "strip_prefix": "liblog-08ff519b647beaa51f8f25ab04b88c079ca253a7",
               "build_file": "@@//third-party/bazel:BUILD.liblog.bazel"
             }
           },

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -48,7 +48,7 @@ mqttc:
   options: ["MQTT_C_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 liblog:
   git: https://github.com/EVerest/liblog.git
-  git_tag: 68d62d6f87067de895b212815d61614d989054e2 # FIXME: v0.3.0
+  git_tag: v0.3.0
   options: ["BUILD_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libfmt:
   git: https://github.com/fmtlib/fmt.git

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -48,7 +48,7 @@ mqttc:
   options: ["MQTT_C_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 liblog:
   git: https://github.com/EVerest/liblog.git
-  git_tag: v0.2.3
+  git_tag: 68d62d6f87067de895b212815d61614d989054e2 # FIXME: v0.3.0
   options: ["BUILD_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libfmt:
   git: https://github.com/fmtlib/fmt.git

--- a/lib/config/sqlite_storage.cpp
+++ b/lib/config/sqlite_storage.cpp
@@ -44,6 +44,10 @@ enum SettingColumnIndex {
 };
 
 SqliteStorage::SqliteStorage(const fs::path& db_path, const std::filesystem::path& migration_files_path) {
+    if (db_path.parent_path().empty()) {
+        throw std::runtime_error("Could not open database at provided path: " + db_path.string() +
+                                 " because it is just a filename. You MUST provide a full path to the database.");
+    }
     db = std::make_unique<Connection>(db_path);
 
     SchemaUpdater updater{db.get()};

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -81,7 +81,7 @@ ManagerSettings::ManagerSettings(const std::string& prefix_, const std::string& 
 
     everest::config::Settings settings;
     if (this->storage->contains_valid_config()) {
-        EVLOG_info << "Booting and parsing configuration from database: " << db_dir;
+        EVLOG_info << "Booting and parsing configuration from database: " << db_;
         const auto settings_response = this->storage->get_settings();
         if (settings_response.status != everest::config::GenericResponseStatus::OK or
             !settings_response.settings.has_value()) {

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -903,6 +903,11 @@ int main(int argc, char* argv[]) {
     po::variables_map vm;
 
     try {
+        const auto default_logging_cfg =
+            defaults::PREFIX / fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE / defaults::LOGGING_CONFIG_NAME;
+        if (fs::exists(default_logging_cfg)) {
+            Logging::init(default_logging_cfg.string());
+        }
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
 

--- a/third-party/bazel/extension.bzl
+++ b/third-party/bazel/extension.bzl
@@ -7,9 +7,9 @@ def _deps_impl(module_ctx):
     maybe(
         http_archive,
         name = "com_github_everest_liblog",
-        url = "https://github.com/EVerest/liblog/archive/763a56a4bf194e7cf1cab7446e993c376ce933fa.tar.gz",
-        sha256 = "6d1f4238f8984cbe0dea9d7bc2c3771ca803387b5215a2b42df0c850bd561770",
-        strip_prefix = "liblog-763a56a4bf194e7cf1cab7446e993c376ce933fa",
+        url = "https://github.com/EVerest/liblog/archive/08ff519b647beaa51f8f25ab04b88c079ca253a7.tar.gz",
+        sha256 = "32c5e419e63bffd094dcdf13adf9da7db1942029d575e7ace7559a434da967f5",
+        strip_prefix = "liblog-08ff519b647beaa51f8f25ab04b88c079ca253a7",
         build_file = "@everest-framework//third-party/bazel:BUILD.liblog.bazel",
     )
 


### PR DESCRIPTION
- Initialize logging with default logging config as early as possible to not miss potential error messages from everest-sqlite during startup
- Fix log of used database path instead of empty db_dir
- Throw a runtime error when the database path that is provided is just a filename
  This would lead to a more cryptic error in everest-sqlite further down the line, so better fail early with a better error message