### PR TITLE
Update libwebsockets dependency to 4.4.1

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -10,8 +10,7 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/source.json": "1b996859f840d8efc7c720efc61dcf2a84b1261cb3974cbbe9b6666ebf567775",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/source.json": "750d5e29326fb59cbe61116a7b803c8a1d0a7090a9c8ed89888d188e3c473fc7",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/source.json": "6b2b8c74d14e8d485528a938e44bdb72a5ba17632b9e14ef6e68a5ee96c8347f",
@@ -187,8 +186,7 @@
     "https://bcr.bazel.build/modules/boost.winapi/1.87.0/MODULE.bazel": "b36870b9f3ebe56c1dadd0507fb6ee6b5a59e13c5c0b784baaa509722bd0ffba",
     "https://bcr.bazel.build/modules/boost.winapi/1.87.0/source.json": "8e363a11b36f5f78b4d00a4543a8b181313d78abdcc5dec6e438a5c4b2fd2a7e",
     "https://bcr.bazel.build/modules/boringssl/0.20240913.0/MODULE.bazel": "fcaa7503a5213290831a91ed1eb538551cf11ac0bc3a6ad92d0fef92c5bd25fb",
-    "https://bcr.bazel.build/modules/boringssl/0.20250311.0/MODULE.bazel": "7f3e225bc7c5db64de9eaf1a4616f71cf534eaec287550e974dd8967d280698d",
-    "https://bcr.bazel.build/modules/boringssl/0.20250311.0/source.json": "8e92cddf8d6193b273046a76b3b4818a39028f6bfe42db7057eda421e7e908f2",
+    "https://bcr.bazel.build/modules/boringssl/0.20240913.0/source.json": "540753d29c271a302442a3d3c6ccd4faace597e7bcf0f77049fe59535782ce9f",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/cxx.rs/1.0.153/MODULE.bazel": "447653c4e57e0476fbbfef78220514266afb1f0398f4a47ec644cd0603e80da5",
@@ -202,13 +200,14 @@
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
-    "https://bcr.bazel.build/modules/googletest/1.16.0/MODULE.bazel": "a175623c69e94fca4ca7acbc12031e637b0c489318cd4805606981d4d7adb34a",
-    "https://bcr.bazel.build/modules/googletest/1.16.0/source.json": "dd011b202542efcd4c0e3df34b1558d41598c6f287846728315ded5f7984b77a",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/source.json": "dbdda654dcb3a0d7a8bc5d0ac5fc7e150b58c2a986025ae5bc634bb2cb61f470",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0/MODULE.bazel": "21f19a4479e994c1546cf6f10c65d2fa464cd95f49eebad98dc5bac49c801dab",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0/source.json": "6bf17b358c467effad70c02ab43e2d65939d740f667157397f583435909cfae1",
+    "https://bcr.bazel.build/modules/openssl/3.3.1.bcr.6/MODULE.bazel": "25b6a35ac9e3ddd1882d2abaf5a4c65dbd23d970f671a7aea203327273feb57c",
+    "https://bcr.bazel.build/modules/openssl/3.3.1.bcr.6/source.json": "bd70b6a648c872c0f5d25f434aeb314e31828b02e55087fc484a7f45b8514044",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
@@ -284,6 +283,8 @@
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_perl/0.4.1/MODULE.bazel": "4d09ad3a3cf71e606faab258a753ba9f0516b5d3c6aff9b813d06ea65c04702f",
+    "https://bcr.bazel.build/modules/rules_perl/0.4.1/source.json": "70e943e2deea44c1b2ddfafe178a294b82f8b8a24ee25d547eaaa202142f1b4d",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -309,7 +310,8 @@
     "https://bcr.bazel.build/modules/rules_rust/0.59.2/source.json": "6575677d9a3008a7cbd8b3fbc94aeb78c893c24a4543fece9540f7c26e8b8df1",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
-    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.0/MODULE.bazel": "0f8f11bb3cd11755f0b48c1de0bbcf62b4b34421023aa41a2fc74ef68d9584f0",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.0/source.json": "1d7fa7f941cd41dc2704ba5b4edc2e2230eea1cc600d80bd2b65838204c50b95",
     "https://bcr.bazel.build/modules/sqlite3/3.49.1/MODULE.bazel": "d162b602a16810ef2eb76ad15a32d7809a10b9831082e55ad35d82cbf59860da",
     "https://bcr.bazel.build/modules/sqlite3/3.49.1/source.json": "7adca38f64362cc70081167b7e9f7066381e1a63151c6c82eae111487dbbbe07",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
@@ -330,7 +332,7 @@
   "moduleExtensions": {
     "//third-party/bazel:extension.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "08BcSSvkleXJcqKiiT+yoRjGuGHRLqUPHmKh8EboC7E=",
+        "bzlTransitiveDigest": "zd3HnxVPW2gTrGZrvfJjBzNUkmMVZ5Maidu7lWFbhlo=",
         "usagesDigest": "z8CC+jdzfTX+iMebHzQRpTRTz8ZX/YFrOJyDYjVdtws=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -402,9 +404,9 @@
           "com_github_warmcatt_libwebsockets": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/warmcat/libwebsockets/archive/e83ed4eb88b77039d69189327482263f6fdf5fef.tar.gz",
-              "sha256": "d0a4029a2b7b557a386eb74883c1d88e15a020168c805769ab326000f2fe40fa",
-              "strip_prefix": "libwebsockets-e83ed4eb88b77039d69189327482263f6fdf5fef",
+              "url": "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
+              "sha256": "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
+              "strip_prefix": "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
               "build_file": "@@//third-party/bazel:BUILD.libwebsockets.bazel"
             }
           },
@@ -1009,7 +1011,7 @@
         "recordedFileInputs": {
           "@@//bazel/validate/Cargo.lock": "7f68ca2d7d57e72c7f3ba32d7d02aa6262fbd7c0776e5dfbb9daf125c04ab9fa",
           "@@//bazel/validate/Cargo.toml": "93a46feee9a01a4cde7991e23dbed02970e7e0d2141dc3faa91a3a1112b27b46",
-          "@@//everestrs/Cargo.lock": "210ce6804ca358a8e3c91325c636090bf5225552a508b5d7d58418ac5ce196bd",
+          "@@//everestrs/Cargo.lock": "6a0783638fa3807833152331819ef2b4eaddd77d4350de6a83ee82d4482df373",
           "@@//everestrs/Cargo.toml": "97347f19b9899f3f340ddf305cb595ae692c626836adf5c8e9841c94a040a23d",
           "@@//everestrs/everestrs-build/Cargo.toml": "1da245c1a506ccbc76195e7ca9c5c561ce16ace73962870f47a336a8f8019400",
           "@@//everestrs/everestrs/Cargo.toml": "12ee695fee00fce1c9f81c0fb9478fdc6813967d8b34121c634cdb70e369c45b"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -5,7 +5,7 @@ ryml:
   options: ["CMAKE_POSITION_INDEPENDENT_CODE ON"]
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
-  git_tag: v4.3.6
+  git_tag: v4.4.1
   cmake_condition: "EVEREST_ENABLE_ADMIN_PANEL_BACKEND"
   options:
     - CMAKE_POLICY_VERSION_MINIMUM 3.5

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -137,16 +137,16 @@ lws_http_mount Server::Impl::mount = {
     0,            // unsigned int cache_revalidate:1; /**< set if client cache should revalidate on use */
     0,            // unsigned int cache_intermediaries:1; /**< set if intermediaries are allowed to cache */
 #if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER >= 4004000
-    0,            // unsigned int cache_no:1; /**< set if client should check cache always*/
+    0, // unsigned int cache_no:1; /**< set if client should check cache always*/
 #endif
     LWSMPRO_FILE, // unsigned char origin_protocol; /**< one of enum lws_mount_protocols */
     1,            // unsigned char mountpoint_len; /**< length of mountpoint string */
     nullptr,      // const char *basic_auth_login_file;
 #if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER >= 4004000
-    nullptr,      // const char *cgi_chroot_path;
-    nullptr,      // const char *cgi_wd;
-    nullptr,      // const struct lws_protocol_vhost_options *headers;
-    0,            // unsigned int keepalive_timeout; /**< 0 or seconds http stream should stay alive while idle. */
+    nullptr, // const char *cgi_chroot_path;
+    nullptr, // const char *cgi_wd;
+    nullptr, // const struct lws_protocol_vhost_options *headers;
+    0,       // unsigned int keepalive_timeout; /**< 0 or seconds http stream should stay alive while idle. */
 #endif
 };
 

--- a/src/controller/server.cpp
+++ b/src/controller/server.cpp
@@ -136,9 +136,18 @@ lws_http_mount Server::Impl::mount = {
     0,            // unsigned int cache_reusable:1; /**< set if client cache may reuse this */
     0,            // unsigned int cache_revalidate:1; /**< set if client cache should revalidate on use */
     0,            // unsigned int cache_intermediaries:1; /**< set if intermediaries are allowed to cache */
+#if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER >= 4004000
+    0,            // unsigned int cache_no:1; /**< set if client should check cache always*/
+#endif
     LWSMPRO_FILE, // unsigned char origin_protocol; /**< one of enum lws_mount_protocols */
     1,            // unsigned char mountpoint_len; /**< length of mountpoint string */
     nullptr,      // const char *basic_auth_login_file;
+#if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER >= 4004000
+    nullptr,      // const char *cgi_chroot_path;
+    nullptr,      // const char *cgi_wd;
+    nullptr,      // const struct lws_protocol_vhost_options *headers;
+    0,            // unsigned int keepalive_timeout; /**< 0 or seconds http stream should stay alive while idle. */
+#endif
 };
 
 int Server::Impl::callback(struct lws* wsi, lws_callback_reasons reason, void* user, void* in, std::size_t len) {

--- a/third-party/bazel/extension.bzl
+++ b/third-party/bazel/extension.bzl
@@ -70,9 +70,9 @@ def _deps_impl(module_ctx):
     maybe(
         http_archive,
         name = "com_github_warmcatt_libwebsockets",
-        url = "https://github.com/warmcat/libwebsockets/archive/e83ed4eb88b77039d69189327482263f6fdf5fef.tar.gz",
-        sha256 = "d0a4029a2b7b557a386eb74883c1d88e15a020168c805769ab326000f2fe40fa",
-        strip_prefix = "libwebsockets-e83ed4eb88b77039d69189327482263f6fdf5fef",
+        url = "https://github.com/warmcat/libwebsockets/archive/adc128ca082a3c6fb9d4abbadefc09e3bc736724.tar.gz",
+        sha256 = "8da42692347ba5bc3cbd89dc2b30aba3934ad51085ebeb2f8657321bf7164831",
+        strip_prefix = "libwebsockets-adc128ca082a3c6fb9d4abbadefc09e3bc736724",
         build_file = "@everest-framework//third-party/bazel:BUILD.libwebsockets.bazel",
     )
 


### PR DESCRIPTION
This updates the libwebsockets library to 4.4.1.

This also adapts the controller server to an incompatible API change in struct `lws_http_mount`. This change adapts to both old and new API.

NOTE: Keep the dependency aligned with everest-core (incoming via RpcApi PR https://github.com/EVerest/everest-core/pull/1324).