### PR TITLE
Rust: Fix error mocks and extend tests

### DIFF
--- a/everestrs/everestrs-build/jinja/service.jinja2
+++ b/everestrs/everestrs-build/jinja/service.jinja2
@@ -90,9 +90,11 @@ mockall::mock!{
 {% endfor %}
 
 {%- if trait.errors %}
-    pub(crate) fn raise_error(&self, error: crate::generated::errors::{{ trait.name | snake }}::Error);
+    pub(crate) fn raise_error(&self, error: ::everestrs::ErrorType<crate::generated::errors::{{ trait.name | snake }}::Error>);
 
     pub(crate) fn clear_error(&self, error: crate::generated::errors::{{ trait.name | snake }}::Error);
+
+    pub(crate) fn clear_all_errors(&self);
 {%- endif %}
    }
 


### PR DESCRIPTION
Adds the missing mock for `clear_all_errors` and fixes the type mismatch for `raise_error` mock