### PR TITLE
Refactor Mqtt payload

### DIFF
--- a/docs/MQTTCommunication.md
+++ b/docs/MQTTCommunication.md
@@ -23,7 +23,8 @@ The payload contains the actual variable data in the `data` field.
 
 ```json
 {
-  "data": <variable_value>
+  "data": <variable_value>,
+  "msg_type": "Var"
 }
 ```
 
@@ -41,12 +42,15 @@ The following structure applies for command topics. Modules that provide (implem
 
 ```json
 {
-  "id": "<unique_call_id>",
-  "args": {
-    "arg1": "value1",
-    "arg2": "value2"
+  "data": {
+    "id": "<unique_call_id>",
+    "args": {
+      "arg1": "value1",
+      "arg2": "value2"
+    },
+    "origin": "<calling_module_id>"
   },
-  "origin": "<calling_module_id>"
+  "msg_type": "Cmd"
 }
 ```
 
@@ -66,13 +70,12 @@ The following structure applies for command response topics. These are used to s
 
 ```json
 {
-  "name": "<cmd_name>",
-  "type": "result",
   "data": {
-    "id": "<matching_call_id>",
-    "retval": <return_value>,
-    "origin": "<responding_module_id>"
-  }
+    "id": <matching_call_id>,
+    "origin": <responding_module_id>,
+    "retval": <return_value>
+  },
+  "msg_type": "CmdResult"
 }
 ```
 
@@ -80,16 +83,12 @@ The following structure applies for command response topics. These are used to s
 
 ```json
 {
-  "name": "<cmd_name>",
-  "type": "result",
   "data": {
-    "id": "<matching_call_id>",
-    "error": {
-      "event": "<error_type>",
-      "msg": "<error_message>"
-    },
-    "origin": "<responding_module_id>"
-  }
+    "id": <matching_call_id>,
+    "origin": <responding_module_id>,
+    "error": <error_value>
+  },
+  "msg_type": "CmdResult"
 }
 ```
 
@@ -111,24 +110,32 @@ The following structure applies for error topics. Errors are raised by modules a
 ### Topic Structure
 
 ```bash
-{everest_prefix}modules/{module_id}/impl/{impl_id}/error/{error_type}
+{everest_prefix}modules/{module_id}/impl/{impl_id}/error/{error_namespace}/{error_type}
 ```
 
 ### Message Payload Structure
 
 ```json
 {
-  "type": "<error_namespace>/<error_name>",
-  "message": "<error_description>",
-  "severity": "<error_severity>",
-  "origin": {
-    "module_id": "<originating_module>",
-    "implementation_id": "<originating_impl>",
-    "evse": <evse_number>,
-    "connector": <connector_number>
+  "data": {
+    "description": "<error_description>",
+    "message": "<error_message>",
+    "origin": {
+      "implementation_id": "<originating_impl>",
+      "mapping": {
+        "evse": 1
+      },
+      "module_id": "<originating_module>"
+    },
+    "severity": "<error_severity>",
+    "state": "<error_state>",
+    "sub_type": "<error_sub_type>",
+    "timestamp": "<iso_timestamp>",
+    "type": "<error_type>",
+    "uuid": "<unique_error_id>",
+    "vendor_id": "<vendor_name>"
   },
-  "state": "<error_state>",
-  "timestamp": "<iso_timestamp>",
-  "uuid": "<unique_error_id>"
+  "msg_type": "RaiseError"
 }
 ```
+

--- a/lib/everest.cpp
+++ b/lib/everest.cpp
@@ -493,8 +493,7 @@ void Everest::publish_var(const std::string& impl_id, const std::string& var_nam
 
     const auto var_topic = fmt::format("{}/var/{}", this->config.mqtt_prefix(this->module_id, impl_id), var_name);
 
-    const json var_publish_data = {{"data", value}};
-    MqttMessagePayload payload{MqttMessageType::Var, var_publish_data};
+    MqttMessagePayload payload{MqttMessageType::Var, value};
 
     // FIXME(kai): implement an efficient way of choosing qos for each variable
     this->mqtt_abstraction->publish(var_topic, payload, QOS::QOS2);
@@ -976,9 +975,7 @@ void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_nam
             res_data["error"] = error.value();
         }
 
-        const json res_publish_data = json::object({{"type", "result"}, {"data", res_data}});
-
-        MqttMessagePayload payload{MqttMessageType::CmdResult, res_publish_data};
+        MqttMessagePayload payload{MqttMessageType::CmdResult, res_data};
         const auto final_cmd_response_topic =
             fmt::format("{}/response/{}", cmd_topic, data.at("origin").get<std::string>());
         this->mqtt_abstraction->publish(final_cmd_response_topic, payload);

--- a/lib/message_handler.cpp
+++ b/lib/message_handler.cpp
@@ -268,7 +268,7 @@ void MessageHandler::register_handler(const std::string& topic, std::shared_ptr<
 // Private message handler methods
 void MessageHandler::handle_var_message(const std::string& topic, const json& data) {
     execute_handlers_from_vector(var_handlers, topic,
-                                 [&](const auto& handler) { (*handler->handler)(topic, data.at("data")); });
+                                 [&](const auto& handler) { (*handler->handler)(topic, data); });
 }
 
 void MessageHandler::handle_cmd_message(const std::string& topic, const json& data) {
@@ -306,7 +306,7 @@ void MessageHandler::handle_module_ready_message(const std::string& topic, const
 }
 
 void MessageHandler::handle_cmd_result(const std::string& topic, const json& payload) {
-    const auto& data = payload.at("data").at("data");
+    const auto& data = payload.at("data");
     const auto id = data.at("id").get<std::string>();
 
     std::shared_ptr<TypedHandler> handler_copy;


### PR DESCRIPTION
The payload of a var message and other messages were:

```json
{
  "data": {
      "data": <variable_value>
   }
  "msg_type": "Var"
}
```

and now is

```json
{
  "data": <variable_value>,
  "msg_type": "Var"
}
```

Updated documentation which was also not entirely correct.