### PR TITLE
Enable position independent code

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -90,3 +90,8 @@ target_compile_definitions(framework
     PRIVATE
         TARGET_MIGRATION_FILE_VERSION=${TARGET_MIGRATION_FILE_VERSION}
 )
+
+set_target_properties(framework
+    PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+)


### PR DESCRIPTION
Noticed during yocto builds for arm32 that there's a QA issue raised `libframework.so.0.22.1 has relocations in .text [textrel]` which can be traced back to everest-sqlite (and everest-framework) not being built with position independent code turned on. This can also prevent EVerest from starting with a `error while loading shared libraries libframework.so: unexpected reloc type 0x03` error