### PR TITLE
Rust: pin cxxbridge version, update to 1.0.189

### DIFF
--- a/everestrs/CMakeLists.txt
+++ b/everestrs/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CXXBRIDGE_VERSION 1.0.189) # Must be kept in sync with `everestrs/Cargo.toml`
 set(CXXBRIDGE_INSTALL_PATH ${CMAKE_CURRENT_BINARY_DIR}/cargo/bin/cxxbridge)
 
-# Checks if the cxxbridge binary at CXXBRIDGE_PATH exists matches the required version.
+# Checks if the cxxbridge binary at CXXBRIDGE_PATH exists and matches the required version.
 # If not, sets VERSION_MATCHES to FALSE.
 function(everestrs_check_cxxbridge_version CXXBRIDGE_PATH VERSION_MATCHES)
     if(NOT CXXBRIDGE_BINARY OR NOT EXISTS ${CXXBRIDGE_BINARY})

--- a/everestrs/CMakeLists.txt
+++ b/everestrs/CMakeLists.txt
@@ -1,9 +1,48 @@
-set(CXXBRIDGE_BINARY ${CMAKE_CURRENT_BINARY_DIR}/cargo/bin/cxxbridge)
-if (NOT EXISTS ${CXXBRIDGE_BINARY})
+set(CXXBRIDGE_VERSION 1.0.189) # Must be kept in sync with `everestrs/Cargo.toml`
+set(CXXBRIDGE_INSTALL_PATH ${CMAKE_CURRENT_BINARY_DIR}/cargo/bin/cxxbridge)
+
+# Checks if the cxxbridge binary at CXXBRIDGE_PATH exists matches the required version.
+# If not, sets VERSION_MATCHES to FALSE.
+function(everestrs_check_cxxbridge_version CXXBRIDGE_PATH VERSION_MATCHES)
+    if(NOT CXXBRIDGE_BINARY OR NOT EXISTS ${CXXBRIDGE_BINARY})
+        set(${VERSION_MATCHES} FALSE PARENT_SCOPE)
+    endif()
+
+    execute_process(
+        COMMAND
+            ${CXXBRIDGE_BINARY} --version
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_BINARY_DIR}
+        OUTPUT_VARIABLE
+            CXXBRIDGE_VERSION_OUTPUT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(CXXBRIDGE_VERSION_OUTPUT MATCHES "cxxbridge ${CXXBRIDGE_VERSION}")
+        set(${VERSION_MATCHES} TRUE PARENT_SCOPE)
+    else()
+        set(${VERSION_MATCHES} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
+# If cxxbridge is already installed system-wide, check if it's the correct version.
+find_program(CXXBRIDGE_BINARY cxxbridge)
+everestrs_check_cxxbridge_version(${CXXBRIDGE_BINARY} CXXBRIDGE_INSTALLED)
+
+# Otherwise, check if we previously installed it in our build dir.
+if(NOT CXXBRIDGE_INSTALLED)
+    set(CXXBRIDGE_BINARY ${CXXBRIDGE_INSTALL_PATH})
+    everestrs_check_cxxbridge_version(${CXXBRIDGE_BINARY} CXXBRIDGE_INSTALLED)
+endif()
+
+# Either we never had cxxbridge installed, or the version is incorrect. Install the correct version to our build dir.
+if(NOT CXXBRIDGE_INSTALLED)
     message(STATUS "Fetching rust cxxbridge cli tool")
     execute_process(
         COMMAND
-            cargo install cxxbridge-cmd --root ${CMAKE_CURRENT_BINARY_DIR}/cargo
+            ${CMAKE_COMMAND} -E env --unset=CARGO_BUILD_TARGET # Ensure we always build for the host
+            cargo install cxxbridge-cmd --force --version ${CXXBRIDGE_VERSION} --root ${CMAKE_CURRENT_BINARY_DIR}/cargo
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_BINARY_DIR}
         RESULT_VARIABLE
@@ -13,10 +52,12 @@ if (NOT EXISTS ${CXXBRIDGE_BINARY})
             CARGO_INSTALL_ERROR
     )
 
-    if (CARGO_INSTALL_RESULT)
+    if(NOT CARGO_INSTALL_RESULT)
+        set(CXXBRIDGE_BINARY ${CXXBRIDGE_INSTALL_PATH})
+    else()
         message(FATAL_ERROR "cargo install cxxbridge-cmd failed with:\n${CARGO_INSTALL_ERROR}")
-    endif ()
-endif ()
+    endif()
+endif()
 
 set(CXXBRIDGE_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(CXXBRIDGE_HEADER ${CXXBRIDGE_OUTPUT_DIR}/rust/cxx.h)

--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -173,11 +173,12 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.158"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
+checksum = "2b788601e7e3e6944d9b37efbae0bee7ee44d9aab533838d4854f631534a1a49"
 dependencies = [
  "cc",
+ "cxx-build",
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
@@ -186,13 +187,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxxbridge-cmd"
-version = "1.0.158"
+name = "cxx-build"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
+checksum = "5e11d62eb0de451f6d3aa83f2cec0986af61c23bd7515f1e2d6572c6c9e53c96"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a368ed4a0fd83ebd3f2808613842d942a409c41cc24cd9d83f1696a00d78afe"
 dependencies = [
  "clap",
  "codespan-reporting",
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -200,19 +217,19 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.158"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
+checksum = "a9571a7c69f236d7202f517553241496125ed56a86baa1ce346d02aa72357c74"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.158"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
+checksum = "eba2aaae28ca1d721d3f364bb29d51811921e7194c08bb9eaf745c8ab8d81309"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -259,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fragile"
@@ -305,9 +322,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
@@ -428,16 +445,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
 
 [[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "serde"

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -5,13 +5,15 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-cxx = { version = "1.0.107", features = ["c++17"] }
 everestrs-build = { workspace = true }
 log = { version = "0.4.20", features = ["std"] }
 serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.34"
 thiserror = "1.0.48"
+
+# Note: the version must be kept in sync with the `cxxbridge-cmd` version installed in `everestrs/CMakeLists.txt`.
+cxx = { version = "1.0.189", features = ["c++17"] }
 
 [features]
 build_bazel = []

--- a/everestrs/everestrs/README.md
+++ b/everestrs/everestrs/README.md
@@ -40,3 +40,28 @@ To enable mocking in your code you need to do some steps however
 * Add a `mockall` feature to your module and enable it for your tests.
 
 Then all publishers are mocked with `mockall`.
+
+## Building from external repositories without CMake
+
+Note that the `everest-core` and `everest-framework` repositories are
+automatically configured for this use case, this section is only relevant for
+Rust modules residing in their own repositories.
+
+While external Rust modules can be compiled using CMake without any setup,
+compiling with `cargo` directly requires some additional setup. This is
+required for rust-analyzer's IDE integration to work properly.
+
+* First, build your EVerest workspace with Rust support enabled by
+  passing `-DEVEREST_ENABLE_RS_SUPPORT=ON` to CMake.
+* Install it using `cmake --install . --prefix build/dist`. Replace
+  `build/dist` with the installation directory you'd like to use.
+* Create a file named `.cargo/config.toml` in your repository's `modules`
+  directory. This file should contain the following, with `<dist-path>`
+  replaced by the installation directory you used in the previous step:
+
+  ```toml
+  [env]
+  # Match CMAKE_INSTALL_LIBDIR, unfortunately Cargo cannot pick automatically: https://github.com/rust-lang/cargo/issues/10273
+  EVEREST_LIB_DIR = "../../<dist-path>/lib64" # For x86_64
+  EVEREST_LIB_DIR = "../../<dist-path>/lib"   # For aarch64
+  ```

--- a/everestrs/everestrs/README.md
+++ b/everestrs/everestrs/README.md
@@ -51,17 +51,18 @@ While external Rust modules can be compiled using CMake without any setup,
 compiling with `cargo` directly requires some additional setup. This is
 required for rust-analyzer's IDE integration to work properly.
 
-* First, build your EVerest workspace with Rust support enabled by
+- First, build your EVerest workspace with Rust support enabled by
   passing `-DEVEREST_ENABLE_RS_SUPPORT=ON` to CMake.
-* Install it using `cmake --install . --prefix build/dist`. Replace
+- Install it using `cmake --install . --prefix build/dist`. Replace
   `build/dist` with the installation directory you'd like to use.
-* Create a file named `.cargo/config.toml` in your repository's `modules`
+- Create a file named `.cargo/config.toml` in your repository's `modules`
   directory. This file should contain the following, with `<dist-path>`
   replaced by the installation directory you used in the previous step:
 
   ```toml
   [env]
-  # Match CMAKE_INSTALL_LIBDIR, unfortunately Cargo cannot pick automatically: https://github.com/rust-lang/cargo/issues/10273
+  # Match CMAKE_INSTALL_LIBDIR, unfortunately Cargo cannot pick automatically:
+  # https://github.com/rust-lang/cargo/issues/10273
   EVEREST_LIB_DIR = "../../<dist-path>/lib64" # For x86_64
   EVEREST_LIB_DIR = "../../<dist-path>/lib"   # For aarch64
   ```


### PR DESCRIPTION
When building an EVerest workspace I noticed all Rust modules failed to link because none of the CXX FFI symbols could be resolved.

The issue appears to be that CMake installs an unbounded (i.e the latest) version of the `cxxbridge-cmd` tool at configure time, even though it must match the version of the `cxx` crate used in `everestrs` (https://github.com/dtolnay/cxx/issues/1507).
In release 1.0.189 (the latest as of writing) they started incorporating the version number in symbol names to detect exactly this scenario, which broke my build. CMake installed `cxxbridge-cmd` 1.0.189, but the `cxx` library version was locked to an older release.

This PR fixes that by: 
* Updating the `cxx` crate to the latest version. This doesn't solve the root cause of the issue, but its nice to have done anyways.
 * Locking the version of `cxxbridge-cmd` when installing to match `cxx`, and try to update it if the existing binary is outdated.(Re)running CMake's configure phase when updating `cxx` now fixes the issue.

It also does a few other Rust related things:
* Use the `cxxbridge-cmd` version from `$PATH` if it has the correct version. Useful for offline builds.
* Ensure we don't inherit cross compilation flags from the environment when installing `cxxbridge-cmd`.
* Document how to get `cargo build` to work in external repositories. 