### PR TITLE
Update dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,13 +35,13 @@ bazel_dep(name = "boringssl", version = "0.20250311.0")
 
 bazel_dep(name = "fast_float", version = "6.1.6")
 
-bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1", repo_name = "com_github_nlohmann_json")
+bazel_dep(name = "nlohmann_json", version = "3.12.0", repo_name = "com_github_nlohmann_json")
 
 bazel_dep(name = "cxx.rs", version = "1.0.153")
 
 bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
 
-bazel_dep(name = "fmt", version = "11.1.4", repo_name = "com_github_fmtlib_fmt")
+bazel_dep(name = "fmt", version = "11.2.0", repo_name = "com_github_fmtlib_fmt")
 
 bazel_dep(name = "sqlite3", version = "3.49.1")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -330,7 +330,7 @@
   "moduleExtensions": {
     "//third-party/bazel:extension.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "zd3HnxVPW2gTrGZrvfJjBzNUkmMVZ5Maidu7lWFbhlo=",
+        "bzlTransitiveDigest": "08BcSSvkleXJcqKiiT+yoRjGuGHRLqUPHmKh8EboC7E=",
         "usagesDigest": "VLNusaMRWHKnI205PAwcEGNqRx+F2hCoArtOzpx5/eI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -402,9 +402,9 @@
           "com_github_warmcatt_libwebsockets": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
-              "sha256": "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
-              "strip_prefix": "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
+              "url": "https://github.com/warmcat/libwebsockets/archive/e83ed4eb88b77039d69189327482263f6fdf5fef.tar.gz",
+              "sha256": "d0a4029a2b7b557a386eb74883c1d88e15a020168c805769ab326000f2fe40fa",
+              "strip_prefix": "libwebsockets-e83ed4eb88b77039d69189327482263f6fdf5fef",
               "build_file": "@@//third-party/bazel:BUILD.libwebsockets.bazel"
             }
           },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -195,8 +195,8 @@
     "https://bcr.bazel.build/modules/cxx.rs/1.0.153/source.json": "57d60d29083232dd4d8f65d33039d57f679297e1cb46a80a2783da136966ee8c",
     "https://bcr.bazel.build/modules/fast_float/6.1.6/MODULE.bazel": "5156fe100c2e05fa248b2658d28c2194393fec181d4cc444cbc51ec7425270f3",
     "https://bcr.bazel.build/modules/fast_float/6.1.6/source.json": "51517fe7906dca1c57ade9753fd3fb36af0bee612830aaebc2fe560b6a10b626",
-    "https://bcr.bazel.build/modules/fmt/11.1.4/MODULE.bazel": "514019a3848f2764cc7aba3f388cd2f54d5d8c6249ddd33a143f37da9ebe66a4",
-    "https://bcr.bazel.build/modules/fmt/11.1.4/source.json": "94756c79709d889323996650a371bbad133a0628e54de3cae229e99275abfc9e",
+    "https://bcr.bazel.build/modules/fmt/11.2.0/MODULE.bazel": "bb2cef47f22163e23aa39ff7812cfe8cec85adb6337493fe38d1fa039133ca5c",
+    "https://bcr.bazel.build/modules/fmt/11.2.0/source.json": "a2c3846c868dbb75e3793e14c7bb9afbb0e34d3967c9a22b335df71eb2ff1481",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -207,8 +207,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.11.3.bcr.1/MODULE.bazel": "83bbe365b1eb640ef903df2240f11e7df8f70563199bc17085816033bc36da89",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.11.3.bcr.1/source.json": "7b0b57c1a789dd0b81b8e6f639f36f96a6f4534c2f2ed4430118af6769b00cdf",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.12.0/MODULE.bazel": "21f19a4479e994c1546cf6f10c65d2fa464cd95f49eebad98dc5bac49c801dab",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.12.0/source.json": "6bf17b358c467effad70c02ab43e2d65939d740f667157397f583435909cfae1",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
@@ -330,7 +330,7 @@
   "moduleExtensions": {
     "//third-party/bazel:extension.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "sNa+Zed1qJQQj1lk8pT7lGvsNi/G6UlStcjUdB5ZhXo=",
+        "bzlTransitiveDigest": "zd3HnxVPW2gTrGZrvfJjBzNUkmMVZ5Maidu7lWFbhlo=",
         "usagesDigest": "VLNusaMRWHKnI205PAwcEGNqRx+F2hCoArtOzpx5/eI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -366,45 +366,45 @@
           "com_github_HowardHinnant_date": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/HowardHinnant/date/archive/2ef74cb41a31dcd03b39dd5e9bf8b340669f48a4.tar.gz",
-              "sha256": "3446ad7e2ba07c9105769bf6fd9b521d4e3a2f2dd0a955643a20f4adb1870efa",
-              "strip_prefix": "date-2ef74cb41a31dcd03b39dd5e9bf8b340669f48a4",
+              "url": "https://github.com/HowardHinnant/date/archive/f94b8f36c6180be0021876c4a397a054fe50c6f2.tar.gz",
+              "sha256": "8be4c3a52d99b22a4478ce3e2a23fa4b38587ea3d3bc3d1a4d68de22c2e65fb2",
+              "strip_prefix": "date-f94b8f36c6180be0021876c4a397a054fe50c6f2",
               "build_file": "@@//third-party/bazel:BUILD.date.bazel"
             }
           },
           "com_github_biojppm_rapidyaml": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/biojppm/rapidyaml/archive/213b201d264139cd1b887790197e08850af628e3.tar.gz",
-              "sha256": "c206d4565ccfa721991a8df90821d1a1f747e68385a0f3f5b9ab995e191c06be",
-              "strip_prefix": "rapidyaml-213b201d264139cd1b887790197e08850af628e3",
+              "url": "https://github.com/biojppm/rapidyaml/archive/47ec2fa184209687c20fd5bc05621e1cb1200311.tar.gz",
+              "sha256": "4edd856d8ced361b80286cde8de40488bb268756b137add912616210a28c2744",
+              "strip_prefix": "rapidyaml-47ec2fa184209687c20fd5bc05621e1cb1200311",
               "build_file": "@@//third-party/bazel:BUILD.rapidyaml.bazel"
             }
           },
           "com_github_biojppm_c4core": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/biojppm/c4core/archive/d35c7c9bf370134595699d791e6ff8db018ddc8d.tar.gz",
-              "sha256": "b768c8fb5dd4740317b7e1a3e43a0b32615d4d4e1e974d7ab515a80d2f1f318d",
-              "strip_prefix": "c4core-d35c7c9bf370134595699d791e6ff8db018ddc8d",
+              "url": "https://github.com/biojppm/c4core/archive/7eb1f39d8c08fb98c089ec6c6ab77e7dc01c991e.tar.gz",
+              "sha256": "904c1bc6dc178ebe9a581f4d7add48bf7c27310dcc9c7d3686ef4bbe0e0be577",
+              "strip_prefix": "c4core-7eb1f39d8c08fb98c089ec6c6ab77e7dc01c991e",
               "build_file": "@@//third-party/bazel:BUILD.c4core.bazel"
             }
           },
           "com_github_biojppm_debugbreak": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/biojppm/debugbreak/archive/5dcbe41d2bd4712c8014aa7e843723ad7b40fd74.tar.gz",
-              "sha256": "4b424d23dad957937c57c142648d32571a78a6c6b2e473709748e5c1bb8a0f92",
-              "strip_prefix": "debugbreak-5dcbe41d2bd4712c8014aa7e843723ad7b40fd74",
+              "url": "https://github.com/biojppm/debugbreak/archive/328e4abca3384cbd0a69e70f263cc7b2794bff09.tar.gz",
+              "sha256": "e90bc63f50e516af1a65991ffa0410fd2698fd0936041f387824b2114e72a549",
+              "strip_prefix": "debugbreak-328e4abca3384cbd0a69e70f263cc7b2794bff09",
               "build_file": "@@//third-party/bazel:BUILD.debugbreak.bazel"
             }
           },
           "com_github_warmcatt_libwebsockets": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/warmcat/libwebsockets/archive/b0a749c8e7a8294b68581ce4feac0e55045eb00b.tar.gz",
-              "sha256": "5c3d6d482e73a0c105f3f14ce9b03c27b5d51c3938f8483b7eb8e6d535baa25f",
-              "strip_prefix": "libwebsockets-b0a749c8e7a8294b68581ce4feac0e55045eb00b",
+              "url": "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
+              "sha256": "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
+              "strip_prefix": "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
               "build_file": "@@//third-party/bazel:BUILD.libwebsockets.bazel"
             }
           },

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,11 +1,11 @@
 ---
 ryml:
   git: https://github.com/biojppm/rapidyaml
-  git_tag: v0.4.1
+  git_tag: v0.9.0
   options: ["CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
-  git_tag: v4.3.3
+  git_tag: v4.4.1
   cmake_condition: "EVEREST_ENABLE_ADMIN_PANEL_BACKEND"
   options:
     - CMAKE_POLICY_DEFAULT_CMP0077 NEW
@@ -30,7 +30,7 @@ libwebsockets:
     - LWS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR}
 nlohmann_json:
   git: https://github.com/nlohmann/json
-  git_tag: v3.11.2
+  git_tag: v3.12.0
   options: ["JSON_BuildTests OFF", "JSON_MultipleHeaders ON"]
 nlohmann_json_schema_validator:
   git: https://github.com/pboettch/json-schema-validator
@@ -52,12 +52,12 @@ liblog:
   options: ["BUILD_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libfmt:
   git: https://github.com/fmtlib/fmt.git
-  git_tag: 10.1.0
+  git_tag: 11.2.0
   options:
     ["FMT_TEST OFF", "FMT_DOC OFF", "BUILD_SHARED_LIBS ON", "FMT_INSTALL ON"]
 date:
   git: https://github.com/HowardHinnant/date.git
-  git_tag: v3.0.1
+  git_tag: v3.0.4
   options:
     [
       "BUILD_TZ_LIB ON",
@@ -68,15 +68,15 @@ date:
     ]
 catch2:
   git: https://github.com/catchorg/Catch2.git
-  git_tag: v3.7.1
+  git_tag: v3.9.0
   cmake_condition: "EVEREST_FRAMEWORK_BUILD_TESTING"
 pybind11:
   git: https://github.com/pybind/pybind11.git
-  git_tag: v2.11.1
+  git_tag: v2.13.6
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT"
 pybind11_json:
   git: https://github.com/pybind/pybind11_json.git
-  git_tag: 0.2.13
+  git_tag: 0.2.15
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT"
 everest-sqlite:
   git: https://github.com/EVerest/everest-sqlite.git

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -5,9 +5,10 @@ ryml:
   options: ["CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
-  git_tag: v4.4.1
+  git_tag: v4.3.6
   cmake_condition: "EVEREST_ENABLE_ADMIN_PANEL_BACKEND"
   options:
+    - CMAKE_POLICY_VERSION_MINIMUM 3.5
     - CMAKE_POLICY_DEFAULT_CMP0077 NEW
     - LWS_ROLE_RAW_FILE OFF
     - LWS_UNIX_SOCK OFF

--- a/lib/yaml_loader.cpp
+++ b/lib/yaml_loader.cpp
@@ -45,7 +45,7 @@ struct RymlCallbackInitializer {
 
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion): recursive parsing preferred for simplicity
-nlohmann::ordered_json ryml_to_nlohmann_json(const c4::yml::NodeRef& ryml_node) {
+nlohmann::ordered_json ryml_to_nlohmann_json(const c4::yml::ConstNodeRef& ryml_node) {
     if (ryml_node.is_map()) {
         // handle object
         auto object = nlohmann::ordered_json::object();

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -136,9 +136,15 @@ lws_http_mount Server::Impl::mount = {
     0,            // unsigned int cache_reusable:1; /**< set if client cache may reuse this */
     0,            // unsigned int cache_revalidate:1; /**< set if client cache should revalidate on use */
     0,            // unsigned int cache_intermediaries:1; /**< set if intermediaries are allowed to cache */
+    0,            // unsigned int cache_no:1; /**< set if client should check cache always */
     LWSMPRO_FILE, // unsigned char origin_protocol; /**< one of enum lws_mount_protocols */
     1,            // unsigned char mountpoint_len; /**< length of mountpoint string */
     nullptr,      // const char *basic_auth_login_file;
+    nullptr,      // const char *cgi_chroot_path;
+    nullptr,      // const char *cgi_wd;
+    nullptr,      // const struct lws_protocol_vhost_options *headers;
+    0, // unsigned int keepalive_timeout; /**< 0 or seconds http stream should stay alive while idle. 0 means use the
+       // vhost value for keepalive_timeout.  */
 };
 
 int Server::Impl::callback(struct lws* wsi, lws_callback_reasons reason, void* user, void* in, std::size_t len) {

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -136,15 +136,9 @@ lws_http_mount Server::Impl::mount = {
     0,            // unsigned int cache_reusable:1; /**< set if client cache may reuse this */
     0,            // unsigned int cache_revalidate:1; /**< set if client cache should revalidate on use */
     0,            // unsigned int cache_intermediaries:1; /**< set if intermediaries are allowed to cache */
-    0,            // unsigned int cache_no:1; /**< set if client should check cache always */
     LWSMPRO_FILE, // unsigned char origin_protocol; /**< one of enum lws_mount_protocols */
     1,            // unsigned char mountpoint_len; /**< length of mountpoint string */
     nullptr,      // const char *basic_auth_login_file;
-    nullptr,      // const char *cgi_chroot_path;
-    nullptr,      // const char *cgi_wd;
-    nullptr,      // const struct lws_protocol_vhost_options *headers;
-    0, // unsigned int keepalive_timeout; /**< 0 or seconds http stream should stay alive while idle. 0 means use the
-       // vhost value for keepalive_timeout.  */
 };
 
 int Server::Impl::callback(struct lws* wsi, lws_callback_reasons reason, void* user, void* in, std::size_t len) {

--- a/src/controller/transpile_config.cpp
+++ b/src/controller/transpile_config.cpp
@@ -12,13 +12,22 @@ namespace {
 void clear_quote_flags(ryml::NodeRef& root) {
     if (root.has_key()) {
         // Remove quotes from key
-        root.tree()->_rem_flags(root.id(), ryml::KEYQUO);
+        if (root.tree()->type_has_any(root.id(), ryml::KEYQUO)) {
+            root.tree()->_rem_flags(root.id(), ryml::KEYQUO);
+        }
+        if (root.key().find('-') != ryml::csubstr::npos) {
+            root.tree()->_add_flags(root.id(), ryml::KEY_SQUO);
+        }
     }
     if (root.has_val()) {
         if (root.val().has_str() && root.val() != "") {
             root.tree()->_rem_flags(root.id(), ryml::VALQUO);
         }
+        if (root.val().empty()) {
+            root.tree()->_add_flags(root.id(), ryml::VAL_SQUO);
+        }
     }
+    root.tree()->_rem_flags(root.id(), ryml::NodeType_e::FLOW_SL);
 
     for (auto child : root.children()) {
         clear_quote_flags(child);
@@ -28,7 +37,7 @@ void clear_quote_flags(ryml::NodeRef& root) {
 
 c4::yml::Tree transpile_config(const nlohmann::json& config_json) {
     const auto json_serialized = config_json.dump();
-    auto ryml_deserialized = ryml::parse_in_arena(ryml::to_csubstr(json_serialized));
+    auto ryml_deserialized = ryml::parse_json_in_arena(ryml::to_csubstr(json_serialized));
     auto root = ryml_deserialized.rootref();
     clear_quote_flags(root);
     return ryml_deserialized;

--- a/third-party/bazel/BUILD.libwebsockets.bazel
+++ b/third-party/bazel/BUILD.libwebsockets.bazel
@@ -2,7 +2,16 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "all_srcs",
-    srcs = glob(["**"]),
+    srcs = [
+        "CMakeLists.txt",
+        "CMakeLists-implied-options.txt",
+    ] + glob([
+        "cmake/**",
+        "include/**",
+        "lib/**",
+        "lwsws/**",
+        "plugins/**",
+    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/third-party/bazel/extension.bzl
+++ b/third-party/bazel/extension.bzl
@@ -34,45 +34,45 @@ def _deps_impl(module_ctx):
     maybe(
         http_archive,
         name = "com_github_HowardHinnant_date",
-        url = "https://github.com/HowardHinnant/date/archive/2ef74cb41a31dcd03b39dd5e9bf8b340669f48a4.tar.gz",
-        sha256 = "3446ad7e2ba07c9105769bf6fd9b521d4e3a2f2dd0a955643a20f4adb1870efa",
-        strip_prefix = "date-2ef74cb41a31dcd03b39dd5e9bf8b340669f48a4",
+        url = "https://github.com/HowardHinnant/date/archive/f94b8f36c6180be0021876c4a397a054fe50c6f2.tar.gz",
+        sha256 = "8be4c3a52d99b22a4478ce3e2a23fa4b38587ea3d3bc3d1a4d68de22c2e65fb2",
+        strip_prefix = "date-f94b8f36c6180be0021876c4a397a054fe50c6f2",
         build_file = "@everest-framework//third-party/bazel:BUILD.date.bazel",
     )
 
     maybe(
         http_archive,
         name = "com_github_biojppm_rapidyaml",
-        url = "https://github.com/biojppm/rapidyaml/archive/213b201d264139cd1b887790197e08850af628e3.tar.gz",
-        sha256 = "c206d4565ccfa721991a8df90821d1a1f747e68385a0f3f5b9ab995e191c06be",
-        strip_prefix = "rapidyaml-213b201d264139cd1b887790197e08850af628e3",
+        url = "https://github.com/biojppm/rapidyaml/archive/47ec2fa184209687c20fd5bc05621e1cb1200311.tar.gz",
+        sha256 = "4edd856d8ced361b80286cde8de40488bb268756b137add912616210a28c2744",
+        strip_prefix = "rapidyaml-47ec2fa184209687c20fd5bc05621e1cb1200311",
         build_file = "@everest-framework//third-party/bazel:BUILD.rapidyaml.bazel",
     )
 
     maybe(
         http_archive,
         name = "com_github_biojppm_c4core",
-        url = "https://github.com/biojppm/c4core/archive/d35c7c9bf370134595699d791e6ff8db018ddc8d.tar.gz",
-        sha256 = "b768c8fb5dd4740317b7e1a3e43a0b32615d4d4e1e974d7ab515a80d2f1f318d",
-        strip_prefix = "c4core-d35c7c9bf370134595699d791e6ff8db018ddc8d",
+        url = "https://github.com/biojppm/c4core/archive/7eb1f39d8c08fb98c089ec6c6ab77e7dc01c991e.tar.gz",
+        sha256 = "904c1bc6dc178ebe9a581f4d7add48bf7c27310dcc9c7d3686ef4bbe0e0be577",
+        strip_prefix = "c4core-7eb1f39d8c08fb98c089ec6c6ab77e7dc01c991e",
         build_file = "@everest-framework//third-party/bazel:BUILD.c4core.bazel",
     )
 
     maybe(
         http_archive,
         name = "com_github_biojppm_debugbreak",
-        url = "https://github.com/biojppm/debugbreak/archive/5dcbe41d2bd4712c8014aa7e843723ad7b40fd74.tar.gz",
-        sha256 = "4b424d23dad957937c57c142648d32571a78a6c6b2e473709748e5c1bb8a0f92",
-        strip_prefix = "debugbreak-5dcbe41d2bd4712c8014aa7e843723ad7b40fd74",
+        url = "https://github.com/biojppm/debugbreak/archive/328e4abca3384cbd0a69e70f263cc7b2794bff09.tar.gz",
+        sha256 = "e90bc63f50e516af1a65991ffa0410fd2698fd0936041f387824b2114e72a549",
+        strip_prefix = "debugbreak-328e4abca3384cbd0a69e70f263cc7b2794bff09",
         build_file = "@everest-framework//third-party/bazel:BUILD.debugbreak.bazel",
     )
 
     maybe(
         http_archive,
         name = "com_github_warmcatt_libwebsockets",
-        url = "https://github.com/warmcat/libwebsockets/archive/b0a749c8e7a8294b68581ce4feac0e55045eb00b.tar.gz",
-        sha256 = "5c3d6d482e73a0c105f3f14ce9b03c27b5d51c3938f8483b7eb8e6d535baa25f",
-        strip_prefix = "libwebsockets-b0a749c8e7a8294b68581ce4feac0e55045eb00b",
+        url = "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
+        sha256 = "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
+        strip_prefix = "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
         build_file = "@everest-framework//third-party/bazel:BUILD.libwebsockets.bazel",
     )
 

--- a/third-party/bazel/extension.bzl
+++ b/third-party/bazel/extension.bzl
@@ -70,9 +70,9 @@ def _deps_impl(module_ctx):
     maybe(
         http_archive,
         name = "com_github_warmcatt_libwebsockets",
-        url = "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
-        sha256 = "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
-        strip_prefix = "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
+        url = "https://github.com/warmcat/libwebsockets/archive/e83ed4eb88b77039d69189327482263f6fdf5fef.tar.gz",
+        sha256 = "d0a4029a2b7b557a386eb74883c1d88e15a020168c805769ab326000f2fe40fa",
+        strip_prefix = "libwebsockets-e83ed4eb88b77039d69189327482263f6fdf5fef",
         build_file = "@everest-framework//third-party/bazel:BUILD.libwebsockets.bazel",
     )
 


### PR DESCRIPTION
rapidyaml: v0.9.0
needed backwards-incompatible changes to yaml loader and transpile config

libwebsockets: v4.3.6
needed adaptations to bazel build file

nlohmann_json: v3.12.0
libfmt: 11.2.0
date: v3.0.4
catch2: v3.9.0
pybind11: v2.13.6
pybind11_json: 0.2.15
needed no adaptations