### PR TITLE
Rust: Add ErrorType handling for raising

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -13,8 +13,7 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/source.json": "750d5e29326fb59cbe61116a7b803c8a1d0a7090a9c8ed89888d188e3c473fc7",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
-    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
-    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/apple_support/1.17.1/source.json": "6b2b8c74d14e8d485528a938e44bdb72a5ba17632b9e14ef6e68a5ee96c8347f",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
@@ -23,9 +22,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
-    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
-    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -268,8 +265,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
@@ -327,15 +324,15 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
     "//third-party/bazel:extension.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "LnfJkoLq0Ad+KqQYQxxe66hd535uL4VeUu9Gq5/wFCw=",
+        "bzlTransitiveDigest": "BRGciJsXK+VP9VQbWgmYG0ZeVa4gOD8rCE4TjH7+IB8=",
         "usagesDigest": "HxWOFFyt0+vHKXWfroRwht4RRcER4BV86UcMvV1AROE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -465,6 +462,37 @@
         ]
       }
     },
+    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "xcBTf2+GaloFpg7YEh/Bv+1yAczRkiCt3DGws4K7kSk=",
+        "usagesDigest": "3L+PK6aRnliv0iIS8m3kdo+LjmvjJWoFCm3qZcPSg+8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc_toolchains": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          },
+          "local_config_apple_cc": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ]
+        ]
+      }
+    },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "wXImnqOfGKOqkiPwQBuez+TGQdj1tuLQU6OYcfhB97I=",
@@ -494,7 +522,7 @@
     },
     "@@rules_foreign_cc+//foreign_cc:extensions.bzl%tools": {
       "general": {
-        "bzlTransitiveDigest": "bzYvbsHj2ct8D8fQBqNNAJqAjmx6oxXp0japlQvDLjo=",
+        "bzlTransitiveDigest": "s250RunLyhfcQbKIaaBuMfP5f663Spl3T3NSHanLTeY=",
         "usagesDigest": "Eyh4mAOi6L+Nn/lY/wQBJclQrmBnWdQM+B4lZeq6azA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -878,7 +906,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
+        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -978,7 +1006,7 @@
     },
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "fZiZd/98SxroknVi1wUHIJHIFTzlG/XPqQfCjbRemCU=",
+        "bzlTransitiveDigest": "0aE92G9z87P2ty8Ik4pXnKVoBMGz3DvWx6vFWObtqeo=",
         "usagesDigest": "3hDLJ2gqpFj3EO/mQfgi2JINDG1+T933i6uQbasGywc=",
         "recordedFileInputs": {
           "@@//bazel/validate/Cargo.lock": "7f68ca2d7d57e72c7f3ba32d7d02aa6262fbd7c0776e5dfbb9daf125c04ab9fa",

--- a/everestrs/everestrs-build/jinja/service.jinja2
+++ b/everestrs/everestrs-build/jinja/service.jinja2
@@ -68,7 +68,7 @@ impl {{trait.name | title }}ServicePublisher {
 {% endfor %}
 
 {%- if trait.errors %}
-    pub(crate) fn raise_error(&self, error: crate::generated::errors::{{ trait.name | snake }}::Error) {
+    pub(crate) fn raise_error(&self, error: ::everestrs::ErrorType<crate::generated::errors::{{ trait.name | snake }}::Error>) {
         self.runtime.raise_error(self.implementation_id, error);
     }
 

--- a/everestrs/tests/modules/RsExample/src/main.rs
+++ b/everestrs/tests/modules/RsExample/src/main.rs
@@ -2,6 +2,7 @@
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 use everestrs::ErrorType;
+use generated::errors::example::Error as ExampleError;
 use generated::{
     get_config, Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module,
     ModulePublisher, OnReadySubscriber,
@@ -14,11 +15,9 @@ pub struct OneClass {}
 impl ExampleServiceSubscriber for OneClass {
     fn uses_something(&self, context: &Context, key: String) -> ::everestrs::Result<bool> {
         use crate::generated::errors::example::ExampleErrorsError;
-        let error = crate::generated::errors::example::Error::ExampleErrors(
-            ExampleErrorsError::ExampleErrorA,
-        );
+        let error = ExampleError::ExampleErrors(ExampleErrorsError::ExampleErrorA);
         if key.is_empty() {
-            context.publisher.foobar.raise_error(error);
+            context.publisher.foobar.raise_error(error.into());
         } else {
             context.publisher.foobar.clear_error(error);
         }
@@ -32,15 +31,11 @@ impl ExampleClientSubscriber for OneClass {
         log::info!("Received {value}");
     }
 
-    fn on_error_raised(&self, _context: &Context, error: ErrorType<crate::generated::errors::example::Error>) {
+    fn on_error_raised(&self, _context: &Context, error: ErrorType<ExampleError>) {
         log::warn!("Recieved an error {:?}", error.error_type);
     }
 
-    fn on_error_cleared(
-        &self,
-        _context: &Context,
-        error: ErrorType<crate::generated::errors::example::Error>,
-    ) {
+    fn on_error_cleared(&self, _context: &Context, error: ErrorType<ExampleError>) {
         log::info!("Cleared an error {:?} - what a relief", error.error_type);
     }
 }

--- a/everestrs/tests/modules/RsIgnore/src/main.rs
+++ b/everestrs/tests/modules/RsIgnore/src/main.rs
@@ -32,7 +32,7 @@ impl OnReadySubscriber for OneClass {
         // Call the other module. This calls should be ignored.
         publishers.example.max_current(12.3).unwrap();
         let error = ExampleError::ExampleErrors(ExampleErrorsError::ExampleErrorA);
-        publishers.example.raise_error(error.clone());
+        publishers.example.raise_error(error.clone().into());
         publishers.example.clear_error(error);
     }
 }

--- a/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
+++ b/everestrs/tests/modules/RsOnReadyRaceCondition/src/main.rs
@@ -52,7 +52,7 @@ impl OnReadySubscriber for OneClass {
         // Call the other module.
         publishers.example.max_current(12.3).unwrap();
         let error = ExampleError::ExampleErrors(ExampleErrorsError::ExampleErrorA);
-        publishers.example.raise_error(error.clone());
+        publishers.example.raise_error(error.clone().into());
         publishers.example.clear_error(error);
 
         // TODO(ddo) Add here the `uses_something` call once the framework can

--- a/everestrs/tests/modules/RsOptionalConnection/src/main.rs
+++ b/everestrs/tests/modules/RsOptionalConnection/src/main.rs
@@ -2,9 +2,10 @@
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 use everestrs::ErrorType;
+use generated::errors::example::Error as ExampleError;
 use generated::{
-    Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module,
-    ModulePublisher, OnReadySubscriber,
+    Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module, ModulePublisher,
+    OnReadySubscriber,
 };
 use std::sync::Arc;
 use std::{thread, time};
@@ -23,15 +24,11 @@ impl ExampleClientSubscriber for OptionalConnection {
         log::info!("Received {value}");
     }
 
-    fn on_error_raised(&self, _context: &Context, error: ErrorType<crate::generated::errors::example::Error>) {
+    fn on_error_raised(&self, _context: &Context, error: ErrorType<ExampleError>) {
         log::info!("Recieved an error {:?}", error.error_type);
     }
 
-    fn on_error_cleared(
-        &self,
-        _context: &Context,
-        error: ErrorType<crate::generated::errors::example::Error>,
-    ) {
+    fn on_error_cleared(&self, _context: &Context, error: ErrorType<ExampleError>) {
         log::info!("Cleared an error {:?} - what a relief", error.error_type);
     }
 }
@@ -48,7 +45,9 @@ impl OnReadySubscriber for OptionalConnection {
 
 fn main() {
     let one_class = Arc::new(OptionalConnection {});
-    let _module = Module::new(one_class.clone(), one_class.clone(), |_index| {one_class.clone()});
+    let _module = Module::new(one_class.clone(), one_class.clone(), |_index| {
+        one_class.clone()
+    });
     log::info!("Module initialized");
 
     loop {


### PR DESCRIPTION
Similar to #304 it adds support for more complex error raising to the server side of the Rust bindings