### PR TITLE
Rust: Fix clippy warning

### DIFF
--- a/everestrs/everestrs-build/jinja/errors.jinja2
+++ b/everestrs/everestrs-build/jinja/errors.jinja2
@@ -1,5 +1,5 @@
 {%- for name, errors in involved_errors | items  %}
-    #![allow(clippy::enum_variant_names)]
+    #[allow(clippy::enum_variant_names)]
     pub mod {{ name | snake }} {
         use everestrs::serde as __serde;
     {%- for error_group in errors %}

--- a/everestrs/everestrs-build/jinja/errors.jinja2
+++ b/everestrs/everestrs-build/jinja/errors.jinja2
@@ -1,4 +1,5 @@
 {%- for name, errors in involved_errors | items  %}
+    #![allow(clippy::enum_variant_names)]
     pub mod {{ name | snake }} {
         use everestrs::serde as __serde;
     {%- for error_group in errors %}


### PR DESCRIPTION
The derived enum names may be invalid/bad for clippy