### PR TITLE
fix: Add extra check for etc path

### DIFF
--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -116,11 +116,13 @@ void ManagerSettings::init_settings(const everest::config::Settings& settings) {
     fs::path etc_dir;
     {
         // etc directory
-        const auto default_etc_dir = fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE;
-        if (prefix.string() != "/usr") {
-            etc_dir = prefix / default_etc_dir;
-        } else {
+        const auto default_etc_dir = (fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE).relative_path();
+        if (prefix.string() == "/usr") {
             etc_dir = fs::path("/") / default_etc_dir;
+        } else if (etc_root.filename() == "usr") {
+            etc_dir = prefix.parent_path() / default_etc_dir;
+        } else {
+            etc_dir = prefix / default_etc_dir;
         }
         etc_dir = assert_dir(etc_dir.string(), "Default etc directory");
     }
@@ -662,8 +664,7 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
 
     if (vm.count("config") != 0) {
         std::cout
-            << "--config is not used anymore, modules request their config automatically via MQTT"
-            << "\n"
+            << "--config is not used anymore, modules request their config automatically via MQTT" << "\n"
             << "If you want to influence this config loading behavior you can specify the appropriate --mqtt_* flags"
             << "\n";
     }

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -119,7 +119,7 @@ void ManagerSettings::init_settings(const everest::config::Settings& settings) {
         const auto default_etc_dir = (fs::path(defaults::SYSCONF_DIR) / defaults::NAMESPACE).relative_path();
         if (prefix.string() == "/usr") {
             etc_dir = fs::path("/") / default_etc_dir;
-        } else if (etc_root.filename() == "usr") {
+        } else if (prefix.filename() == "usr") {
             etc_dir = prefix.parent_path() / default_etc_dir;
         } else {
             etc_dir = prefix / default_etc_dir;

--- a/lib/runtime.cpp
+++ b/lib/runtime.cpp
@@ -664,7 +664,8 @@ bool ModuleLoader::parse_command_line(int argc, char* argv[]) {
 
     if (vm.count("config") != 0) {
         std::cout
-            << "--config is not used anymore, modules request their config automatically via MQTT" << "\n"
+            << "--config is not used anymore, modules request their config automatically via MQTT"
+            << "\n"
             << "If you want to influence this config loading behavior you can specify the appropriate --mqtt_* flags"
             << "\n";
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,11 @@ include(test_utilities.cmake)
 
 setup_test_directory(empty_config)
 setup_test_directory(valid_config)
+setup_test_directory(valid_config_custom_prefix)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix_tmp)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix_tmp ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix/usr)
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix/usr/etc ${CMAKE_CURRENT_BINARY_DIR}/valid_config_custom_prefix/etc)
 setup_test_directory(valid_module_config TESTValidManifest test_interface)
 setup_test_directory(valid_module_config_userconfig TESTValidManifest test_interface
     CONFIG valid_module_config_config.yaml

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -28,6 +28,13 @@ SCENARIO("Check ManagerSettings Constructor", "[!throws]") {
             CHECK_NOTHROW(Everest::ManagerSettings(bin_dir + "valid_config/", bin_dir + "valid_config/config.yaml"));
         }
     }
+    GIVEN("A valid prefix and a valid config file with a custom prefix") {
+        THEN("It should not throw") {
+            auto ms = Everest::ManagerSettings(bin_dir + "valid_config_custom_prefix/usr",
+                                               bin_dir + "valid_config_custom_prefix/usr/config.yaml");
+            CHECK(ms.runtime_settings.etc_dir == bin_dir + "valid_config_custom_prefix/etc/everest");
+        }
+    }
     GIVEN("A broken yaml file") {
         // FIXME (aw): this also throws, if the folder doesn't even exists or some other things fail
         THEN("It should throw") {

--- a/tests/test_configs/valid_config_custom_prefix_config.yaml
+++ b/tests/test_configs/valid_config_custom_prefix_config.yaml
@@ -1,0 +1,9 @@
+active_modules: {}
+settings:
+  interfaces_dir: "interfaces"
+  modules_dir: "modules"
+  types_dir: "types"
+  errors_dir: "errors"
+  schemas_dir: "schemas"
+  www_dir: "www"
+  logging_config_file: "logging.ini"


### PR DESCRIPTION
Problem
When using a custom prefix ending with "usr" (e.g., /extra/usr), the etc directory path was incorrectly resolved to /extra/usr/etc instead of /extra/etc.

An extra check has been added which uses parent path as root directory for etc.

Test Cases
  Prefix:   /usr
  Got:      /etc

  Prefix:   /extra/usr
  Got:      /extra/etc

  Prefix:   /opt/usr
  Got:      /opt/etc

  Prefix:   /usr/local
  Got:      /usr/local/etc

  Prefix:   /extra
  Got:      /extra/etc

  Prefix:   /opt/myapp
  Got:      /opt/myapp/etc